### PR TITLE
feat(note-html): enhance link handling in note processing

### DIFF
--- a/src/utils/editNoteStrippers.ts
+++ b/src/utils/editNoteStrippers.ts
@@ -12,7 +12,7 @@
 // =============================================================================
 
 /** Names of simplified-only elements (tags that don't exist in raw HTML). */
-const SIMPLIFIED_ELEMENT_NAMES = /^\/?(citation|annotation-image|annotation|image)\b/;
+const SIMPLIFIED_ELEMENT_NAMES = /^\/?(citation|annotation-image|annotation|image|link)\b/;
 
 export interface PartialElementStrip {
     /** old_string with partial element boundary fragments removed */

--- a/src/utils/editNoteValidation.ts
+++ b/src/utils/editNoteValidation.ts
@@ -351,7 +351,7 @@ export function applyOldStringEnrichment(
 // =============================================================================
 
 export interface PartialSimplifiedTag {
-    kind: 'citation' | 'annotation';
+    kind: 'citation' | 'annotation' | 'link';
     snippet: string;
 }
 
@@ -374,10 +374,10 @@ export function detectPartialSimplifiedTag(
     oldString: string,
 ): PartialSimplifiedTag | null {
     if (!oldString) return null;
-    const openerRe = /<(citation|annotation)(?=\s|>|\/|$)/g;
+    const openerRe = /<(citation|annotation|link)(?=\s|>|\/|$)/g;
     let m: RegExpExecArray | null;
     while ((m = openerRe.exec(oldString)) !== null) {
-        const kind = m[1] as 'citation' | 'annotation';
+        const kind = m[1] as 'citation' | 'annotation' | 'link';
         const start = m.index;
         let cursor = start + m[0].length;
         let closed = false;
@@ -387,7 +387,7 @@ export function detectPartialSimplifiedTag(
             // never terminated — the model truncated the tag.
             if (c === '<' || c === '\n') break;
             if (c === '/' && oldString[cursor + 1] === '>') {
-                closed = kind === 'citation';
+                closed = kind === 'citation' || kind === 'link';
                 cursor += 2;
                 break;
             }
@@ -420,6 +420,14 @@ export function detectPartialSimplifiedTag(
  * reading the generic zero-match hint.
  */
 export function buildPartialSimplifiedTagMessage(partial: PartialSimplifiedTag): string {
+    if (partial.kind === 'link') {
+        return (
+            '`<link/>` tags are atomic — the matcher cannot match a partial tag. '
+            + `Found a partial opener in old_string: \`${partial.snippet}\`.\n`
+            + 'A `<link/>` tag is a hyperlink. Copy the FULL `<link href="..."/>` '
+            + 'tag from `read_note` verbatim as old_string, not a prefix of it.'
+        );
+    }
     return (
         `${partial.kind === 'citation' ? 'Citation' : 'Annotation'} tags are atomic — `
         + `the matcher cannot match a partial tag. Found a partial opener in old_string: `

--- a/src/utils/noteCitationExpand.ts
+++ b/src/utils/noteCitationExpand.ts
@@ -566,6 +566,31 @@ export function expandToRawHtml(
         }
     );
 
+    // Expand self-linking anchor tokens (<link href="X"/>) back to raw anchors.
+    // Found in metadata → return the exact stored raw <a> (a verbatim slice of
+    // the note, so the matcher's exact strategy succeeds). Not found → a new
+    // URL the model wrote in new_string, so reconstruct the canonical anchor.
+    // The expanded anchors are shielded behind placeholders so the dollar-math
+    // passes below cannot corrupt a URL that contains `$...$`.
+    const rawLinkAnchors: string[] = [];
+    str = str.replace(
+        /<link\s+href="([^"]*)"\s*\/>/g,
+        (_match, tokenHref) => {
+            const decodedHref = unescapeAttr(tokenHref);
+            const stored = metadata.elements.get(`link:${decodedHref}`);
+            // For an unknown URL, re-encode the decoded href canonically so the
+            // reconstructed anchor matches what normalizeNoteHtml emits — a
+            // model-written bare `&` becomes `&amp;`, and a token that already
+            // carried `&amp;` is never double-escaped to `&amp;amp;`.
+            const escapedHref = escapeAttr(decodedHref);
+            const anchor = stored
+                ? stored.rawHtml
+                : `<a href="${escapedHref}" rel="noopener noreferrer nofollow">${escapedHref}</a>`;
+            const idx = rawLinkAnchors.push(anchor) - 1;
+            return `__BEAVER_RAW_LINK_${idx}__`;
+        }
+    );
+
     // Preserve math wrappers that already exist in the edited string. Empty
     // placeholders now survive simplification as raw HTML, and the model may
     // keep those wrappers when filling them in. Shield them before the dollar
@@ -618,6 +643,12 @@ export function expandToRawHtml(
     str = str.replace(
         /__BEAVER_RAW_MATH_(\d+)__/g,
         (match, idx) => preservedMathWrappers[Number(idx)] ?? match
+    );
+
+    // Restore shielded self-linking anchors (see the <link/> expansion above).
+    str = str.replace(
+        /__BEAVER_RAW_LINK_(\d+)__/g,
+        (match, idx) => rawLinkAnchors[Number(idx)] ?? match
     );
 
     return str;

--- a/src/utils/noteHtmlSimplifier.ts
+++ b/src/utils/noteHtmlSimplifier.ts
@@ -11,7 +11,7 @@
  */
 
 import { stripBeaverEditFooter, stripBeaverCreatedFooter } from './noteEditFooter';
-import { escapeAttr } from './noteHtmlEntities';
+import { escapeAttr, unescapeAttr } from './noteHtmlEntities';
 import { stripDataCitationItems, stripNoteWrapperDiv } from './noteWrapper';
 import { normalizeNoteHtml } from '../prosemirror/normalize';
 
@@ -32,7 +32,7 @@ export interface SimplificationMetadata {
 
 export interface StoredElement {
     rawHtml: string;
-    type: 'citation' | 'compound-citation' | 'annotation' | 'annotation-image' | 'image';
+    type: 'citation' | 'compound-citation' | 'annotation' | 'annotation-image' | 'image' | 'link';
     originalAttrs?: { item_id: string; page?: string };
     isCompound?: boolean;
     originalText?: string;
@@ -327,6 +327,50 @@ export function simplifyNoteHtml(rawHtml: string, libraryID: number): Simplifica
             }
         }
     );
+
+    // 5.5. Replace self-linking anchors with a compact <link href="X"/> token.
+    // Zotero auto-linkifies bare URLs typed into notes, producing
+    // <a href="X" rel="...">X</a> where the visible text equals the href. The
+    // verbose, URL-duplicating anchor is hard for the agent to copy verbatim
+    // into edit_note old_string; the token is short and stable.
+    // Annotation tokens are shielded first: a self-linking <a> could sit inside
+    // an annotation's inner text, and rewriting it there would desync the
+    // <annotation> tag from the stored originalText, breaking the equality
+    // check in expandToRawHtml. Citations/images are self-closing tokens and
+    // cannot contain a nested <a>.
+    {
+        const shieldedAnnotations: string[] = [];
+        simplified = simplified.replace(
+            /<annotation\s[^>]*>[\s\S]*?<\/annotation>/g,
+            (annMatch) => {
+                const idx = shieldedAnnotations.push(annMatch) - 1;
+                return `__BEAVER_LINK_SHIELD_${idx}__`;
+            }
+        );
+        simplified = simplified.replace(
+            /<a\s+href="([^"]*)"\s+rel="[^"]*">([^<]*)<\/a>/g,
+            (match, rawHref, rawText) => {
+                // Decode both sides so entity-encoded ampersands etc. compare
+                // equal. Only collapse genuine auto-linkified bare URLs: the
+                // visible text must equal the href and the scheme must be
+                // http(s) (exclude zotero://, mailto:, relative hrefs).
+                const decodedHref = unescapeAttr(rawHref);
+                const decodedText = unescapeAttr(rawText);
+                if (decodedHref !== decodedText) return match;
+                if (!/^https?:\/\//i.test(decodedHref)) return match;
+                metadata.elements.set(`link:${decodedHref}`, {
+                    rawHtml: match,
+                    type: 'link',
+                });
+                // rawHref is already valid attribute encoding — use verbatim.
+                return `<link href="${rawHref}"/>`;
+            }
+        );
+        simplified = simplified.replace(
+            /__BEAVER_LINK_SHIELD_(\d+)__/g,
+            (m, idx) => shieldedAnnotations[Number(idx)] ?? m
+        );
+    }
 
     // 6. Simplify math to dollar notation
     // Strip HTML wrappers from math elements, leaving dollar-delimited content.

--- a/tests/unit/notes/noteHtmlSimplifier.test.ts
+++ b/tests/unit/notes/noteHtmlSimplifier.test.ts
@@ -41,6 +41,7 @@ import {
     validateNewString,
     checkDuplicateCitations,
     enrichOldStringCitationRefs,
+    detectPartialSimplifiedTag,
 } from '../../../src/utils/editNoteValidation';
 import {
     findUniqueRawMatchPosition,
@@ -3138,5 +3139,147 @@ describe('simplifyNoteHtml with pre-normalization', () => {
         // Expand back
         const expanded = expandToRawHtml(simplified, metadata, 'old');
         expect(expanded).toContain('data-annotation=');
+    });
+});
+
+// =============================================================================
+// self-linking anchor collapse (<link/> token)
+// =============================================================================
+
+describe('self-linking anchor collapse', () => {
+    it('collapses a self-linking http anchor to a <link/> token', () => {
+        const url = 'https://example.com/page';
+        const html = wrap(`<p><a href="${url}">${url}</a></p>`);
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        expect(simplified).toContain(`<link href="${url}"/>`);
+        expect(simplified).not.toContain('<a ');
+        const stored = metadata.elements.get(`link:${url}`);
+        expect(stored).toBeDefined();
+        expect(stored?.type).toBe('link');
+    });
+
+    it('round-trips a self-linking anchor back to the exact raw HTML', () => {
+        const url = 'https://example.com/page';
+        const html = wrap(`<p><a href="${url}">${url}</a></p>`);
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        const stored = metadata.elements.get(`link:${url}`);
+        expect(stored).toBeDefined();
+        // The stored raw anchor is a verbatim slice of the matchable note HTML.
+        expect(normalizeNoteHtml(html)).toContain(stored!.rawHtml);
+        // Expanding the simplified note restores that exact raw anchor.
+        expect(expandToRawHtml(simplified, metadata, 'old')).toContain(stored!.rawHtml);
+    });
+
+    it('leaves a labeled (non-self-linking) anchor verbatim', () => {
+        const html = wrap('<p><a href="https://doi.org/10.1/x">Smith 2020</a></p>');
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        expect(simplified).not.toContain('<link ');
+        expect(simplified).toContain('<a href="https://doi.org/10.1/x"');
+        expect([...metadata.elements.keys()].some((k) => k.startsWith('link:'))).toBe(false);
+    });
+
+    it('does not collapse mailto: or relative self-links', () => {
+        const mailto = wrap('<p><a href="mailto:a@b.com">mailto:a@b.com</a></p>');
+        expect(simplifyNoteHtml(mailto, 1).simplified).not.toContain('<link ');
+        const relative = wrap('<p><a href="#section">#section</a></p>');
+        expect(simplifyNoteHtml(relative, 1).simplified).not.toContain('<link ');
+    });
+
+    it('keeps a single &amp; in the token for a URL with an ampersand', () => {
+        const html = wrap(
+            '<p><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></p>'
+        );
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        expect(simplified).toContain('<link href="https://example.com/?a=1&amp;b=2"/>');
+        expect(simplified).not.toContain('&amp;amp;');
+        // Metadata is keyed by the decoded (bare-&) URL.
+        const stored = metadata.elements.get('link:https://example.com/?a=1&b=2');
+        expect(stored).toBeDefined();
+        expect(expandToRawHtml(simplified, metadata, 'old')).toContain(stored!.rawHtml);
+    });
+
+    it('does not corrupt a URL containing $...$ during expansion', () => {
+        const url = 'https://example.com/a$b$c';
+        const html = wrap(`<p><a href="${url}">${url}</a></p>`);
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        expect(simplified).toContain(`<link href="${url}"/>`);
+        const expanded = expandToRawHtml(simplified, metadata, 'old');
+        expect(expanded).not.toContain('class="math"');
+        expect(expanded).toContain(metadata.elements.get(`link:${url}`)!.rawHtml);
+    });
+
+    it('reconstructs a canonical anchor for an unknown <link/> in new_string', () => {
+        const metadata: SimplificationMetadata = { elements: new Map() };
+        const result = expandToRawHtml('<link href="https://new.com/p"/>', metadata, 'new');
+        expect(result).toBe(
+            '<a href="https://new.com/p" rel="noopener noreferrer nofollow">https://new.com/p</a>'
+        );
+    });
+
+    it('reconstructs a canonical single &amp; for an unknown <link/> URL', () => {
+        const metadata: SimplificationMetadata = { elements: new Map() };
+        // Model wrote a bare `&` in the token — expansion must emit canonical
+        // `&amp;` (and never double-escaped `&amp;amp;`).
+        const result = expandToRawHtml('<link href="https://new.com/?a=1&b=2"/>', metadata, 'new');
+        expect(result).toBe(
+            '<a href="https://new.com/?a=1&amp;b=2" rel="noopener noreferrer nofollow">'
+            + 'https://new.com/?a=1&amp;b=2</a>'
+        );
+        expect(result).not.toContain('&amp;amp;');
+        // A token that already carried `&amp;` converges on the same output.
+        const fromEncoded = expandToRawHtml(
+            '<link href="https://new.com/?a=1&amp;b=2"/>', metadata, 'new'
+        );
+        expect(fromEncoded).toBe(result);
+    });
+
+    it('does not throw for an unknown <link/> in old_string context', () => {
+        const metadata: SimplificationMetadata = { elements: new Map() };
+        expect(() => expandToRawHtml('<link href="https://x.com/q"/>', metadata, 'old')).not.toThrow();
+        expect(expandToRawHtml('<link href="https://x.com/q"/>', metadata, 'old')).toBe(
+            '<a href="https://x.com/q" rel="noopener noreferrer nofollow">https://x.com/q</a>'
+        );
+    });
+
+    it('collapses a self-link while leaving annotations intact (shielding round-trip)', () => {
+        const html = wrap(
+            `<p>${rawAnnotation('ANN1', 'highlighted text')}</p>`
+            + '<p><a href="https://example.com/p">https://example.com/p</a></p>'
+        );
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+        expect(simplified).toContain('<link href="https://example.com/p"/>');
+        expect(simplified).toContain('<annotation id="a_ANN1"');
+        // The annotation token still expands — shield placeholders fully restored.
+        expect(() => expandToRawHtml(simplified, metadata, 'old')).not.toThrow();
+    });
+
+    it('does not collapse a self-link that carries a title attribute', () => {
+        const html = wrap('<p><a href="https://x.com/p" title="tip">https://x.com/p</a></p>');
+        const { simplified } = simplifyNoteHtml(html, 1);
+        expect(simplified).not.toContain('<link ');
+        expect(simplified).toContain('<a href="https://x.com/p"');
+    });
+
+    it('leaves a literal raw <a> in old_string untouched (backward compatible)', () => {
+        const url = 'https://example.com/p';
+        const html = wrap(`<p><a href="${url}">${url}</a></p>`);
+        const { metadata } = simplifyNoteHtml(html, 1);
+        const rawAnchor = metadata.elements.get(`link:${url}`)!.rawHtml;
+        // A verbose raw <a> (no <link/> token) passes through expansion unchanged
+        // and is a verbatim slice of the matchable note HTML — so the matcher's
+        // exact strategy still works if the model copies the legacy form.
+        expect(expandToRawHtml(rawAnchor, metadata, 'old')).toBe(rawAnchor);
+        expect(normalizeNoteHtml(html)).toContain(rawAnchor);
+    });
+});
+
+describe('detectPartialSimplifiedTag — <link>', () => {
+    it('flags a truncated <link href= opener', () => {
+        const result = detectPartialSimplifiedTag('see <link href="https://y.com');
+        expect(result?.kind).toBe('link');
+    });
+
+    it('returns null for a complete <link/> tag', () => {
+        expect(detectPartialSimplifiedTag('see <link href="https://y.com/p"/> ok')).toBeNull();
     });
 });

--- a/tests/unit/notes/stripPartialSimplifiedElements.test.ts
+++ b/tests/unit/notes/stripPartialSimplifiedElements.test.ts
@@ -208,4 +208,25 @@ describe('stripPartialSimplifiedElements — other element types', () => {
         expect(result).not.toBeNull();
         expect(result!.strippedOld).toBe('Before ');
     });
+
+    it('strips a leading partial <link/> tag fragment', () => {
+        const simplified = 'See <link href="https://example.com/p"/> after link';
+        const oldString = 'p"/> after link';
+        const pos = simplified.indexOf(oldString);
+
+        const result = stripPartialSimplifiedElements(oldString, 'p"/> new text', simplified, pos);
+        expect(result).not.toBeNull();
+        expect(result!.strippedOld).toBe(' after link');
+        expect(result!.strippedNew).toBe(' new text');
+    });
+
+    it('strips a trailing partial <link/> tag fragment', () => {
+        const simplified = 'Before <link href="https://example.com/p"/> after';
+        const oldString = 'Before <link href=';
+        const pos = simplified.indexOf(oldString);
+
+        const result = stripPartialSimplifiedElements(oldString, 'Before replacement', simplified, pos);
+        expect(result).not.toBeNull();
+        expect(result!.strippedOld).toBe('Before ');
+    });
 });


### PR DESCRIPTION
- Updated the note processing utilities to support `<link/>` tags, allowing for self-linking anchors to be collapsed into a compact format.
- Modified `editNoteStrippers.ts` to recognize `<link/>` as a simplified element.
- Enhanced `editNoteValidation.ts` to include `link` in the `PartialSimplifiedTag` interface and updated related functions.
- Implemented logic in `noteCitationExpand.ts` to expand `<link/>` tokens back to raw anchors during HTML processing.
- Updated `noteHtmlSimplifier.ts` to replace self-linking anchors with `<link/>` tokens and ensure proper metadata handling.
- Added unit tests to verify the correct behavior of link handling, including collapsing, expanding, and stripping of `<link/>` tags.