### PR TITLE
feat(pdf): add figure-text detection module for identifying candidate…

### DIFF
--- a/src/services/pdf/FigureTextFilter.ts
+++ b/src/services/pdf/FigureTextFilter.ts
@@ -1,0 +1,347 @@
+/**
+ * Figure-text detection — classifies detected columns that look like
+ * figure-internal text (axis labels, tick marks, panel labels, in-
+ * figure annotations) on pages that show a figure-heavy signature.
+ *
+ * **Dormant.** This module produces detection metadata only: it
+ * identifies *candidate* figure-internal columns and a per-page
+ * `figurePage` flag. It does NOT remove anything from the extraction
+ * pipeline — line / paragraph / sentence detection still runs over
+ * the full column set. The candidate list is reserved for future
+ * `NonStandardContentRegion` integration; today it is exposed solely
+ * as a debugging signal via the column-detector wrapper and the
+ * `pdf-pipeline-trace` endpoint.
+ *
+ * Intent of the heuristic (preserved here for future activation):
+ * candidates are columns that, on a page exhibiting clustered tiny
+ * non-body columns or a stacked rotated tick column, lack body-
+ * content evidence (caption marker, sentence terminator, substantial
+ * prose, multi-word title-case). The figure-heavy precondition
+ * keeps the detector quiet on ordinary 1- and 2-column body pages.
+ *
+ * Worker-safe: imports only sibling PDF modules and `Rect` from
+ * `ColumnDetector`. No barrel imports.
+ */
+import type { Rect } from "./ColumnDetector";
+import type { RawLine, RawPageData } from "./types";
+
+export interface FigureTextDetectionOptions {
+    /** Minimum tiny columns lacking body content needed for figure-heavy mode. */
+    minTinyColumnsForFigurePage?: number;
+    /** Width fraction (relative to page content width) below which a column counts as tiny. */
+    tinyColumnWidthFraction?: number;
+    /** Max alnum chars in the entire column for the tiny-column shape. */
+    tinyColumnMaxAlnumChars?: number;
+    /** Or every line ≤ this many words for the tiny-column shape. */
+    tinyColumnMaxWordsPerLine?: number;
+    /** h/w ratio threshold above which a line is treated as rotated/vertical. */
+    rotatedAspectRatio?: number;
+    /** Minimum alnum chars in a rotated line before it triggers the rotated rule. */
+    rotatedMinAlnumChars?: number;
+}
+
+const DEFAULTS: Required<FigureTextDetectionOptions> = {
+    minTinyColumnsForFigurePage: 3,
+    tinyColumnWidthFraction: 0.35,
+    tinyColumnMaxAlnumChars: 30,
+    tinyColumnMaxWordsPerLine: 4,
+    rotatedAspectRatio: 2,
+    rotatedMinAlnumChars: 3,
+};
+
+export type FigureTextReason = "tiny_cluster" | "rotated";
+
+export interface FigureTextDetectionResult {
+    /**
+     * Columns classified as figure-internal candidates. **Not removed
+     * from the pipeline** — these are detection metadata only,
+     * reserved for future NonStandardContentRegion integration.
+     */
+    candidates: Rect[];
+    /** Reason per candidate column. */
+    reasons: Map<Rect, FigureTextReason>;
+    /** True iff the page met the figure-heavy precondition. */
+    figurePage: boolean;
+}
+
+/**
+ * Classify a page's detected columns and return the figure-text
+ * candidate set. The input `columns` array is not modified; callers
+ * receive only metadata (candidates + figurePage flag).
+ *
+ * Pure function — no I/O, no side effects.
+ */
+export function detectFigureTextColumns(
+    columns: Rect[],
+    page: RawPageData,
+    pageContentWidth: number,
+    opts: FigureTextDetectionOptions = {},
+): FigureTextDetectionResult {
+    const o = { ...DEFAULTS, ...opts };
+
+    if (columns.length === 0) {
+        return { candidates: [], reasons: new Map(), figurePage: false };
+    }
+
+    // Collect the lines that overlap each column. We use the same
+    // overlap rule the line detector uses (centerline of the line
+    // falls inside the column rect) so the detector sees the same
+    // content the downstream line/paragraph stages would see.
+    const linesPerColumn = columns.map((col) => collectLinesInColumn(col, page));
+
+    const shapes = columns.map((col, i) => describeColumn(col, linesPerColumn[i], pageContentWidth, o));
+
+    // Figure-heavy precondition. Fires when EITHER:
+    //   (a) ≥ minTinyColumnsForFigurePage tiny non-body columns
+    //       cluster spatially — share a ~100pt vertical band
+    //       (horizontal cluster: X-axis ticks, panel labels) or a
+    //       ~30pt horizontal band (vertical cluster: Y-axis ticks at
+    //       the same X). Rejects equation pages where fragments
+    //       are spread vertically across body text.
+    //   (b) Some single column contains ≥ minTinyColumnsForFigurePage
+    //       rotated lines and lacks body content. The MuPDF JSON walk
+    //       sometimes merges a stacked column of rotated tick numbers
+    //       (e.g. "0 / 200000 / 400000 / 600000 / …" on a y-axis)
+    //       into a single column with N rotated lines. Clause (a)
+    //       can't see the cluster — we recover it via the per-column
+    //       rotated-line count.
+    const tinyIdx: number[] = [];
+    for (let i = 0; i < shapes.length; i++) {
+        if (shapes[i].tiny && !shapes[i].bodyContent) tinyIdx.push(i);
+    }
+    const horizontalCluster = maxColumnsInBand(tinyIdx, columns, "y", 100);
+    const verticalCluster = maxColumnsInBand(tinyIdx, columns, "x", 30);
+    const stackedRotatedCol = shapes.some(
+        (s) =>
+            !s.bodyContent &&
+            s.rotatedLineCount >= o.minTinyColumnsForFigurePage,
+    );
+    const figurePage =
+        (tinyIdx.length >= o.minTinyColumnsForFigurePage &&
+            Math.max(horizontalCluster, verticalCluster) >=
+                o.minTinyColumnsForFigurePage) ||
+        stackedRotatedCol;
+
+    if (!figurePage) {
+        return { candidates: [], reasons: new Map(), figurePage: false };
+    }
+
+    const candidates: Rect[] = [];
+    const reasons = new Map<Rect, FigureTextReason>();
+
+    for (let i = 0; i < columns.length; i++) {
+        const col = columns[i];
+        const s = shapes[i];
+
+        if (s.bodyContent) continue;
+        if (s.tiny) {
+            candidates.push(col);
+            reasons.set(col, "tiny_cluster");
+            continue;
+        }
+        if (s.rotated) {
+            candidates.push(col);
+            reasons.set(col, "rotated");
+            continue;
+        }
+    }
+
+    return { candidates, reasons, figurePage: true };
+}
+
+// ---------------------------------------------------------------------------
+// Per-column shape analysis
+// ---------------------------------------------------------------------------
+
+interface ColumnShape {
+    tiny: boolean;
+    rotated: boolean;
+    /** Number of lines in the column whose bbox is rotated/vertical. */
+    rotatedLineCount: number;
+    bodyContent: boolean;
+}
+
+function describeColumn(
+    col: Rect,
+    lines: RawLine[],
+    pageContentWidth: number,
+    o: Required<FigureTextDetectionOptions>,
+): ColumnShape {
+    const totalAlnum = lines.reduce((sum, l) => sum + countAlnum(l.text), 0);
+    const everyLineShort =
+        lines.length > 0 && lines.every((l) => wordCount(l.text) <= o.tinyColumnMaxWordsPerLine);
+    const widthFrac = pageContentWidth > 0 ? col.w / pageContentWidth : 1;
+    const tiny =
+        widthFrac < o.tinyColumnWidthFraction &&
+        (totalAlnum <= o.tinyColumnMaxAlnumChars || everyLineShort);
+
+    let rotatedLineCount = 0;
+    for (const l of lines) {
+        if (l.bbox.w <= 0) continue;
+        const ratio = l.bbox.h / l.bbox.w;
+        if (ratio >= o.rotatedAspectRatio && countAlnum(l.text) >= o.rotatedMinAlnumChars) {
+            rotatedLineCount++;
+        }
+    }
+    const rotated = rotatedLineCount > 0;
+
+    // Rotated columns lose access to the multi-word-title-case escape
+    // hatch: an axis label like "Number of Genes" is title-case but
+    // still axis text, not a panel title. Caption markers, sentence
+    // terminators, and substantial prose still preserve a rotated
+    // column.
+    const bodyContent = hasBodyContentEvidence(lines, { allowTitleCase: !rotated });
+
+    return { tiny, rotated, rotatedLineCount, bodyContent };
+}
+
+// ---------------------------------------------------------------------------
+// Body-content evidence
+// ---------------------------------------------------------------------------
+
+const CAPTION_PREFIX = /^(?:Fig\.?|Figure|Tab\.?|Table|Eq\.?|Equation|Scheme|Supplementary)\b/;
+// Sentence terminator (`. ! ?`) preceded by a word of ≥ 3 letters and
+// optional closing punctuation. Excludes things like "Fig." (only 3
+// letters but followed by a digit/colon usually) and "(P = 0.51)".
+const SENTENCE_TERMINATOR = /[A-Za-z]{3,}[)\]"']*[.!?][)\]"']*\s*$/;
+
+function hasBodyContentEvidence(
+    lines: RawLine[],
+    opts: { allowTitleCase: boolean } = { allowTitleCase: true },
+): boolean {
+    if (lines.length === 0) return false;
+
+    let alphaWordTotal = 0;
+    for (const l of lines) {
+        const text = l.text.trim();
+        if (!text) continue;
+
+        if (CAPTION_PREFIX.test(text)) return true;
+        if (SENTENCE_TERMINATOR.test(text)) return true;
+        if (opts.allowTitleCase && isMultiWordTitleCase(text)) return true;
+
+        alphaWordTotal += countAlphaWords(text);
+        if (alphaWordTotal >= 6) return true;
+    }
+    return false;
+}
+
+/**
+ * "Multi-word title-like label" — accepts both true title-case
+ * ("Dehejia Wahba Sample", "Lalonde Sample", "Number of Reads") and
+ * longer sentence-case article titles ("Putting the pieces together").
+ * Rejects in-figure annotations like "fresh used", "no overlay with
+ * overlay", "10 µL".
+ *
+ * Two acceptance shapes:
+ *   - title-case: ≥ 2 alpha words, ≥ 2 start with a capital letter,
+ *     total alpha length ≥ 6.
+ *   - sentence-case title: ≥ 4 alpha words AND the first alpha word
+ *     starts with a capital letter, total alpha length ≥ 12.
+ */
+function isMultiWordTitleCase(text: string): boolean {
+    const tokens = text.split(/\s+/).filter(Boolean);
+    const alphaTokens = tokens.filter((t) => /^[A-Za-z]+$/.test(t));
+    if (alphaTokens.length < 2) return false;
+    const alphaLen = alphaTokens.reduce((s, t) => s + t.length, 0);
+    const capitalized = alphaTokens.filter((t) => /^[A-Z]/.test(t)).length;
+    if (capitalized >= 2 && alphaLen >= 6) return true;
+    if (
+        alphaTokens.length >= 4 &&
+        /^[A-Z]/.test(alphaTokens[0]) &&
+        alphaLen >= 12
+    ) {
+        return true;
+    }
+    return false;
+}
+
+function countAlphaWords(text: string): number {
+    const tokens = text.split(/\s+/).filter(Boolean);
+    let n = 0;
+    for (const t of tokens) {
+        if (/^[A-Za-z]{2,}$/.test(t)) n++;
+    }
+    return n;
+}
+
+function countAlnum(text: string): number {
+    const m = text.match(/[\p{L}\p{N}]/gu);
+    return m ? m.length : 0;
+}
+
+function wordCount(text: string): number {
+    const m = text.trim().match(/\S+/g);
+    return m ? m.length : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Spatial clustering helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of selected columns whose centers (along the
+ * requested axis) fall within any sliding window of `bandPt` points.
+ * Used to require spatial clustering of figure-text columns: a Y band
+ * captures rows of X-axis ticks; an X band captures columns of Y-axis
+ * ticks.
+ */
+function maxColumnsInBand(
+    selectedIdx: number[],
+    columns: Rect[],
+    axis: "x" | "y",
+    bandPt: number,
+): number {
+    if (selectedIdx.length === 0) return 0;
+    const centers = selectedIdx
+        .map((i) => {
+            const c = columns[i];
+            return axis === "y" ? c.y + c.h / 2 : c.x + c.w / 2;
+        })
+        .sort((a, b) => a - b);
+    let best = 1;
+    let lo = 0;
+    for (let hi = 0; hi < centers.length; hi++) {
+        while (centers[hi] - centers[lo] > bandPt) lo++;
+        const span = hi - lo + 1;
+        if (span > best) best = span;
+    }
+    return best;
+}
+
+// ---------------------------------------------------------------------------
+// Column ↔ line membership
+// ---------------------------------------------------------------------------
+
+/**
+ * A line belongs to a column when its centerline falls inside the
+ * column rect (with a small slack for edge rounding). This mirrors the
+ * convention used by `LineDetector.detectLinesInColumn` in spirit
+ * without depending on it: the detector must reason about the same
+ * lines the downstream stages will see.
+ */
+function collectLinesInColumn(col: Rect, page: RawPageData): RawLine[] {
+    const out: RawLine[] = [];
+    const colLeft = col.x;
+    const colRight = col.x + col.w;
+    const colTop = col.y;
+    const colBottom = col.y + col.h;
+    const SLACK = 1; // pt — accommodates float drift in column rects
+
+    for (const block of page.blocks) {
+        if (block.type !== "text" || !block.lines) continue;
+        for (const line of block.lines) {
+            const cx = line.bbox.x + line.bbox.w / 2;
+            const cy = line.bbox.y + line.bbox.h / 2;
+            if (
+                cx >= colLeft - SLACK &&
+                cx <= colRight + SLACK &&
+                cy >= colTop - SLACK &&
+                cy <= colBottom + SLACK
+            ) {
+                out.push(line);
+            }
+        }
+    }
+    return out;
+}

--- a/src/services/pdf/index.ts
+++ b/src/services/pdf/index.ts
@@ -56,7 +56,19 @@ export {
 } from "./MarginFilter";
 export { PageExtractor } from "./PageExtractor";
 export { detectColumns, logColumnDetection } from "./ColumnDetector";
-export type { Rect, ColumnDetectionResult, ColumnDetectionOptions } from "./ColumnDetector";
+export type {
+    Rect,
+    ColumnDetectionResult,
+    ColumnDetectionOptions,
+} from "./ColumnDetector";
+// Standalone figure-text detector. Not wired into the extraction
+// pipeline today — exported for future NonStandardContentRegion work.
+export { detectFigureTextColumns } from "./FigureTextFilter";
+export type {
+    FigureTextDetectionOptions,
+    FigureTextDetectionResult,
+    FigureTextReason,
+} from "./FigureTextFilter";
 export {
     detectLinesInColumn,
     detectLinesOnPage,

--- a/tests/unit/pdf/FigureTextFilter.test.ts
+++ b/tests/unit/pdf/FigureTextFilter.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for FigureTextFilter — covers the layout shapes the
+ * detector is meant to recognize.
+ *
+ * The detector is dormant: it produces detection metadata
+ * (`candidates`, `figurePage`) only. These tests assert what the
+ * detector classifies — they do not assert that anything is removed
+ * from the input column set, since detection is non-invasive.
+ * Pipeline-level non-invasiveness is covered in
+ * `FilteredParagraphPipeline.test.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Rect } from "../../../src/services/pdf/ColumnDetector";
+import { detectFigureTextColumns } from "../../../src/services/pdf/FigureTextFilter";
+import type { RawBlock, RawLine, RawPageData } from "../../../src/services/pdf/types";
+
+const PAGE_W = 612;
+const PAGE_H = 792;
+const CONTENT_W = PAGE_W - 50; // mirrors DEFAULT_MARGINS.left + .right
+
+function line(text: string, bbox: { x: number; y: number; w: number; h: number }): RawLine {
+    return {
+        wmode: 0,
+        bbox,
+        font: { name: "Body", family: "Body", weight: "normal", style: "normal", size: 10 },
+        x: bbox.x,
+        y: bbox.y,
+        text,
+    };
+}
+
+function page(lines: RawLine[]): RawPageData {
+    const blocks: RawBlock[] = lines.length
+        ? [
+              {
+                  type: "text",
+                  bbox: { x: 0, y: 0, w: PAGE_W, h: PAGE_H },
+                  lines,
+              },
+          ]
+        : [];
+    return {
+        pageIndex: 0,
+        pageNumber: 1,
+        width: PAGE_W,
+        height: PAGE_H,
+        blocks,
+    };
+}
+
+/** Build a column rect that snugly encloses the supplied lines. */
+function colFromLines(ls: RawLine[]): Rect {
+    const x0 = Math.min(...ls.map((l) => l.bbox.x));
+    const y0 = Math.min(...ls.map((l) => l.bbox.y));
+    const x1 = Math.max(...ls.map((l) => l.bbox.x + l.bbox.w));
+    const y1 = Math.max(...ls.map((l) => l.bbox.y + l.bbox.h));
+    return { x: x0, y: y0, w: x1 - x0, h: y1 - y0 };
+}
+
+describe("FigureTextFilter (detection-only)", () => {
+    it("flags rotated 'Transmittance' label on a figure-heavy page", () => {
+        // 1 wide caption + 4 tiny tick columns + 1 rotated label.
+        const captionLines = [
+            line("Fig. S3. ATR spectra of the used MnO2 (A), CeMn (B) and SnCeMn (C) catalysts.",
+                { x: 80, y: 100, w: 450, h: 12 }),
+        ];
+        const tick1 = [line("4000", { x: 90, y: 300, w: 22, h: 8 })];
+        const tick2 = [line("3000", { x: 140, y: 300, w: 22, h: 8 })];
+        const tick3 = [line("2000", { x: 190, y: 300, w: 22, h: 8 })];
+        const tick4 = [line("1000", { x: 240, y: 300, w: 22, h: 8 })];
+        const transmittance = [line("Transmittance", { x: 60, y: 200, w: 13, h: 80 })];
+
+        const lines = [...captionLines, ...tick1, ...tick2, ...tick3, ...tick4, ...transmittance];
+        const cols: Rect[] = [
+            colFromLines(captionLines),
+            colFromLines(tick1),
+            colFromLines(tick2),
+            colFromLines(tick3),
+            colFromLines(tick4),
+            colFromLines(transmittance),
+        ];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).not.toContain(cols[0]); // caption preserved
+        expect(result.candidates).toContain(cols[1]); // tick rows
+        expect(result.candidates).toContain(cols[2]);
+        expect(result.candidates).toContain(cols[3]);
+        expect(result.candidates).toContain(cols[4]);
+        expect(result.candidates).toContain(cols[5]); // rotated label
+        expect(["rotated", "tiny_cluster"]).toContain(result.reasons.get(cols[5]));
+        expect(result.reasons.get(cols[1])).toBe("tiny_cluster");
+    });
+
+    it("flags a wide rotated label as 'rotated'", () => {
+        const rotatedLine = line("Number of Genes", { x: 80, y: 200, w: 13, h: 80 });
+        const rotated = [rotatedLine];
+        const ticks = [
+            [line("0", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("1", { x: 140, y: 300, w: 6, h: 8 })],
+            [line("2", { x: 190, y: 300, w: 6, h: 8 })],
+        ];
+        const lines = [...rotated, ...ticks.flat()];
+        const cols = [colFromLines(rotated), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).toContain(cols[0]);
+    });
+
+    it("does NOT flag a single rotated label when the page is not figure-heavy", () => {
+        // 2 body columns + 1 rotated label — precondition fails.
+        const body1 = [
+            line(
+                "This is a normal paragraph of body text. It contains several sentences.",
+                { x: 60, y: 100, w: 240, h: 12 },
+            ),
+            line(
+                "It continues across multiple lines with regular prose content here.",
+                { x: 60, y: 116, w: 240, h: 12 },
+            ),
+        ];
+        const body2 = [
+            line(
+                "A second column of body text sits next to the first one on this page.",
+                { x: 320, y: 100, w: 240, h: 12 },
+            ),
+        ];
+        const rotated = [line("Sidebar", { x: 30, y: 100, w: 12, h: 60 })];
+
+        const lines = [...body1, ...body2, ...rotated];
+        const cols = [colFromLines(body1), colFromLines(body2), colFromLines(rotated)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(false);
+        expect(result.candidates).toHaveLength(0);
+    });
+
+    it("flags a cluster of numeric tick rows", () => {
+        const ticks = [
+            [line("0.05", { x: 90, y: 300, w: 22, h: 8 })],
+            [line("0.10", { x: 140, y: 300, w: 22, h: 8 })],
+            [line("0.15", { x: 190, y: 300, w: 22, h: 8 })],
+            [line("0.20", { x: 240, y: 300, w: 22, h: 8 })],
+            [line("0.25", { x: 290, y: 300, w: 22, h: 8 })],
+        ];
+        const lines = ticks.flat();
+        const cols = ticks.map(colFromLines);
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).toHaveLength(5);
+    });
+
+    it("does NOT flag a single tiny column on a body page", () => {
+        const body = [
+            line(
+                "An ordinary paragraph of body text sits in the main column of the page.",
+                { x: 60, y: 100, w: 360, h: 12 },
+            ),
+            line(
+                "Wrapping to a second line so the column is clearly tall body content here.",
+                { x: 60, y: 116, w: 360, h: 12 },
+            ),
+        ];
+        const tiny = [line("3.14", { x: 480, y: 100, w: 22, h: 8 })];
+
+        const lines = [...body, ...tiny];
+        const cols = [colFromLines(body), colFromLines(tiny)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(false);
+        expect(result.candidates).toHaveLength(0);
+    });
+
+    it("preserves a figure caption (not flagged) on a figure-heavy page", () => {
+        const captionLines = [line("Fig. 3:", { x: 80, y: 100, w: 60, h: 10 })];
+        const ticks = [
+            [line("1", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("2", { x: 140, y: 300, w: 6, h: 8 })],
+            [line("3", { x: 190, y: 300, w: 6, h: 8 })],
+            [line("4", { x: 240, y: 300, w: 6, h: 8 })],
+        ];
+
+        const lines = [...captionLines, ...ticks.flat()];
+        const cols = [colFromLines(captionLines), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).not.toContain(cols[0]);
+    });
+
+    it("preserves a multi-word title-case panel title (not flagged)", () => {
+        const titleLines = [line("Dehejia Wahba Sample", { x: 200, y: 100, w: 110, h: 12 })];
+        const ticks = [
+            [line("0", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("0.05", { x: 140, y: 300, w: 22, h: 8 })],
+            [line("0.10", { x: 190, y: 300, w: 22, h: 8 })],
+            [line("0.15", { x: 240, y: 300, w: 22, h: 8 })],
+        ];
+
+        const lines = [...titleLines, ...ticks.flat()];
+        const cols = [colFromLines(titleLines), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).not.toContain(cols[0]);
+    });
+
+    it("flags a lowercase multi-word tick group", () => {
+        const overlayLine = [line("no overlay with overlay", { x: 200, y: 320, w: 100, h: 8 })];
+        const ticks = [
+            [line("1", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("2", { x: 140, y: 300, w: 6, h: 8 })],
+            [line("3", { x: 190, y: 300, w: 6, h: 8 })],
+        ];
+
+        const lines = [...overlayLine, ...ticks.flat()];
+        const cols = [colFromLines(overlayLine), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).toContain(cols[0]);
+    });
+
+    it("preserves a narrow column ending in a sentence terminator", () => {
+        const sentenceLine = [
+            line("This explains the experimental setup briefly.", {
+                x: 200,
+                y: 100,
+                w: 180,
+                h: 10,
+            }),
+        ];
+        const ticks = [
+            [line("0", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("1", { x: 140, y: 300, w: 6, h: 8 })],
+            [line("2", { x: 190, y: 300, w: 6, h: 8 })],
+        ];
+
+        const lines = [...sentenceLine, ...ticks.flat()];
+        const cols = [colFromLines(sentenceLine), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).not.toContain(cols[0]);
+    });
+
+    it("does not treat '(P = 0.51)' as a sentence end", () => {
+        const pValueLine = [line("(P = 0.51)", { x: 200, y: 320, w: 50, h: 8 })];
+        const ticks = [
+            [line("1", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("2", { x: 140, y: 300, w: 6, h: 8 })],
+            [line("3", { x: 190, y: 300, w: 6, h: 8 })],
+        ];
+
+        const lines = [...pValueLine, ...ticks.flat()];
+        const cols = [colFromLines(pValueLine), ...ticks.map(colFromLines)];
+
+        const result = detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(result.figurePage).toBe(true);
+        expect(result.candidates).toContain(cols[0]);
+    });
+
+    it("returns empty result for an empty column list", () => {
+        const result = detectFigureTextColumns([], page([]), CONTENT_W);
+        expect(result.candidates).toHaveLength(0);
+        expect(result.figurePage).toBe(false);
+    });
+
+    it("does not mutate the input column array", () => {
+        // Detection must be a pure read of the column list.
+        const ticks = [
+            [line("0", { x: 90, y: 300, w: 6, h: 8 })],
+            [line("0.05", { x: 140, y: 300, w: 22, h: 8 })],
+            [line("0.10", { x: 190, y: 300, w: 22, h: 8 })],
+            [line("0.15", { x: 240, y: 300, w: 22, h: 8 })],
+        ];
+        const lines = ticks.flat();
+        const cols = ticks.map(colFromLines);
+        const before = cols.slice();
+
+        detectFigureTextColumns(cols, page(lines), CONTENT_W);
+
+        expect(cols).toEqual(before);
+        expect(cols).toHaveLength(4);
+    });
+});

--- a/tests/unit/pdf/FilteredParagraphPipeline.test.ts
+++ b/tests/unit/pdf/FilteredParagraphPipeline.test.ts
@@ -446,4 +446,5 @@ describe("detectFilteredParagraphs", () => {
             );
         });
     });
+
 });


### PR DESCRIPTION
Introduced the `FigureTextFilter` module to classify columns as figure-internal candidates based on specific heuristics for figure-heavy pages. This module currently produces detection metadata without modifying the extraction pipeline, reserving the candidate list for future integration with `NonStandardContentRegion`. Added unit tests to validate the detection logic and ensure accurate classification of figure-related text elements.