### PR TITLE
feat: Enhance external-file citation handling in Zotero plugin

### DIFF
--- a/react/atoms/citations.ts
+++ b/react/atoms/citations.ts
@@ -110,6 +110,15 @@ export type PageLabelsByAttachmentId = Record<number, Record<number, string>>;
 export const pageLabelsByAttachmentIdAtom = atom<PageLabelsByAttachmentId>({});
 
 /**
+ * Absolute local paths for external-file citations, keyed by ext key. Populated
+ * only in the isolated render store during note export (see `renderToHTML`), and
+ * only for files that exist on this computer. Carries host-resolved data into the
+ * synchronous static render so the export layer can offer a clickable file link;
+ * empty for clients without locally stored external files.
+ */
+export const externalFileLocalPathsAtom = atom<Record<string, string>>({});
+
+/**
  * Reset citation markers and thread-scoped page-label render state. Called when
  * creating a new thread or loading an existing one.
  */

--- a/react/components/citations/Citation.tsx
+++ b/react/components/citations/Citation.tsx
@@ -7,7 +7,7 @@ import {
     getSymbolicLocation,
 } from '../../types/citations';
 import { externalReferenceMappingAtom } from '../../atoms/externalReferences';
-import { pageLabelsByAttachmentIdAtom } from '../../atoms/citations';
+import { pageLabelsByAttachmentIdAtom, externalFileLocalPathsAtom } from '../../atoms/citations';
 import { useCitationMarker } from '../../hooks/useCitationMarker';
 import { getHost } from '../../host';
 import { useCitationViewModel } from './useCitationViewModel';
