### PR TITLE
perf(threadView): reduce re-renders during scroll and streaming

### DIFF
--- a/react/components/agentRuns/AgentRunView.tsx
+++ b/react/components/agentRuns/AgentRunView.tsx
@@ -38,7 +38,7 @@ const hasVisibleContent = (run: AgentRun): boolean => {
  * Container component for a single agent run.
  * Renders the user's request, model messages, status indicator, and usage footer.
  */
-export const AgentRunView = forwardRef<HTMLDivElement, AgentRunViewProps>(function AgentRunView({ run, isLastRun }, ref) {
+export const AgentRunView = React.memo(forwardRef<HTMLDivElement, AgentRunViewProps>(function AgentRunView({ run, isLastRun }, ref) {
     const isStreaming = run.status === 'in_progress';
     const hasError = run.status === 'error';
     const allWarnings = useAtomValue(threadWarningsAtom);
@@ -158,7 +158,7 @@ export const AgentRunView = forwardRef<HTMLDivElement, AgentRunViewProps>(functi
 
         </div>
     );
-});
+}));
 
 AgentRunView.displayName = 'AgentRunView';
 

--- a/react/components/agentRuns/ModelMessagesView.tsx
+++ b/react/components/agentRuns/ModelMessagesView.tsx
@@ -19,13 +19,13 @@ interface ModelMessagesViewProps {
  * Only renders ModelResponse messages (kind='response').
  * ModelRequest messages (user prompts or tool returns) are handled via toolResultsMapAtom.
  */
-export const ModelMessagesView: React.FC<ModelMessagesViewProps> = ({
+export const ModelMessagesView: React.FC<ModelMessagesViewProps> = React.memo(function ModelMessagesView({
     messages,
     runId,
     isStreaming,
     showStatusIndicator,
     status,
-}) => {
+}) {
     // Don't render anything if there's no content to show
     if (messages.length === 0 && !showStatusIndicator) {
         return null;
@@ -79,7 +79,7 @@ export const ModelMessagesView: React.FC<ModelMessagesViewProps> = ({
             )}
         </div>
     );
-};
+});
 
 export default ModelMessagesView;
 

--- a/react/components/agentRuns/ModelResponseView.tsx
+++ b/react/components/agentRuns/ModelResponseView.tsx
@@ -31,14 +31,14 @@ interface ModelResponseViewProps {
  * All edit_note runs are routed through EditNoteGroupView, including
  * single-call runs, so note edits have one container path.
  */
-export const ModelResponseView: React.FC<ModelResponseViewProps> = ({
+export const ModelResponseView: React.FC<ModelResponseViewProps> = React.memo(function ModelResponseView({
     message,
     isStreaming,
     previousMessageHasToolCall,
     runId,
     responseIndex,
     runStatus,
-}) => {
+}) {
     const contentRef = useRef<HTMLDivElement | null>(null);
     
     const { 
@@ -149,6 +149,6 @@ export const ModelResponseView: React.FC<ModelResponseViewProps> = ({
             />
         </div>
     );
-};
+});
 
 export default ModelResponseView;

--- a/react/components/agentRuns/TextPartView.tsx
+++ b/react/components/agentRuns/TextPartView.tsx
@@ -13,19 +13,19 @@ interface TextPartViewProps {
  * Since WSPartEvent sends accumulated content (not deltas),
  * we simply render the current content state.
  */
-export const TextPartView: React.FC<TextPartViewProps> = ({ part, runId }) => {
+export const TextPartView: React.FC<TextPartViewProps> = React.memo(function TextPartView({ part, runId }) {
     if (!part.content || part.content.trim() === '' || part.content == '_') {
         return null;
     }
 
     return (
-        <MarkdownRenderer 
+        <MarkdownRenderer
             className="markdown"
             content={part.content.trim()}
             runId={runId}
         />
     );
-};
+});
 
 export default TextPartView;
 

--- a/react/components/agentRuns/ThreadView.tsx
+++ b/react/components/agentRuns/ThreadView.tsx
@@ -62,7 +62,9 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
         // Select the correct atoms based on whether we're in the separate window
         const scrollPositionAtom = isWindow ? windowScrollPositionAtom : currentThreadScrollPositionAtom;
         const scrolledAtom = isWindow ? windowUserScrolledAtom : userScrolledAtom;
-        const storedScrollTop = useAtomValue(scrollPositionAtom);
+        // Read scroll position imperatively inside restoreScrollPosition rather than subscribing.
+        // The atom is updated every ~10px of scroll, so subscribing would cause ThreadView to
+        // re-render constantly while the user scrolls, cascading through all message components.
         
         // Watch expansion state to re-evaluate scroll button visibility after expand/collapse
         // Track multiple expansion states: tool calls, sources, and agent actions
@@ -169,7 +171,7 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
                 return;
             }
 
-            const targetScrollTop = storedScrollTop ?? container.scrollHeight;
+            const targetScrollTop = store.get(scrollPositionAtom) ?? container.scrollHeight;
             const delta = Math.abs(container.scrollTop - targetScrollTop);
             
             // Check if this is a thread switch
@@ -202,7 +204,7 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
                     }
                 }
             }
-        }, [pendingRunId, isProtocolScrollLocked, storedScrollTop, scrolledAtom, scrollContainerRef, currentThreadId, isLoadingThread]);
+        }, [pendingRunId, isProtocolScrollLocked, scrollPositionAtom, scrolledAtom, scrollContainerRef, currentThreadId]);
 
         // Restore scroll position from atom (only for thread switching, not during streaming)
         // Note: userScrolledAtom is managed by useAutoScroll.handleScroll, not here

