### PR TITLE
Add runtime capability detection for diff preview feature

### DIFF
--- a/react/components/agentRuns/EditNoteGroupView.tsx
+++ b/react/components/agentRuns/EditNoteGroupView.tsx
@@ -43,7 +43,7 @@ import { openNoteByKey } from '../../utils/sourceUtils';
 import { executeEditNoteAction, undoEditNoteAction } from '../../utils/editNoteActions';
 import { logger } from '../../../src/utils/logger';
 import { EditNoteRowView } from './EditNoteRowView';
-import { DIFF_PREVIEW_ENABLED } from '../../utils/diffPreviewCoordinator';
+import { isDiffPreviewLive } from '../../utils/diffPreviewCoordinator';
 import {
     buildPreviewableEditOperations,
     dismissActiveEditNotePreview,
@@ -512,8 +512,8 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
     }, [allActions]);
 
     const handlePreviewInEditor = useCallback(async () => {
-        if (!DIFF_PREVIEW_ENABLED) {
-            logger(`EditNoteGroupView: handlePreviewInEditor — aborting, DIFF_PREVIEW_ENABLED is false`, 1);
+        if (!isDiffPreviewLive()) {
+            logger(`EditNoteGroupView: handlePreviewInEditor — aborting, diff preview not live (kill switch off or Zotero 7)`, 1);
             return;
         }
         if (!resolvedTarget) {
@@ -590,9 +590,12 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
         appliedCount > 0 || (isProcessing && clickedButton === 'undo');
     const showFooterRetry =
         errorActions.length > 0 || (isProcessing && clickedButton === 'retry');
+    // Gate on both the global kill switch and the runtime Zotero capability
+    // check so the button is hidden on Zotero 7 (where showDiffPreview would
+    // silently no-op) without requiring a version bump of strict_min_version.
     const canShowPreview =
         !isProcessing
-        && DIFF_PREVIEW_ENABLED
+        && isDiffPreviewLive()
         && (
         resolvedTarget !== null
         && (hasPendingApprovals || reapplicableActions.length > 0)

--- a/react/components/agentRuns/useEditNoteActions.ts
+++ b/react/components/agentRuns/useEditNoteActions.ts
@@ -28,7 +28,7 @@ import {
     showDiffPreview,
     type EditOperation,
 } from '../../utils/noteEditorDiffPreview';
-import { diffPreviewNoteKeyAtom } from '../../utils/diffPreviewCoordinator';
+import { diffPreviewNoteKeyAtom, isDiffPreviewLive } from '../../utils/diffPreviewCoordinator';
 import { logger } from '../../../src/utils/logger';
 import { store } from '../../store';
 import { PreviewData, STATUS_CONFIGS, buildPreviewData } from './agentActionViewHelpers';
@@ -94,6 +94,10 @@ export async function showEditNotePreviewForEdits(
     edits: EditOperation[],
     onAction: (bannerAction: 'approve' | 'reject') => void,
 ): Promise<boolean> {
+    if (!isDiffPreviewLive()) {
+        logger(`showEditNotePreviewForEdits: diff preview not live (kill switch off or Zotero 7), aborting`, 1);
+        return false;
+    }
     await openNoteByKey(target.libraryId, target.zoteroKey);
     await waitForNoteEditorReady(target.libraryId, target.zoteroKey);
     return await showDiffPreview(target.libraryId, target.zoteroKey, edits, {

--- a/react/utils/diffPreviewCoordinator.ts
+++ b/react/utils/diffPreviewCoordinator.ts
@@ -18,6 +18,7 @@ import {
     showDiffPreview,
     dismissDiffPreview,
     isDiffPreviewActive,
+    isDiffPreviewSupported,
     isNoteInSelectedTab,
     getPreviewNoteKey,
     setOnBannerAction,
@@ -31,10 +32,25 @@ import { pendingApprovalsAtom } from '../agents/agentActions';
 import { sendApprovalResponseAtom } from '../atoms/agentRunAtoms';
 
 /**
- * Kill switch for the diff preview feature.
- * Set to `false` to disable all in-editor diff previews.
+ * Global kill switch for the diff preview feature.
+ * Set to `false` to disable all in-editor diff previews regardless of
+ * runtime capability. This is intentionally a compile-time constant so the
+ * feature can be toggled off quickly without a settings round-trip.
+ *
+ * For runtime feature detection (e.g. Zotero 7 vs 8) use
+ * `isDiffPreviewSupported()` from `noteEditorDiffPreview.ts`. The preview is
+ * considered live only when BOTH flags are true; see `isDiffPreviewLive()`.
  */
 export const DIFF_PREVIEW_ENABLED = true;
+
+/**
+ * Convenience gate that combines the kill switch and the runtime capability
+ * check. Use this from UI components to decide whether to render
+ * preview-related controls.
+ */
+export function isDiffPreviewLive(): boolean {
+    return DIFF_PREVIEW_ENABLED && isDiffPreviewSupported();
+}
 
 // Accessor for the Jotai store. The store is imported eagerly above
 // (store.ts is safe in tests because it guards on `typeof Zotero`).
@@ -65,7 +81,7 @@ export const diffPreviewNoteKeyAtom = atom<string | null>(null);
  * Called from addPendingApprovalAtom and removePendingApprovalAtom.
  */
 export function updateDiffPreviewForNote(libraryId: number, zoteroKey: string): void {
-    if (!DIFF_PREVIEW_ENABLED) return;
+    if (!isDiffPreviewLive()) return;
     const store = getStore();
     const noteKey = makeNoteKey(libraryId, zoteroKey);
     const allApprovals: Map<string, any> = store.get(pendingApprovalsAtom);

--- a/react/utils/noteEditorDiffPreview.ts
+++ b/react/utils/noteEditorDiffPreview.ts
@@ -145,6 +145,28 @@ function isEditorInstanceUsable(inst: any): boolean {
     } catch { return false; }
 }
 
+/**
+ * Runtime capability gate for the in-editor diff preview.
+ *
+ * The preview relies on Zotero 8-only APIs (`Zotero.Notes.open()` to open
+ * notes as tabs and `EditorInstance.applyIncrementalUpdate()` to inject diff
+ * HTML without persisting it). On Zotero 7 these are absent and the feature
+ * cannot work — callers should hide any UI that exposes it and avoid
+ * triggering the coordinator's automatic preview.
+ *
+ * This is a feature detection rather than a version check, and it is
+ * independent from `DIFF_PREVIEW_ENABLED` (which remains a global kill
+ * switch, e.g. to disable the feature in production without a code change).
+ * The preview is considered live only when BOTH are true.
+ */
+export function isDiffPreviewSupported(): boolean {
+    try {
+        if (typeof (Zotero as any).Notes?.open !== 'function') return false;
+        if (!Array.isArray((Zotero as any).Notes?._editorInstances)) return false;
+        return true;
+    } catch { return false; }
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -205,6 +227,11 @@ export async function showDiffPreview(
     try {
         if (edits.length === 0) {
             logger(`showDiffPreview: aborting for ${noteKey}, edits array is empty`, 1);
+            return false;
+        }
+
+        if (!isDiffPreviewSupported()) {
+            logger(`showDiffPreview: aborting for ${noteKey}, required Zotero APIs unavailable (Zotero 7 or older)`, 1);
             return false;
         }
 

--- a/tests/unit/utils/diffPreviewCoordinator.test.ts
+++ b/tests/unit/utils/diffPreviewCoordinator.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../react/utils/noteEditorDiffPreview', () => ({
     showDiffPreview: vi.fn().mockResolvedValue(true),
     dismissDiffPreview: (...args: any[]) => mockDismissDiffPreview(...args),
     isDiffPreviewActive: vi.fn().mockReturnValue(false),
+    isDiffPreviewSupported: vi.fn().mockReturnValue(true),
     isNoteInSelectedTab: vi.fn().mockReturnValue(true),
     getPreviewNoteKey: () => capturedHandlers.previewNoteKey,
     setOnBannerAction: (handler: any) => { capturedHandlers.bannerAction = handler; },


### PR DESCRIPTION
## Summary
This PR adds runtime capability detection for the in-editor diff preview feature to support both Zotero 7 and Zotero 8, where the feature relies on Zotero 8-only APIs.

## Key Changes

- **Added `isDiffPreviewSupported()` function** in `noteEditorDiffPreview.ts`: Performs feature detection by checking for the presence of `Zotero.Notes.open()` and `Zotero.Notes._editorInstances`, which are only available in Zotero 8. This is independent from the global kill switch.

- **Added `isDiffPreviewLive()` convenience function** in `diffPreviewCoordinator.ts`: Combines both the global `DIFF_PREVIEW_ENABLED` kill switch and the runtime capability check. UI components should use this to determine whether preview-related controls should be rendered.

- **Updated `showDiffPreview()` call site** in `noteEditorDiffPreview.ts`: Added an explicit check for `isDiffPreviewSupported()` before attempting to show the preview, with appropriate logging for Zotero 7 environments.

- **Updated all UI components and coordinator functions** to use `isDiffPreviewLive()` instead of checking only `DIFF_PREVIEW_ENABLED`:
  - `EditNoteGroupView.tsx`: Updated preview button visibility and handler logic
  - `useEditNoteActions.ts`: Added capability check in `showEditNotePreviewForEdits()`
  - `diffPreviewCoordinator.ts`: Updated `updateDiffPreviewForNote()` to use the combined check

- **Updated test mocks** in `diffPreviewCoordinator.test.ts` to include the new `isDiffPreviewSupported` mock.

## Implementation Details

The feature detection approach allows the preview to gracefully degrade on Zotero 7 without requiring a version bump of `strict_min_version`. The preview is considered "live" only when both conditions are true:
1. `DIFF_PREVIEW_ENABLED` is true (global kill switch)
2. `isDiffPreviewSupported()` returns true (runtime capability check)

This ensures UI elements are hidden and automatic preview triggering is avoided on Zotero 7, where the underlying APIs (`Zotero.Notes.open()` and `EditorInstance.applyIncrementalUpdate()`) are unavailable.

https://claude.ai/code/session_01Egw367B86RM5fx2Zq9k1St