@@ -93,6 +93,9 @@ const Citation: React.FC<CitationProps> = (props) => {
     // Read via the active store (the Provider's, isolated during note export) so
     // export locators use the labels renderToHTML preloads.
     const labelsByAttachmentId = useAtomValue(pageLabelsByAttachmentIdAtom);
+    // Host-resolved local paths for external files (note export only); empty
+    // otherwise. Read from the active store so it respects the isolated export store.
+    const externalFileLocalPaths = useAtomValue(externalFileLocalPathsAtom);
 
     // Get the citation format preference
     const authorYearFormat = (getHost().config?.citationFormat() ?? 'author-year') !== 'numeric';
@@ -163,11 +166,22 @@ const Citation: React.FC<CitationProps> = (props) => {
             return (<span>{`(${citation})`}</span>);
         }
 
-        // External-file citations export as plain filename text (no Zotero
-        // item to format, excluded from the bibliography). Preserve the cited
-        // page/section locator so the export is as specific as the chat view.
+        // External-file citations have no Zotero item to format and are excluded
+        // from the bibliography. Preserve the cited page/section locator so the
+        // export is as specific as the chat view. The host may upgrade this to a
+        // clickable link to the locally stored file; the plain-text form is the
+        // client-agnostic fallback when the host can't (e.g. no local copy).
         if (isExternalFile) {
             const locatorSuffix = pages.length > 0 ? `, p.${pagesDisplay}` : '';
+            const exportedFile = getHost().documentExport?.renderExternalFileCitation?.({
+                externalFileKey,
+                displayName: citation,
+                locatorSuffix,
+                localPathsByExtKey: externalFileLocalPaths,
+            });
+            if (exportedFile && exportedFile.kind === 'html') {
+                return <span dangerouslySetInnerHTML={{ __html: exportedFile.html }} />;
+            }
             return (<span>{`(${citation}${locatorSuffix})`}</span>);
         }
 

--- a/react/host/types.ts
+++ b/react/host/types.ts
@@ -143,6 +143,26 @@ export type CitationExportRender =
     | { kind: 'citation'; html: string; citationData: string };
 
 /**
+ * What the host needs to render an external-file citation (a user-attached,
+ * non-Zotero file) as host-native output for document export.
+ */
+export interface ExternalFileCitationExportRequest {
+    /** Ext key of the cited external file, or null when unknown. */
+    externalFileKey: string | null;
+    /** Display label (filename / cited name). */
+    displayName: string;
+    /** Cited page/section locator suffix (e.g. ", p.3"), already formatted; empty when none. */
+    locatorSuffix: string;
+    /**
+     * Absolute local paths for external files present on this computer, keyed by
+     * ext key. Passed in from the active render store (rather than read from a
+     * module-global store) so note export uses the isolated store that
+     * `renderToHTML` populates.
+     */
+    localPathsByExtKey: Record<string, string>;
+}
+
+/**
  * Render content into the host's native document format. For Zotero this is a
  * note (CSL-formatted HTML); other clients format
  * differently. Clients that don't support document export omit this slice.
@@ -150,6 +170,14 @@ export type CitationExportRender =
 export interface DocumentExportHost {
     /** Render a Zotero/library citation for export. Returns null when the item is unavailable. */
     renderCitation(request: CitationExportRequest): CitationExportRender | null;
+    /**
+     * Render an external-file citation as host-native output. Returns null when
+     * the host has no richer representation than plain text (e.g. no local copy
+     * of the file on this computer), in which case the render layer falls back to
+     * its client-agnostic plain-text form. Optional — clients without local
+     * external-file storage omit it.
+     */
+    renderExternalFileCitation?(request: ExternalFileCitationExportRequest): CitationExportRender | null;
 }
 
 /**

--- a/react/host/zotero/citationExport.ts
+++ b/react/host/zotero/citationExport.ts
@@ -3,7 +3,21 @@ import { getPageLocator } from '../../utils/citationGrammar';
 import { resolvePageLabelFromLabels, translatePageNumberToLabelFromLabels } from '../../utils/pageLabels';
 import { buildZoteroCitationLinkHTML, isLinkCitationItem } from '../../../src/utils/zoteroLinkCitation';
 import { logger } from '../../../src/utils/logger';
-import type { CitationExportRequest, CitationExportRender, DocumentExportHost } from '../types';
+import type {
+    CitationExportRequest,
+    CitationExportRender,
+    DocumentExportHost,
+    ExternalFileCitationExportRequest,
+} from '../types';
+
+/** Escape text for safe interpolation into an HTML attribute or text node. */
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
 
 /**
  * Render a Zotero/library citation as CSL-formatted HTML for note export.
@@ -54,7 +68,34 @@ function renderCitation(request: CitationExportRequest): CitationExportRender | 
     }
 }
 
+/**
+ * Render an external-file citation as a clickable link to the locally stored
+ * copy, for note export.
+ *
+ * Zotero-only enhancement: the note editor opens a `file://` link via the OS
+ * default handler. Returns null when there's no local copy on this computer
+ * (the file was attached on another machine), so the render layer falls back to
+ * plain text. The locator suffix is appended outside the link, mirroring the
+ * external-reference export form.
+ */
+function renderExternalFileCitation(request: ExternalFileCitationExportRequest): CitationExportRender | null {
+    const { externalFileKey, displayName, locatorSuffix, localPathsByExtKey } = request;
+    if (!externalFileKey) return null;
+    const path = localPathsByExtKey[externalFileKey];
+    if (!path) return null;
+    try {
+        const href = escapeHtml(Zotero.File.pathToFileURI(path));
+        const label = escapeHtml(displayName);
+        const suffix = escapeHtml(locatorSuffix);
+        return { kind: 'html', html: `(<a href="${href}">${label}</a>${suffix})` };
+    } catch (e) {
+        logger(`zoteroDocumentExport: failed to build file link for ext-${externalFileKey}: ${e}`);
+        return null;
+    }
+}
+
 /** Zotero implementation of {@link DocumentExportHost}. */
 export const zoteroDocumentExport: DocumentExportHost = {
     renderCitation,
+    renderExternalFileCitation,
 };

