### PR TITLE
Remove collection filtering from AddSourcesMenu search

### DIFF
--- a/react/components/ui/menus/AddSourcesMenu.tsx
+++ b/react/components/ui/menus/AddSourcesMenu.tsx
@@ -140,16 +140,15 @@ const AddSourcesMenu: React.FC<{
             query = query.trim();
             
             // Search Zotero items
-            const { libraryIds, collectionIds, tagSelections } = store.get(currentMessageFiltersAtom);
+            const { libraryIds, tagSelections } = store.get(currentMessageFiltersAtom);
             const searchLibraryIds = libraryIds.length > 0
                 ? libraryIds
                 : tagSelections.length > 0
                     ? Array.from(new Set(tagSelections.map((tag: ZoteroTag) => tag.libraryId)))
                     : searchableLibraryIds;
-            const searchCollectionIds = collectionIds.length > 0 ? collectionIds : undefined;
             const searchTags = tagSelections.length > 0 ? tagSelections : undefined;
-            logger(`AddSourcesMenu.handleSearch: Searching for '${query}' in libraries: ${searchLibraryIds.join(', ')}${searchCollectionIds ? `, collections: ${searchCollectionIds.join(', ')}` : ''}${searchTags ? `, tags: ${searchTags.map((tag: ZoteroTag) => `${tag.tag} (lib ${tag.libraryId})`).join('; ')}` : ''}`)
-            const resultsItems = await searchTitleCreatorYear(query, searchLibraryIds, searchCollectionIds, searchTags);
+            logger(`AddSourcesMenu.handleSearch: Searching for '${query}' in libraries: ${searchLibraryIds.join(', ')}${searchTags ? `, tags: ${searchTags.map((tag: ZoteroTag) => `${tag.tag} (lib ${tag.libraryId})`).join('; ')}` : ''}`)
+            const resultsItems = await searchTitleCreatorYear(query, searchLibraryIds, undefined, searchTags);
 
             // Ensure item data is loaded
             await loadFullItemData(resultsItems);


### PR DESCRIPTION
## Summary
Removed collection-based filtering from the search functionality in AddSourcesMenu. The search now only filters by library IDs and tags, simplifying the search logic.

## Key Changes
- Removed `collectionIds` extraction from `currentMessageFiltersAtom` store state
- Removed `searchCollectionIds` variable calculation that was conditionally set based on `collectionIds` length
- Updated `searchTitleCreatorYear` function call to pass `undefined` for the collection IDs parameter instead of the computed `searchCollectionIds`
- Simplified the search logging statement to remove collection information from the debug output

## Implementation Details
The changes indicate that collection-level filtering is no longer needed or supported in the search flow. The search now operates at the library and tag level only, which may reflect a shift in how search filtering is handled in the application's data model.

https://claude.ai/code/session_01HBgUPHaYTtSBki4feveErE