--- a/react/components/messages/MarkdownRenderer.tsx
+++ b/react/components/messages/MarkdownRenderer.tsx
@@ -231,101 +231,86 @@ function parseContentIntoSegments(content: string): Segment[] {
 }
 
 
-const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
-    content, 
-    className = 'markdown', 
+/**
+ * Process partial tags at the end of content (streaming-safe).
+ * Pure function \u2014 extracted so it can be called from useMemo.
+ */
+function processPartialContent(content: string, exportRendering: boolean): string {
+    let processed = content;
+
+    // Remove invisible or control characters
+    // Includes: zero-width space, zero-width non-joiner, soft hyphen, etc.
+    processed = exportRendering
+        ? processed.normalize("NFC").replace(/[\u200B-\u200D\uFEFF\u00AD]/g, '')
+        : processed.normalize("NFKC").replace(/[\u200B-\u200D\uFEFF\u00AD]/g, '');
+
+    // Complete unclosed bold formatting for rendering during streaming
+    // Strategy: Count ** pairs and if there's an odd number, temporarily add closing **
+    const boldMarkers = (processed.match(/\*\*/g) || []).length;
+    if (boldMarkers % 2 === 1) {
+        if (!processed.endsWith('**')) {
+            processed = processed + '**';
+        }
+    }
+
+    // Clean up backticks around complete citations (handles both /> and > endings)
+    processed = processed.replace(/`(<citation[^>]*\/?>)`/g, '$1');
+
+    // Filter out other partial tags
+    const partialTagPatterns = [
+        /<citation[^>]*$/,                // Partial citation tag
+        /<note[^>]*$/,                    // Partial note opening tag
+        /<\/note$/,                       // Partial note closing tag
+        /<[a-z][a-z0-9]*(?:\s+[^>]*)?$/i, // Any partial HTML tag
+        /\$\$[^$]*$/                      // Unclosed math equation
+    ];
+
+    for (const pattern of partialTagPatterns) {
+        const match = processed.match(pattern);
+        if (match && match.index !== undefined && match.index + match[0].length === processed.length) {
+            processed = processed.substring(0, match.index);
+            break;
+        }
+    }
+
+    return processed;
+}
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(function MarkdownRenderer({
+    content,
+    className = 'markdown',
     exportRendering = false,
     messageId,
     runId,
     enableNoteBlocks = true
-}) => {
-    // Process partial tags at the end of content
-    const processPartialContent = (content: string): string => {
-        let processed = content;
+}) {
+    // Heavy preprocessing: skip when content/flags are unchanged (e.g. parent re-render).
+    const processedSegments = React.useMemo(() => {
+        const processedContent = processPartialContent(content, exportRendering);
 
-        // Remove invisible or control characters
-        // Includes: zero-width space, zero-width non-joiner, soft hyphen, etc.
-        processed = exportRendering
-            ? processed.normalize("NFC").replace(/[\u200B-\u200D\uFEFF\u00AD]/g, '')
-            : processed.normalize("NFKC").replace(/[\u200B-\u200D\uFEFF\u00AD]/g, '');
-            
-        // Complete unclosed code blocks
-        // const codeBlockRegex = /```(?:\w+)?\s+[^`]*$/;
-        // const codeBlockMatch = processed.match(codeBlockRegex);
-        // if (codeBlockMatch && codeBlockMatch.index !== undefined && 
-        //     codeBlockMatch.index + codeBlockMatch[0].length === processed.length) {
-        //     // Add closing ``` for proper formatting during streaming
-        //     return processed + "\n```";
-        // }
+        const segments = enableNoteBlocks
+            ? parseContentIntoSegments(processedContent)
+            : [{ type: 'markdown' as const, content: processedContent }];
 
-        // Complete unclosed bold formatting for rendering during streaming
-        // Strategy: Count ** pairs and if there's an odd number, temporarily add closing **
-        const boldMarkers = (processed.match(/\*\*/g) || []).length;
-        if (boldMarkers % 2 === 1) {
-            if (!processed.endsWith('**')) {
-                processed = processed + '**';
+        // Track citation state across all markdown segments for consecutive detection
+        const preprocessState = createPreprocessState();
+
+        return segments.map((segment) => {
+            if (segment.type === 'note') {
+                return segment;
             }
-        }
 
-        // Clean up backticks around complete citations (handles both /> and > endings)
-        processed = processed.replace(/`(<citation[^>]*\/?>)`/g, '$1');
+            let markdownContent = segment.content;
+            markdownContent = preprocessCitations(markdownContent, preprocessState);
+            markdownContent = markdownContent
+                .replace(/```plaintext\s*([\s\S]*?)\s*```/, '$1')
+                .replace(/(?<!\\)\\\(((?:\\.|[^\\])*?)\\\)/g, (_, match) => `$${match}$`)
+                .replace(/(?<!\\)\\\[((?:\\.|[^\\])*?)\\\]/g, (_, match) => `$$${match}$$`)
+                .replace(/\$\$([^$]+)\$\$/g, (_, equation) => `\n$$\n${equation.trim()}\n$$\n`);
 
-        // Filter out other partial tags
-        const partialTagPatterns = [
-            /<citation[^>]*$/,                // Partial citation tag
-            /<note[^>]*$/,                    // Partial note opening tag
-            /<\/note$/,                       // Partial note closing tag
-            /<[a-z][a-z0-9]*(?:\s+[^>]*)?$/i, // Any partial HTML tag
-            /\$\$[^$]*$/                      // Unclosed math equation
-        ];
-        
-        // Check if content ends with any of our partial tag patterns
-        for (const pattern of partialTagPatterns) {
-            const match = processed.match(pattern);
-            if (match && match.index !== undefined && match.index + match[0].length === processed.length) {
-                // Remove the partial tag if it's at the end of the content
-                processed = processed.substring(0, match.index);
-                break; // Only apply one filter
-            }
-        }
-        
-        return processed;
-    };
-    
-    const processedContent = processPartialContent(content);
-    
-    // Parse into segments if note blocks are enabled
-    const segments = enableNoteBlocks 
-        ? parseContentIntoSegments(processedContent)
-        : [{ type: 'markdown' as const, content: processedContent }];
-    
-    // Track citation state across all markdown segments for consecutive detection
-    const preprocessState = createPreprocessState();
-    
-    // Process each segment
-    const processedSegments = segments.map((segment, index) => {
-        if (segment.type === 'note') {
-            return segment;
-        }
-        
-        // Apply citation preprocessing to markdown segments
-        let markdownContent = segment.content;
-        
-        // Preprocess citations (state is mutated to track consecutive citations)
-        markdownContent = preprocessCitations(markdownContent, preprocessState);
-        
-        // Apply other markdown preprocessing
-        markdownContent = markdownContent
-            // Fix common formatting issues
-            .replace(/```plaintext\s*([\s\S]*?)\s*```/, '$1')
-            // Convert \(...\) and \[...\] to $...$ and $$...$$ BEFORE newline-padding
-            .replace(/(?<!\\)\\\(((?:\\.|[^\\])*?)\\\)/g, (_, match) => `$${match}$`)
-            .replace(/(?<!\\)\\\[((?:\\.|[^\\])*?)\\\]/g, (_, match) => `$$${match}$$`)
-            // Ensure display math ($$...$$) has surrounding newlines for remark-math
-            .replace(/\$\$([^$]+)\$\$/g, (_, equation) => `\n$$\n${equation.trim()}\n$$\n`);
-        
-        return { type: 'markdown' as const, content: markdownContent };
-    });
+            return { type: 'markdown' as const, content: markdownContent };
+        });
+    }, [content, exportRendering, enableNoteBlocks]);
 
     // Render segments
     return (
@@ -366,6 +351,6 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
             })}
         </div>
     );
-};
+});
 
 export default MarkdownRenderer;


### PR DESCRIPTION
Long chats had laggy scrolling because every scroll event re-rendered the entire transcript and re-parsed every markdown segment.

- ThreadView: stop subscribing to the scroll-position atom. The atom is written every ~10px of user scroll; subscribing forced ThreadView (and thus every run/message component) to re-render on every scroll tick. Read it imperatively inside restoreScrollPosition instead.
- Wrap AgentRunView, ModelMessagesView, ModelResponseView, TextPartView, and MarkdownRenderer in React.memo so unchanged runs/messages don't re-render when a parent re-renders (e.g. during streaming).
- Memoize MarkdownRenderer's content preprocessing (processPartialContent, parseContentIntoSegments, citation/math regex passes) via useMemo so completed runs don't re-run those passes on every render.