--- a/react/utils/citationRenderContext.ts
+++ b/react/utils/citationRenderContext.ts
@@ -140,20 +140,62 @@ export async function buildLocalCitationDataMapForContent(
 }
 
 /**
+ * Resolve absolute local paths for external-file citations in the content,
+ * limited to files that exist on this computer. Used by note export to offer a
+ * clickable file link; files attached on another machine resolve to no entry and
+ * fall back to plain text.
+ */
+export async function resolveExternalFileLocalPaths(
+    content: string,
+): Promise<Record<string, string>> {
+    const db = Zotero.Beaver?.db;
+    if (!db) return {};
+
+    const result: Record<string, string> = {};
+    const seen = new Set<string>();
+    const regex = new RegExp(CITATION_TAG_PATTERN.source, CITATION_TAG_PATTERN.flags);
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(content)) !== null) {
+        const normalized = normalizeCitationTag(parseRawCitationAttributes(match[1] || ''));
+        if (!normalized.ok || normalized.ref.kind !== 'external_file') continue;
+
+        const extKey = normalized.ref.ext_key;
+        if (seen.has(extKey)) continue;
+        seen.add(extKey);
+
+        try {
+            const record = await db.getExternalFileByKey(extKey);
+            const path = record?.storedPath ?? null;
+            if (path && (await IOUtils.exists(path).catch(() => false))) {
+                result[extKey] = path;
+            }
+        } catch {
+            // The file link is an export enhancement; unresolved external files
+            // fall back to plain-text citation rendering.
+        }
+    }
+
+    return result;
+}
+
+/**
  * Build the full static-render context for Zotero note export.
  */
 export async function prepareCitationRenderContext(
     content: string,
     contextData?: RenderContextData,
 ): Promise<RenderContextData | undefined> {
-    const [pageLabelsByAttachmentId, localCitationDataMap] = await Promise.all([
+    const [pageLabelsByAttachmentId, localCitationDataMap, externalFileLocalPaths] = await Promise.all([
         preloadPageLabelsForContent(content),
         buildLocalCitationDataMapForContent(content),
+        resolveExternalFileLocalPaths(content),
     ]);
 
     const hasPageLabels = Object.keys(pageLabelsByAttachmentId).length > 0;
     const hasLocalCitations = Object.keys(localCitationDataMap).length > 0;
-    if (!contextData && !hasPageLabels && !hasLocalCitations) return undefined;
+    const hasExternalFilePaths = Object.keys(externalFileLocalPaths).length > 0;
+    if (!contextData && !hasPageLabels && !hasLocalCitations && !hasExternalFilePaths) return undefined;
 
     const baseContext: RenderContextData = contextData ?? {
         citationDataMap: store.get(citationMapAtom),
@@ -170,6 +212,10 @@ export async function prepareCitationRenderContext(
         pageLabelsByAttachmentId: {
             ...(baseContext.pageLabelsByAttachmentId ?? {}),
             ...pageLabelsByAttachmentId,
+        },
+        externalFileLocalPaths: {
+            ...(baseContext.externalFileLocalPaths ?? {}),
+            ...externalFileLocalPaths,
         },
     };
 }

--- a/react/utils/citationRenderers.ts
+++ b/react/utils/citationRenderers.ts
@@ -4,7 +4,7 @@ import { Provider, createStore } from 'jotai';
 import { store } from '../store';
 import MarkdownRenderer from '../components/messages/MarkdownRenderer';
 import { Citation } from '../../src/services/CitationService';
-import { citationsAtom, citationByKeyAtom, citationKeyToMarkerAtom, pageLabelsByAttachmentIdAtom, type PageLabelsByAttachmentId } from '../atoms/citations';
+import { citationsAtom, citationByKeyAtom, citationKeyToMarkerAtom, pageLabelsByAttachmentIdAtom, externalFileLocalPathsAtom, type PageLabelsByAttachmentId } from '../atoms/citations';
 import { externalReferenceItemMappingAtom, externalReferenceMappingAtom } from '../atoms/externalReferences';
 import { Citation as BeaverCitation } from '../types/citations';
 import { CITATION_TAG_PATTERN } from '../utils/citationPreprocessing';
@@ -213,6 +213,8 @@ export interface RenderContextData {
     externalMapping?: Record<string, ZoteroItemReference | null>;
     externalReferencesMap?: Record<string, ExternalReference>;
     pageLabelsByAttachmentId?: PageLabelsByAttachmentId;
+    /** Absolute local paths for external-file citations present on this computer, keyed by ext key. */
+    externalFileLocalPaths?: Record<string, string>;
 }
 
 /**
@@ -288,6 +290,10 @@ export function renderToHTML(
 
         if (contextData.pageLabelsByAttachmentId) {
             renderStore.set(pageLabelsByAttachmentIdAtom, contextData.pageLabelsByAttachmentId);
+        }
+
+        if (contextData.externalFileLocalPaths) {
+            renderStore.set(externalFileLocalPathsAtom, contextData.externalFileLocalPaths);
         }
     }
 

--- a/tests/unit/utils/citationRenderContext.test.ts
+++ b/tests/unit/utils/citationRenderContext.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../../react/utils/pageLabels', () => ({
 import {
     buildLocalCitationDataMapForContent,
     prepareCitationRenderContext,
+    resolveExternalFileLocalPaths,
 } from '../../../react/utils/citationRenderContext';
 import {
     getCitationPreloadFilePath,
@@ -179,5 +180,46 @@ describe('citation render context', () => {
 
         expect(map).toEqual({});
         expect(cache.getResult).not.toHaveBeenCalled();
+    });
+
+    describe('resolveExternalFileLocalPaths', () => {
+        let db: any;
+
+        beforeEach(() => {
+            db = { getExternalFileByKey: vi.fn() };
+            (globalThis as any).Zotero.Beaver.db = db;
+        });
+
+        it('returns local paths for external files present on this computer', async () => {
+            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/beaver/external-files/AB12CD34.pdf' });
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const map = await resolveExternalFileLocalPaths('See <citation id="ext-ab12cd34"/>');
+
+            // Ext key normalized to uppercase before the DB lookup.
+            expect(db.getExternalFileByKey).toHaveBeenCalledWith('AB12CD34');
+            expect(map).toEqual({ AB12CD34: '/beaver/external-files/AB12CD34.pdf' });
+        });
+
+        it('omits external files with no local copy on this computer', async () => {
+            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/beaver/external-files/AB12CD34.pdf' });
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(false);
+
+            const map = await resolveExternalFileLocalPaths('See <citation id="ext-ab12cd34"/>');
+
+            expect(map).toEqual({});
+        });
+
+        it('dedupes repeated ext keys and ignores non-external-file citations', async () => {
+            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/p/AB12CD34.pdf' });
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const map = await resolveExternalFileLocalPaths(
+                'A <citation id="ext-ab12cd34"/> B <citation id="ext-ab12cd34" loc="page2"/> C <citation id="1-ATTACH01"/>'
+            );
+
+            expect(db.getExternalFileByKey).toHaveBeenCalledTimes(1);
+            expect(map).toEqual({ AB12CD34: '/p/AB12CD34.pdf' });
+        });
     });
 });


### PR DESCRIPTION
- Introduced `externalFileLocalPathsAtom` to store absolute local paths for external-file citations, enabling clickable links during note export for files present on the user's computer.
- Updated the `Citation` component to utilize the new atom for rendering external-file citations as clickable links when available.
- Implemented `resolveExternalFileLocalPaths` function to resolve local paths for external files, ensuring accurate representation in the citation context.
- Enhanced the `DocumentExportHost` interface with a new method for rendering external-file citations, improving integration with the export layer.

These changes improve the user experience by providing direct access to locally stored external files in citations, enhancing the functionality of the Zotero plugin.