### PR TITLE
refactor(ocr): remove primaryReason from OCR detection results

### DIFF
--- a/react/components/ui/buttons/DevToolsMenuButton.tsx
+++ b/react/components/ui/buttons/DevToolsMenuButton.tsx
@@ -556,7 +556,6 @@ const DevToolsMenuButton: React.FC<DevToolsMenuButtonProps> = ({
             console.log("=".repeat(60));
             
             console.group("[OCR Detection Test] Summary");
-            console.log(`Primary Reason: ${result.primaryReason}`);
             console.log(`Issue Ratio: ${(result.issueRatio * 100).toFixed(1)}% of sampled pages have issues`);
             console.log(`Pages Sampled: ${result.sampledPages} of ${result.totalPages} total`);
             console.groupEnd();

--- a/src/beaver-extract/DocumentAnalyzer.ts
+++ b/src/beaver-extract/DocumentAnalyzer.ts
@@ -706,68 +706,8 @@ export class DocumentAnalyzer {
             (issueRatio >= opts.confirmationThreshold &&
                 !documentHasUsableText);
 
-        // Determine primary reason. Gated on `needsOCR` so a document rescued
-        // by the sufficient-text guard reports `text_extraction_acceptable`
-        // rather than a stale per-page issue reason.
-        let primaryReason = "text_extraction_acceptable";
-        if (needsOCR && issueRatio >= opts.confirmationThreshold) {
-            // Find the most common issue
-            const sortedIssues = Object.entries(issueBreakdown)
-                .filter(([, count]) => count > 0)
-                .sort((a, b) => b[1] - a[1]);
-
-            if (sortedIssues.length > 0) {
-                const topIssue = sortedIssues[0][0] as OCRIssueReason;
-                // Check if this looks like a scanned document without OCR
-                // (large_image_coverage is now only flagged with text problems)
-                const hasLargeImages = issueBreakdown.large_image_coverage > 0;
-                const hasTextProblems = issueBreakdown.no_text_blocks > 0 ||
-                    issueBreakdown.no_body_text > 0 ||
-                    issueBreakdown.insufficient_text > 0;
-
-                if (hasLargeImages && hasTextProblems) {
-                    primaryReason = "scanned_without_ocr";
-                } else {
-                    switch (topIssue) {
-                        case "no_text_blocks":
-                        case "no_body_text":
-                        case "insufficient_text":
-                            primaryReason = "missing_text_content";
-                            break;
-                        case "large_image_coverage":
-                            // This shouldn't happen anymore since we combine with text issues
-                            primaryReason = "scanned_without_ocr";
-                            break;
-                        case "high_whitespace_ratio":
-                        case "high_newline_ratio":
-                        case "low_alphanumeric_ratio":
-                        case "invalid_characters":
-                        case "fragmented_text_lines":
-                            primaryReason = "poor_text_quality";
-                            break;
-                        case "bbox_overflow":
-                        case "excessive_line_overlap":
-                            primaryReason = "extraction_formatting_issues";
-                            break;
-                    }
-                }
-            } else {
-                primaryReason = "quality_threshold_exceeded";
-            }
-        } else if (needsOCR && documentNearEmpty) {
-            // The near-empty guard is the sole trigger — no per-page issue
-            // crossed the confirmation threshold. Derive the reason from
-            // whether the sampled pages carry images: image-backed pages with
-            // no usable text are un-OCR'd scans, otherwise the text layer is
-            // simply missing.
-            primaryReason = pageAnalyses.some((p) => p.hasImages)
-                ? "scanned_without_ocr"
-                : "missing_text_content";
-        }
-
         return {
             needsOCR,
-            primaryReason,
             issueRatio,
             issueBreakdown,
             pageAnalyses,

--- a/src/beaver-extract/cli/commands/fixture.ts
+++ b/src/beaver-extract/cli/commands/fixture.ts
@@ -196,7 +196,7 @@ function buildCaptureCommand(deps: CliDeps): Command {
                     const ocr = await deps.api.analyzeOCRNeeds(bytes);
                     if (ocr.needsOCR) {
                         throw new Error(
-                            `PDF needs OCR (${ocr.primaryReason}); use \`ocr-fixture capture\` for OCR-detection fixtures, or pass --allow-ocr to capture anyway`,
+                            `PDF needs OCR; use \`ocr-fixture capture\` for OCR-detection fixtures, or pass --allow-ocr to capture anyway`,
                         );
                     }
                 }

--- a/src/beaver-extract/cli/commands/ocrFixture.ts
+++ b/src/beaver-extract/cli/commands/ocrFixture.ts
@@ -237,7 +237,6 @@ function buildCaptureCommand(deps: CliDeps): Command {
                     sharedPdf: sharedPdfPath(root, sha),
                     sourcePdfLink,
                     needsOCR: snapshot.needsOCR,
-                    primaryReason: snapshot.primaryReason,
                     wrote,
                     capturedAt: fixture.capturedAt,
                     updatedAt: fixture.updatedAt,
@@ -440,7 +439,6 @@ function buildUpdateCommand(deps: CliDeps): Command {
                     wrote,
                     sourcePdfLink,
                     needsOCR: expected.needsOCR,
-                    primaryReason: expected.primaryReason,
                     capturedAt: previous.capturedAt,
                     updatedAt: wrote ? candidate.updatedAt : previous.updatedAt,
                 });

--- a/src/beaver-extract/cli/fixture/ocrFixtureSchema.ts
+++ b/src/beaver-extract/cli/fixture/ocrFixtureSchema.ts
@@ -67,7 +67,6 @@ export interface SnapshotPageOcr {
 
 export interface OcrSnapshot {
     needsOCR: boolean;
-    primaryReason: string;
     issueRatio: number;
     issueBreakdown: Record<OCRIssueReason, number>;
     sampledPages: number;
@@ -279,7 +278,6 @@ function validateTolerance(
 function validateSnapshot(value: unknown, source: string): OcrSnapshot {
     const v = expectObject(value, source);
     const needsOCR = expectBool(v.needsOCR, `${source}.needsOCR`);
-    const primaryReason = expectString(v.primaryReason, `${source}.primaryReason`);
     const issueRatio = expectFiniteNumber(v.issueRatio, `${source}.issueRatio`);
     const issueBreakdown = validateIssueBreakdown(
         v.issueBreakdown,
@@ -293,7 +291,6 @@ function validateSnapshot(value: unknown, source: string): OcrSnapshot {
     );
     return {
         needsOCR,
-        primaryReason,
         issueRatio,
         issueBreakdown,
         sampledPages,

--- a/src/beaver-extract/debug/ocrSnapshot.ts
+++ b/src/beaver-extract/debug/ocrSnapshot.ts
@@ -36,7 +36,6 @@ export type { OcrSnapshot, SnapshotPageOcr } from "../cli/fixture/ocrFixtureSche
 export function projectOcrSnapshot(result: OCRDetectionResult): OcrSnapshot {
     return {
         needsOCR: result.needsOCR,
-        primaryReason: result.primaryReason,
         issueRatio: round3(result.issueRatio),
         issueBreakdown: normalizeBreakdown(result.issueBreakdown),
         sampledPages: result.sampledPages,
@@ -163,7 +162,6 @@ function diffSnapshot(
     cap: number,
 ): void {
     diffScalar("expected.needsOCR", e.needsOCR, a.needsOCR, diffs);
-    diffScalar("expected.primaryReason", e.primaryReason, a.primaryReason, diffs);
 
     if (Math.abs(e.issueRatio - a.issueRatio) > opts.issueRatioAbs) {
         diffs.push({

--- a/src/beaver-extract/types.ts
+++ b/src/beaver-extract/types.ts
@@ -998,8 +998,6 @@ export interface PageOCRAnalysis {
 export interface OCRDetectionResult {
     /** Whether the document likely needs OCR */
     needsOCR: boolean;
-    /** Primary reason for the decision */
-    primaryReason: string;
     /** Ratio of pages with issues (0-1) */
     issueRatio: number;
     /** Breakdown by issue type */

--- a/src/beaver-extract/worker/ops.ts
+++ b/src/beaver-extract/worker/ops.ts
@@ -1267,7 +1267,7 @@ export async function opExtract(
             if (ocr.needsOCR) {
                 throw workerError(
                     ERROR_CODES.NO_TEXT_LAYER,
-                    `Document may require OCR: ${ocr.primaryReason} (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
+                    `Document may require OCR (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
                     { ocrAnalysis: ocr, pageLabels, pageCount },
                 );
             }
@@ -1372,7 +1372,7 @@ export async function opStructuredExtractWithDebug(
             if (ocr.needsOCR) {
                 throw workerError(
                     ERROR_CODES.NO_TEXT_LAYER,
-                    `Document may require OCR: ${ocr.primaryReason} (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
+                    `Document may require OCR (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
                     { ocrAnalysis: ocr, pageLabels, pageCount },
                 );
             }
@@ -1488,7 +1488,7 @@ export async function opAnalyzeLayout(
             if (ocr.needsOCR) {
                 throw workerError(
                     ERROR_CODES.NO_TEXT_LAYER,
-                    `Document may require OCR: ${ocr.primaryReason} (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
+                    `Document may require OCR (${Math.round(ocr.issueRatio * 100)}% of sampled pages have issues)`,
                     { ocrAnalysis: ocr, pageLabels, pageCount },
                 );
             }

--- a/tests/live/mupdfWorker.live.test.ts
+++ b/tests/live/mupdfWorker.live.test.ts
@@ -201,7 +201,6 @@ describe('MuPDF worker smoke — orchestration ops', () => {
             expect(res.error?.payload?.ocrAnalysis).toBeDefined();
             const ocr = res.error!.payload!.ocrAnalysis as any;
             expect(ocr.needsOCR).toBe(true);
-            expect(typeof ocr.primaryReason).toBe('string');
             expect(typeof res.error!.payload!.pageCount).toBe('number');
             expect(res.error!.payload!.pageLabels).toBeDefined();
         });
@@ -228,7 +227,6 @@ describe('MuPDF worker smoke — orchestration ops', () => {
 
             const result = res.result;
             expect(result.needsOCR).toBe(false);
-            expect(typeof result.primaryReason).toBe('string');
             expect(typeof result.issueRatio).toBe('number');
             expect(result.issueBreakdown).toBeDefined();
             expect(typeof result.sampledPages).toBe('number');
@@ -239,7 +237,6 @@ describe('MuPDF worker smoke — orchestration ops', () => {
             const res = await pdfAnalyzeOcr(NO_TEXT_PDF);
             expect(res.ok).toBe(true);
             expect(res.result.needsOCR).toBe(true);
-            expect(typeof res.result.primaryReason).toBe('string');
         });
     });
 

--- a/tests/unit/pdf/cliOcrFixtureCommand.test.ts
+++ b/tests/unit/pdf/cliOcrFixtureCommand.test.ts
@@ -44,7 +44,6 @@ const FAKE_PDF_SHA = createHash("sha256").update(FAKE_PDF_BYTES).digest("hex");
 function baseOcrResult(overrides: Partial<OCRDetectionResult> = {}): OCRDetectionResult {
     return {
         needsOCR: false,
-        primaryReason: "text_extraction_acceptable",
         issueRatio: 0,
         issueBreakdown: {
             no_text_blocks: 0,
@@ -262,7 +261,7 @@ describe("ocr-fixture capture", () => {
         expect(await runCli(baseArgs, makeDeps().deps)).toBe(0);
 
         const { deps: updateDeps, stdout } = makeDeps(
-            baseOcrResult({ needsOCR: true, primaryReason: "scanned_without_ocr" }),
+            baseOcrResult({ needsOCR: true }),
         );
         const code = await runCli([...baseArgs, "--update"], updateDeps);
         expect(code).toBe(0);
@@ -333,7 +332,7 @@ describe("ocr-fixture evaluate", () => {
     it("exits 1 with a structured envelope when the snapshot drifts", async () => {
         await captureBaseline();
         const { deps, stdout } = makeDeps(
-            baseOcrResult({ needsOCR: true, primaryReason: "scanned_without_ocr" }),
+            baseOcrResult({ needsOCR: true }),
         );
         const code = await runCli(
             ["ocr-fixture", "evaluate", "EVAL", "--root", tmpRoot, "--json"],

--- a/tests/unit/pdf/documentAnalyzerEmptyBody.test.ts
+++ b/tests/unit/pdf/documentAnalyzerEmptyBody.test.ts
@@ -100,7 +100,6 @@ describe("DocumentAnalyzer per-page no-body-text check", () => {
         expect(result.pageAnalyses[0].textLength).toBe(0);
         expect(result.pageAnalyses[0].issues).toContain("no_body_text");
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 
     it("flags a body-empty page even when its image is too small to count as a large image", () => {
@@ -144,7 +143,6 @@ describe("DocumentAnalyzer per-page no-body-text check", () => {
 
         expect(result.issueBreakdown.no_body_text).toBeGreaterThan(0);
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 
     it("does not route a healthy document to OCR for a single empty body page", () => {
@@ -158,6 +156,5 @@ describe("DocumentAnalyzer per-page no-body-text check", () => {
         const result = new DocumentAnalyzer(makeProvider(pages)).analyzeOCRNeeds();
 
         expect(result.needsOCR).toBe(false);
-        expect(result.primaryReason).toBe("text_extraction_acceptable");
     });
 });

--- a/tests/unit/pdf/documentAnalyzerFragmentedText.test.ts
+++ b/tests/unit/pdf/documentAnalyzerFragmentedText.test.ts
@@ -76,7 +76,6 @@ describe("DocumentAnalyzer fragmented-text check", () => {
         const result = new DocumentAnalyzer(makeProvider(pages)).analyzeOCRNeeds();
 
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("poor_text_quality");
         expect(result.issueBreakdown.fragmented_text_lines).toBeGreaterThan(0);
         expect(result.pageAnalyses[0].issues).toContain("fragmented_text_lines");
     });

--- a/tests/unit/pdf/documentAnalyzerMarginText.test.ts
+++ b/tests/unit/pdf/documentAnalyzerMarginText.test.ts
@@ -96,7 +96,6 @@ describe("DocumentAnalyzer margin-text exclusion", () => {
 
         expect(result.pageAnalyses[0].textLength).toBe(0);
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 
     it("excludes watermarks in every margin edge", () => {
@@ -127,7 +126,6 @@ describe("DocumentAnalyzer margin-text exclusion", () => {
 
         expect(result.pageAnalyses[0].textLength).toBe(nonWs(bodyText));
         expect(result.needsOCR).toBe(false);
-        expect(result.primaryReason).toBe("text_extraction_acceptable");
     });
 
     it("keeps a body line that bleeds into the side margins", () => {

--- a/tests/unit/pdf/documentAnalyzerNearEmpty.test.ts
+++ b/tests/unit/pdf/documentAnalyzerNearEmpty.test.ts
@@ -91,10 +91,9 @@ describe("DocumentAnalyzer document-level near-empty guard", () => {
 
         expect(result.issueRatio).toBe(0);
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 
-    it("reports scanned_without_ocr when the near-empty pages carry images", () => {
+    it("flags a near-empty document whose pages carry sub-threshold images", () => {
         // Images present but each below the large-image coverage threshold, so
         // the per-page `insufficient_text` + `large_image_coverage` checks do
         // not fire; only the document-level guard catches it.
@@ -105,7 +104,6 @@ describe("DocumentAnalyzer document-level near-empty guard", () => {
 
         expect(result.issueRatio).toBe(0);
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("scanned_without_ocr");
     });
 
     it("does not flag ordinary prose documents", () => {
@@ -113,7 +111,6 @@ describe("DocumentAnalyzer document-level near-empty guard", () => {
         const result = new DocumentAnalyzer(makeProvider(pages)).analyzeOCRNeeds();
 
         expect(result.needsOCR).toBe(false);
-        expect(result.primaryReason).toBe("text_extraction_acceptable");
     });
 
     it("does not flag a document whose mean text is just above the threshold", () => {
@@ -139,7 +136,6 @@ describe("DocumentAnalyzer document-level near-empty guard", () => {
         });
 
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 
     it("can be disabled with minMeanTextPerPage = 0", () => {
@@ -166,6 +162,5 @@ describe("DocumentAnalyzer document-level near-empty guard", () => {
         const result = new DocumentAnalyzer(makeProvider(pages)).analyzeOCRNeeds();
 
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("missing_text_content");
     });
 });

--- a/tests/unit/pdf/documentAnalyzerTextQuality.test.ts
+++ b/tests/unit/pdf/documentAnalyzerTextQuality.test.ts
@@ -98,7 +98,6 @@ describe("DocumentAnalyzer low_alphanumeric_ratio false-positive defenses", () =
 
         expect(result.issueBreakdown.low_alphanumeric_ratio).toBe(0);
         expect(result.needsOCR).toBe(false);
-        expect(result.primaryReason).toBe("text_extraction_acceptable");
     });
 
     it("does not flag symbol-dense pages that carry substantial real text", () => {
@@ -125,7 +124,6 @@ describe("DocumentAnalyzer low_alphanumeric_ratio false-positive defenses", () =
 
         expect(result.issueBreakdown.low_alphanumeric_ratio).toBe(2);
         expect(result.needsOCR).toBe(true);
-        expect(result.primaryReason).toBe("poor_text_quality");
     });
 
     it("re-flags symbol-dense pages once the volume guard is raised above their real-text count", () => {

--- a/tests/unit/pdf/ocrFixtureFile.test.ts
+++ b/tests/unit/pdf/ocrFixtureFile.test.ts
@@ -56,7 +56,6 @@ function syntheticFixture(): CapturedOcrFixture {
         tolerance: { issueRatioAbs: 0.02, textLengthAbs: 5 },
         expected: {
             needsOCR: false,
-            primaryReason: "text_extraction_acceptable",
             issueRatio: 0,
             issueBreakdown: {
                 no_text_blocks: 0,

--- a/tests/unit/pdf/ocrFixtureSchema.test.ts
+++ b/tests/unit/pdf/ocrFixtureSchema.test.ts
@@ -48,7 +48,6 @@ function wellFormed(): Record<string, unknown> {
         tolerance: { issueRatioAbs: 0.02, textLengthAbs: 5 },
         expected: {
             needsOCR: false,
-            primaryReason: "text_extraction_acceptable",
             issueRatio: 0,
             issueBreakdown: {
                 no_text_blocks: 0,

--- a/tests/unit/pdf/ocrSnapshotDiff.test.ts
+++ b/tests/unit/pdf/ocrSnapshotDiff.test.ts
@@ -33,7 +33,6 @@ const ALL_REASONS_ZERO = (): Record<OCRIssueReason, number> => ({
 function syntheticResult(overrides: Partial<OCRDetectionResult> = {}): OCRDetectionResult {
     return {
         needsOCR: false,
-        primaryReason: "text_extraction_acceptable",
         issueRatio: 0,
         issueBreakdown: ALL_REASONS_ZERO(),
         sampledPages: 6,


### PR DESCRIPTION
- Eliminated the `primaryReason` field from various OCR-related interfaces and functions to streamline the analysis process.
- Updated the `DocumentAnalyzer` and related components to reflect the removal of `primaryReason`, ensuring consistent handling of OCR detection results.
- Adjusted unit tests and fixtures to remove references to `primaryReason`, maintaining test integrity and accuracy.