### PR TITLE
Restructure background queue into pluggable lanes; add dormant docume…

### DIFF
--- a/react/hooks/httpHandlers/testBackgroundHandlers.ts
+++ b/react/hooks/httpHandlers/testBackgroundHandlers.ts
@@ -90,6 +90,7 @@ export async function handleTestBackgroundStatsHttpRequest(_request: unknown) {
     return {
         ok: true,
         queue,
+        lanes: Zotero.Beaver?.backgroundExtractor?.getLaneStatus() ?? {},
         workers: {
             hot: hot?.getStats() ?? null,
             background: background?.getStats() ?? null,

--- a/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
@@ -4,7 +4,7 @@
  * Resolves the request to a readable attachment, then dispatches by content
  * kind. Plain text is read directly (no document cache). PDFs and EPUBs use
  * shared extraction helpers. On a hot-path PDF timeout it enqueues a
- * `document_timeout_retry` background job; EPUB timeouts are returned directly.
+ * `document_extract` background job; EPUB timeouts are returned directly.
  */
 
 import { logger } from '../../utils/logger';
@@ -521,7 +521,7 @@ export async function handleZoteroDocumentRequest(
             };
             try {
                 await Zotero.Beaver?.db?.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: target.libraryId,
                     zoteroKey: target.zoteroKey,
                     contentKind: 'pdf',

--- a/src/services/backgroundExtractor.ts
+++ b/src/services/backgroundExtractor.ts
@@ -1,46 +1,30 @@
 /**
- * Background extraction processor.
+ * Background processing dispatcher.
  *
- * Owns the `"background"` MuPDFWorkerClient and drains the
- * `background_jobs` queue (see `src/services/database.ts`). Lives on the
- * esbuild side of the bundle split, reached via
+ * Owns the `"background"` MuPDFWorkerClient and drains registered lanes from
+ * the `background_jobs` queue. The exported class name is kept stable because
+ * addon lifecycle hooks and dev endpoints reach it through
  * `Zotero.Beaver?.backgroundExtractor`.
- *
- * Lifecycle: `start()` schedules ticks; `stop()` aborts any in-flight job
- * (via the external abort signal threaded into `extractAndCacheDocument`),
- * waits for the current iteration to settle, and disposes the background
- * worker. `processOnce()` exists as a test hook — it drives one iteration
- * synchronously and never schedules a follow-up tick.
- *
- * The processor is intentionally conservative:
- *  - Idles when no main window is open (worker constructor unreachable).
- *  - Optionally backs off when the hot worker has pending dispatches.
- *  - Recycles the background worker every `RECYCLE_AFTER_N` completed jobs
- *    to bound the documented MuPDF WASM heap leak.
- *
- * v1 has no UI subscriber for the emitted events; they exist for future
- * telemetry / indexing UI work and are dispatched on `__beaverEventBus`.
  */
 
 import {
     disposeMuPDFWorker,
     getExistingMuPDFWorkerClient,
 } from '../beaver-extract';
-import { extractAndCacheDocument } from './documentExtractionCore';
-import type { BackgroundJobRecord } from './database';
-import type { DocumentCache } from './documentCache';
-import { liveAttachmentContentKind } from './documentExtraction/attachmentResolution';
-
-/**
- * Local alias for the BeaverDB surface this processor actually uses.
- * Resolves to the structural type that `Zotero.Beaver?.db` exposes in the
- * global typings, which is a narrowed subset of the full `BeaverDB` class
- * exported by `database.ts`.
- */
-type QueueDB = NonNullable<typeof Zotero.Beaver.db>;
+import type {
+    BackgroundJobInput,
+    BackgroundJobRecord,
+    BackgroundJobType,
+} from './database';
+import { DocumentExtractExecutor } from './backgroundQueue/documentExtractExecutor';
+import type {
+    JobExecutionContext,
+    JobExecutor,
+    JobOutcome,
+    QueueDB,
+} from './backgroundQueue/jobExecutor';
+import { MuPDFLane } from './backgroundQueue/muPDFLane';
 import { logger } from '../utils/logger';
-// Import `safeIsInTrash` from the react-free helper module
-import { safeIsInTrash } from '../utils/zoteroItemUtils';
 import { createAbortController } from '../utils/abortController';
 import { getPref } from '../utils/prefs';
 import { getSystemIdleTimeMs, registerIdleObserver } from '../utils/idleService';
@@ -53,31 +37,11 @@ const MAX_ATTEMPTS = 3;
 const BACKOFF_MS = (attempt: number) =>
     Math.min(60_000 * Math.pow(2, attempt - 1), 30 * 60_000);
 
-/**
- * Defer the first claim by this much after `start()` so the loop does not
- * compete with main-window load and lets Zotero finish auto-sync.
- */
 const STARTUP_DELAY_MS = 30_000;
-/**
- * Threshold at which the user is considered idle. Jobs at or above
- * `LOW_PRIORITY_CEILING` only claim once `nsIUserIdleService.idleTime`
- * passes this mark.
- */
 const IDLE_THRESHOLD_MS = 30_000;
 const IDLE_THRESHOLD_SEC = 30;
-/**
- * Exclusive upper bound used by the idle-aware claim. Jobs enqueued with
- * `priority < LOW_PRIORITY_CEILING` (e.g. hot-path retries) run any time;
- * `priority >= LOW_PRIORITY_CEILING` only runs while the user is idle.
- */
 const LOW_PRIORITY_CEILING = 100;
 const PREF_ENABLED = 'backgroundExtractorEnabled';
-
-/**
- * Cooperative throttle: when the hot worker has pending dispatches, the
- * background processor skips its claim and waits a tick. Kept behind a
- * const flag so it's easy to disable if it starves the queue.
- */
 const COOPERATIVE_THROTTLE = true;
 
 export type ProcessOnceReason =
@@ -95,64 +59,73 @@ export interface ProcessOnceResult {
     reason?: ProcessOnceReason;
 }
 
+export type BackgroundLaneStatus = Partial<
+    Record<BackgroundJobType, { inFlight: number; capacity: number }>
+>;
+
+type LaneEntry = {
+    promise: Promise<void>;
+    abort: AbortController;
+};
+
+type ExecutorRegistration = {
+    executor: JobExecutor;
+    maxInFlight: number;
+};
+
 export class BackgroundExtractor {
     private stopRequested = false;
     private started = false;
     private currentTickId: ReturnType<typeof setTimeout> | undefined;
-    private inFlight: Promise<void> | null = null;
-    private inFlightAbortController: AbortController | null = null;
-    private inFlightJobId: number | null = null;
-    private jobsProcessedSinceRecycle = 0;
-    /**
-     * True while `tick()` is executing (from entry to its `finally`).
-     * Used to (1) bounce re-entrant ticks when two timers race, and
-     * (2) tell `notify()` to defer the wake to the active tick instead
-     * of scheduling a parallel one.
-     */
     private tickRunning = false;
-    /**
-     * Set by `notify()` when a tick is already running. The active
-     * tick's tail consumes it to reschedule at 0ms, overriding its
-     * default idle reschedule. Prevents the wake from being dropped
-     * when an enqueue races with a tick that's about to schedule
-     * `IDLE_INTERVAL_MS`.
-     */
     private pendingWake = false;
-    /**
-     * Latched once shutdown is observed (via `Zotero.__beaverShuttingDown`
-     * or `stop()` called during shutdown).
-     */
     private dbWritesPermanentlyDisabled = false;
-    /**
-     * Set to `false` while the user has flipped the kill-switch pref off.
-     * Re-checked at every claim; an in-flight job is not interrupted.
-     */
     private prefEnabled = true;
-    /**
-     * Mirrors `Zotero.Sync.Runner.syncInProgress`. Maintained via the
-     * `['sync']` notifier observer registered in `start()`. While true,
-     * the loop returns `sync_in_progress` from `processOnce()` and waits
-     * for the `'finish'` event to drain.
-     */
     private syncInProgress = false;
-    /**
-     * Earliest epoch-ms at which a tick may fire. Set in `start()` to
-     * `Date.now() + STARTUP_DELAY_MS`. Producers and observers that call
-     * `notify()` during the delay record their intent (no events are
-     * lost) but the scheduler clamps the actual wake to this floor.
-     */
     private startupDelayUntil = 0;
     private prefObserverSymbol: symbol | null = null;
     private syncObserverId: string | null = null;
     private unregisterIdleObserver: (() => void) | null = null;
     private workerRunning = false;
+    private readonly executors = new Map<BackgroundJobType, ExecutorRegistration>();
+    private readonly laneInFlight = new Map<BackgroundJobType, Map<number, LaneEntry>>();
+    private readonly muPDFLane = new MuPDFLane(RECYCLE_AFTER_N);
+
+    constructor() {
+        this.registerExecutor(new DocumentExtractExecutor(), { maxInFlight: 1 });
+    }
 
     /** Return the current background worker activity state for UI subscribers. */
     getStatus(): { running: boolean } {
         return { running: this.workerRunning };
     }
 
-    /** Schedule the first tick. Safe to call more than once (idempotent). */
+    /** Return capacity and in-flight counts for registered lanes. */
+    getLaneStatus(): BackgroundLaneStatus {
+        const status: BackgroundLaneStatus = {};
+        for (const [jobType, registration] of this.executors) {
+            status[jobType] = {
+                inFlight: this.laneInFlight.get(jobType)?.size ?? 0,
+                capacity: registration.maxInFlight,
+            };
+        }
+        return status;
+    }
+
+    /** Register a queue executor and activate its lane. */
+    registerExecutor(
+        executor: JobExecutor,
+        options: { maxInFlight: number },
+    ): void {
+        const maxInFlight = Math.max(1, Math.floor(options.maxInFlight));
+        this.executors.set(executor.jobType, { executor, maxInFlight });
+        if (!this.laneInFlight.has(executor.jobType)) {
+            this.laneInFlight.set(executor.jobType, new Map());
+        }
+        this.notify();
+    }
+
+    /** Schedule the first tick. Safe to call more than once. */
     start(): void {
         if (this.started) return;
         this.started = true;
@@ -161,15 +134,8 @@ export class BackgroundExtractor {
         this.pendingWake = false;
         this.startupDelayUntil = Date.now() + STARTUP_DELAY_MS;
 
-        // Pref: read initial value before registering the observer so a
-        // race-flip during startup is caught by the observer.
         this.prefEnabled = (getPref(PREF_ENABLED) as boolean | undefined) ?? true;
 
-        // Sync: register the observer FIRST, then read the current
-        // `syncInProgress` getter. This closes the race window — if a
-        // sync starts between read and register we would miss it; the
-        // other ordering catches an already-running sync via the getter
-        // and any subsequent transitions via the observer.
         try {
             const syncObs = {
                 notify: (
@@ -181,9 +147,6 @@ export class BackgroundExtractor {
                     if (event === 'start') {
                         this.syncInProgress = true;
                     } else if (event === 'finish' || event === 'stop') {
-                        // Zotero's sync runner emits 'finish' on normal
-                        // completion (syncRunner.js); 'stop' is accepted
-                        // defensively but is not part of the sync flow.
                         this.syncInProgress = false;
                         this.notify();
                     }
@@ -203,9 +166,6 @@ export class BackgroundExtractor {
             this.syncInProgress = false;
         }
 
-        // Pref observer: registered against the full global pref path so
-        // `getPref(PREF_ENABLED)`-equivalent flips trigger a wake. Going
-        // from disabled → enabled re-arms the loop via `notify()`.
         try {
             this.prefObserverSymbol = Zotero.Prefs.registerObserver(
                 'extensions.zotero.beaver.backgroundExtractorEnabled',
@@ -215,15 +175,12 @@ export class BackgroundExtractor {
                     this.prefEnabled = next;
                     if (!wasEnabled && next) this.notify();
                 },
-                true, // global pref path (not a branch-relative key)
+                true,
             );
         } catch (e) {
             logger(`BackgroundExtractor: registerObserver(pref) failed: ${e}`, 1);
         }
 
-        // Idle observer: push-based wake the moment the user crosses
-        // the 30s idle threshold, instead of waiting up to IDLE_INTERVAL_MS
-        // for the next poll tick.
         try {
             this.unregisterIdleObserver = registerIdleObserver(
                 { onIdle: () => this.notify() },
@@ -233,28 +190,19 @@ export class BackgroundExtractor {
             logger(`BackgroundExtractor: registerIdleObserver failed: ${e}`, 1);
         }
 
-        // First tick deferred by STARTUP_DELAY_MS so the loop does not
-        // compete with main-window load / auto-sync kickoff.
         this.scheduleTick(STARTUP_DELAY_MS);
     }
 
     /**
-     * Stop the processor:
-     *  1. Set `stopRequested` so the next tick exits early.
-     *  2. Cancel any pending tick timer.
-     *  3. Abort the in-flight job (if any) via its external abort signal.
-     *  4. Wait for the in-flight extraction to settle and release the job.
-     *  5. Dispose the background worker so its WASM heap is released.
+     * Stop the dispatcher, abort all active lanes, and release the background
+     * MuPDF worker.
      */
     async stop(): Promise<void> {
         this.stopRequested = true;
-        // Latch the per-instance disable NOW if global shutdown is in
-        // progress
         if (Zotero.__beaverShuttingDown === true) {
             this.dbWritesPermanentlyDisabled = true;
         }
-        // Tear down observers BEFORE the rest of shutdown so notifier or
-        // idle callbacks cannot fire into a half-disposed processor.
+
         if (this.prefObserverSymbol) {
             try {
                 Zotero.Prefs.unregisterObserver(this.prefObserverSymbol);
@@ -283,6 +231,7 @@ export class BackgroundExtractor {
             clearTimeout(this.currentTickId);
             this.currentTickId = undefined;
         }
+
         await this.abortAndAwaitInFlight();
         try {
             await disposeMuPDFWorker('background');
@@ -294,74 +243,44 @@ export class BackgroundExtractor {
         this.pendingWake = false;
     }
 
-    /**
-     * Abort any in-flight job and wait for it to settle
-     */
+    /** Abort every active lane and wait for all jobs to settle. */
     async abortInFlight(): Promise<void> {
         await this.abortAndAwaitInFlight();
-        this.setWorkerRunning(false);
+        this.setWorkerRunning(this.totalInFlight() > 0);
     }
 
     /**
-     * Producer-side wake. Producers call this after enqueueing a job
-     * they want picked up immediately, instead of waiting for the next
-     * idle tick (up to `IDLE_INTERVAL_MS`). Safe to call any time.
-     *
-     * Behavior:
-     *  - No-op when the processor is not started, has been stopped, or
-     *    is in (latched) shutdown.
-     *  - When a tick is already running (or a job is in flight from a
-     *    direct `processOnce()` call), records a `pendingWake` that the
-     *    active tick's tail consumes by rescheduling at 0ms instead of
-     *    `IDLE_INTERVAL_MS`. This avoids two failure modes:
-     *      (a) Scheduling a parallel 0ms tick that the active tick's
-     *          own reschedule later cancels — dropping the wake.
-     *      (b) Two ticks entering `processOnce()` concurrently and
-     *          claiming different rows, leaking the first job's abort
-     *          controller (only the latest `inFlight` is tracked).
-     *  - Otherwise (idle, between ticks): reschedules the next tick to
-     *    fire immediately.
-     *
-     * Bulk producers (e.g. library indexers) should call this **once
-     * after a batch commit**, not per row, to avoid thrashing the
-     * timer and to sidestep visibility races where the tick fires
-     * before the transaction commits.
+     * Producer-side wake. In-flight IO jobs do not block scheduling because
+     * free capacity in another lane may still be claimable.
      */
     notify(): void {
         if (!this.started || this.stopRequested) return;
         if (this.dbWritesPermanentlyDisabled) return;
         if (Zotero.__beaverShuttingDown === true) return;
-        if (this.tickRunning || this.inFlight) {
+        if (this.tickRunning) {
             this.pendingWake = true;
             return;
         }
-        // Clamp to the startup-delay floor so a producer enqueue or an
-        // observer callback during the first 30s cannot defeat the
-        // delay. Once we are past the floor this is a no-op (max(0, neg)).
         const delay = Math.max(0, this.startupDelayUntil - Date.now());
         this.scheduleTick(delay);
     }
 
     private async abortAndAwaitInFlight(): Promise<void> {
-        if (this.inFlightAbortController) {
-            try {
-                this.inFlightAbortController.abort();
-            } catch (_e) {
-                // best-effort
+        const promises: Promise<void>[] = [];
+        for (const lane of this.laneInFlight.values()) {
+            for (const entry of lane.values()) {
+                try {
+                    entry.abort.abort();
+                } catch {
+                    // best-effort
+                }
+                promises.push(entry.promise);
             }
         }
-        if (this.inFlight) {
-            try {
-                await this.inFlight;
-            } catch (_e) {
-                // logged by processJob
-            }
-        }
+        await Promise.allSettled(promises);
     }
 
-    /**
-     * Skip DB writes once global shutdown has been observed
-     */
+    /** Skip DB writes once global shutdown has been observed. */
     private shouldSkipDbWrites(): boolean {
         if (this.dbWritesPermanentlyDisabled) return true;
         if (Zotero.__beaverShuttingDown === true) {
@@ -378,35 +297,28 @@ export class BackgroundExtractor {
     }
 
     /**
-     * Drive a single iteration of the tick loop synchronously and return
-     * what happened. Used by tests and the dev `process-once` endpoint.
-     * Never schedules a follow-up tick.
+     * Drive one dispatcher pass. Tests can pass `awaitLaunchedJobs: true` to
+     * await IO lanes; the dev endpoint uses the default non-blocking behavior.
      */
     async processOnce(
-        options: { keepRunningAfterJob?: boolean } = {},
+        options: {
+            keepRunningAfterJob?: boolean;
+            awaitLaunchedJobs?: boolean;
+        } = {},
     ): Promise<ProcessOnceResult> {
         const inactive = (reason: ProcessOnceReason): ProcessOnceResult => {
-            this.setWorkerRunning(false);
+            if (this.totalInFlight() === 0) this.setWorkerRunning(false);
             return { processed: false, reason };
         };
 
         if (this.stopRequested) return inactive('stopped');
-
-        // Global shutdown check BEFORE claim
-        if (this.shouldSkipDbWrites()) {
-            return inactive('shutting_down');
-        }
-
-        if (!this.prefEnabled) {
-            return inactive('disabled');
-        }
+        if (this.shouldSkipDbWrites()) return inactive('shutting_down');
+        if (!this.prefEnabled) return inactive('disabled');
 
         const win = Zotero.getMainWindow?.() ?? null;
         if (!win) return inactive('no_window');
 
-        if (this.syncInProgress) {
-            return inactive('sync_in_progress');
-        }
+        if (this.syncInProgress) return inactive('sync_in_progress');
 
         if (COOPERATIVE_THROTTLE) {
             const hot = getExistingMuPDFWorkerClient('hot');
@@ -416,37 +328,220 @@ export class BackgroundExtractor {
         }
 
         const db = Zotero.Beaver?.db;
-        if (!db) return inactive('empty');
+        if (!db || this.executors.size === 0) return inactive('empty');
 
-        // Idle gate: when the user is actively using the OS we still
-        // run user-blocking work (priority < LOW_PRIORITY_CEILING, e.g.
-        // hot-path retries) but defer library-scale indexing.
         const idleMs = getSystemIdleTimeMs();
         const maxPriority =
             idleMs >= IDLE_THRESHOLD_MS ? undefined : LOW_PRIORITY_CEILING;
 
-        const record = await db.claimNextBackgroundJob(
-            Date.now(),
-            VISIBILITY_TIMEOUT_MS,
+        const launched = await this.dispatchPass({
+            db,
             maxPriority,
-        );
-        if (!record) return inactive('empty');
+            awaitLaunchedJobs: options.awaitLaunchedJobs === true,
+        });
 
-        logger(
-            `BackgroundExtractor: claimed job id=${record.id} type=${record.jobType} ${record.libraryId}-${record.zoteroKey} content_kind=${record.contentKind} payload_kind=${record.payloadKind} attempt=${record.attemptCount + 1}`,
-            3,
-        );
-        this.setWorkerRunning(true);
-        let completedJob = false;
-        try {
-            await this.runJob(record, db);
-            completedJob = true;
-        } finally {
-            if (!options.keepRunningAfterJob || !completedJob) {
-                this.setWorkerRunning(false);
-            }
+        if (launched === 0) return inactive('empty');
+        if (!options.keepRunningAfterJob && this.totalInFlight() === 0) {
+            this.setWorkerRunning(false);
         }
         return { processed: true, reason: 'job_done' };
+    }
+
+    private async dispatchPass(options: {
+        db: QueueDB;
+        maxPriority?: number;
+        awaitLaunchedJobs: boolean;
+    }): Promise<number> {
+        let launched = 0;
+        const waits: Promise<void>[] = [];
+        for (const [jobType, registration] of this.executors) {
+            const freeSlots = this.laneCapacityFree(jobType);
+            for (let slot = 0; slot < freeSlots; slot += 1) {
+                if (this.stopRequested) return launched;
+                const record = await options.db.claimNextBackgroundJob(
+                    Date.now(),
+                    VISIBILITY_TIMEOUT_MS,
+                    options.maxPriority,
+                    [jobType],
+                );
+                if (!record) break;
+                if (this.stopRequested) {
+                    if (!this.shouldSkipDbWrites()) {
+                        await options.db.releaseBackgroundJob(record.id, Date.now());
+                    }
+                    return launched;
+                }
+
+                logger(
+                    `BackgroundExtractor: claimed job id=${record.id} type=${record.jobType} ${record.libraryId}-${record.zoteroKey} content_kind=${record.contentKind} payload_kind=${record.payloadKind} attempt=${record.attemptCount + 1}`,
+                    3,
+                );
+                launched += 1;
+                const shouldAwait =
+                    jobType === 'document_extract' || options.awaitLaunchedJobs;
+                const promise = this.launchJob(
+                    record,
+                    registration.executor,
+                    jobType !== 'document_extract',
+                );
+                if (shouldAwait) {
+                    waits.push(promise);
+                }
+            }
+        }
+        if (waits.length > 0) {
+            await Promise.all(waits);
+        }
+        return launched;
+    }
+
+    private launchJob(
+        record: BackgroundJobRecord,
+        executor: JobExecutor,
+        notifyOnSettle: boolean,
+    ): Promise<void> {
+        const abort = createAbortController();
+        const lane = this.laneInFlight.get(record.jobType) ?? new Map<number, LaneEntry>();
+        this.laneInFlight.set(record.jobType, lane);
+        this.setWorkerRunning(true);
+
+        const promise = this.executeAndPersist(record, executor, abort.signal)
+            .catch((error) => {
+                const message = error instanceof Error ? error.message : String(error);
+                logger(`BackgroundExtractor: job id=${record.id} threw: ${message}`, 1);
+            })
+            .finally(() => {
+                lane.delete(record.id);
+                if (this.totalInFlight() === 0 && !this.tickRunning) {
+                    this.setWorkerRunning(false);
+                }
+                if (notifyOnSettle) {
+                    this.notify();
+                }
+            });
+        lane.set(record.id, { promise, abort });
+        return promise;
+    }
+
+    private async executeAndPersist(
+        record: BackgroundJobRecord,
+        executor: JobExecutor,
+        externalAbortSignal: AbortSignal,
+    ): Promise<void> {
+        dispatchBackgroundEvent('background-job:start', { id: record.id, record });
+        const db = Zotero.Beaver?.db;
+        if (!db) return;
+
+        const ctx: JobExecutionContext = {
+            db,
+            runOnMuPDFWorker: (fn) => this.muPDFLane.run(fn),
+            externalAbortSignal,
+            shouldSkipDbWrites: () => this.shouldSkipDbWrites(),
+            enqueue: async (input: BackgroundJobInput) => {
+                await db.enqueueBackgroundJob(input);
+                this.notify();
+            },
+        };
+
+        let outcome: JobOutcome;
+        try {
+            outcome = await executor.execute(record, ctx);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            outcome = { kind: 'retry', error: `unexpected: ${message}` };
+        }
+
+        await this.persistOutcome(record, executor, outcome, db);
+    }
+
+    private async persistOutcome(
+        record: BackgroundJobRecord,
+        executor: JobExecutor,
+        outcome: JobOutcome,
+        db: QueueDB,
+    ): Promise<void> {
+        if (this.shouldSkipDbWrites()) return;
+
+        switch (outcome.kind) {
+            case 'complete':
+                await db.completeBackgroundJob(record.id);
+                logger(
+                    `BackgroundExtractor: job id=${record.id} done (${outcome.reason})`,
+                    3,
+                );
+                dispatchBackgroundEvent('background-job:done', {
+                    id: record.id,
+                    reason: outcome.reason,
+                });
+                return;
+            case 'release':
+                await db.releaseBackgroundJob(record.id, Date.now());
+                logger(
+                    `BackgroundExtractor: job id=${record.id} released (${outcome.reason})`,
+                    3,
+                );
+                dispatchBackgroundEvent('background-job:done', {
+                    id: record.id,
+                    reason: outcome.reason,
+                });
+                return;
+            case 'retry':
+                await this.recordRetryFailure(record, executor, outcome, db);
+                return;
+            case 'failPermanent':
+                await db.recordDocumentProcessingFailure(outcome.failure);
+                await db.completeBackgroundJob(record.id);
+                dispatchBackgroundEvent('background-job:done', {
+                    id: record.id,
+                    reason:
+                        outcome.reason
+                        ?? (
+                            outcome.failure.terminalCode
+                                ? `terminal:${outcome.failure.terminalCode}`
+                                : 'terminal'
+                        ),
+                });
+                return;
+        }
+    }
+
+    private async recordRetryFailure(
+        record: BackgroundJobRecord,
+        executor: JobExecutor,
+        outcome: Extract<JobOutcome, { kind: 'retry' }>,
+        db: QueueDB,
+    ): Promise<void> {
+        const result = await db.failBackgroundJob(record.id, outcome.error, {
+            maxAttempts: MAX_ATTEMPTS,
+            backoffMs: BACKOFF_MS,
+            now: Date.now(),
+        });
+        if (result.dead) {
+            const failure = executor.describeFailure?.(record, outcome.error) ?? null;
+            if (failure) {
+                await db.recordDocumentProcessingFailure(failure);
+            }
+            logger(
+                `BackgroundExtractor: job id=${record.id} dead-lettered: ${outcome.error}`,
+                1,
+            );
+            dispatchBackgroundEvent('background-job:dead', {
+                id: record.id,
+                error: outcome.error,
+                reason: outcome.reason,
+            });
+            return;
+        }
+
+        logger(
+            `BackgroundExtractor: job id=${record.id} failed, retry scheduled: ${outcome.error}`,
+            2,
+        );
+        dispatchBackgroundEvent('background-job:failed', {
+            id: record.id,
+            error: outcome.error,
+            reason: outcome.reason,
+        });
     }
 
     private scheduleTick(delayMs: number): void {
@@ -456,8 +551,6 @@ export class BackgroundExtractor {
             this.currentTickId = undefined;
             this.tick().catch((e) => {
                 logger(`BackgroundExtractor: tick threw: ${e}`, 1);
-                // Always reschedule even after a failure so a transient
-                // throw does not park the loop forever.
                 this.scheduleTick(IDLE_INTERVAL_MS);
             });
         }, delayMs);
@@ -467,284 +560,44 @@ export class BackgroundExtractor {
 
     private async tick(): Promise<void> {
         if (this.stopRequested) return;
-        // Re-entrancy guard: if a stale timer races with the active
-        // tick (e.g. two timers queued before the first set
-        // `currentTickId = undefined`), bail out cleanly so two ticks
-        // do not run `processOnce()` in parallel.
         if (this.tickRunning) return;
         this.tickRunning = true;
         try {
             const result = await this.processOnce({ keepRunningAfterJob: true });
-
             if (this.stopRequested) return;
 
-            if (result.processed) {
-                this.jobsProcessedSinceRecycle += 1;
-                if (this.jobsProcessedSinceRecycle >= RECYCLE_AFTER_N) {
-                    try {
-                        await disposeMuPDFWorker('background');
-                    } catch (e) {
-                        logger(
-                            `BackgroundExtractor: recycle disposeMuPDFWorker failed: ${e}`,
-                            1,
-                        );
-                    }
-                    this.jobsProcessedSinceRecycle = 0;
-                }
-            }
-
-            // Always honor a wake recorded during this tick — even when
-            // the queue was empty this iteration — so a notify() racing
-            // a pre-claim await is not swallowed by the default idle
-            // reschedule. JS is single-threaded between these two lines,
-            // so no notify() can sneak in and have its flag cleared.
             const wakeNow = this.pendingWake;
             this.pendingWake = false;
             if (wakeNow) {
-                // Same startup-delay clamp as `notify()` — a wake recorded
-                // during the first 30s must not bypass the delay floor.
                 const delay = Math.max(0, this.startupDelayUntil - Date.now());
                 this.scheduleTick(delay);
                 return;
             }
+
             this.scheduleTick(
-                result.processed ? BUSY_INTERVAL_MS : IDLE_INTERVAL_MS,
+                result.processed || this.totalInFlight() > 0
+                    ? BUSY_INTERVAL_MS
+                    : IDLE_INTERVAL_MS,
             );
         } finally {
             this.tickRunning = false;
         }
     }
 
-    private async runJob(record: BackgroundJobRecord, db: QueueDB): Promise<void> {
-        // Use the shim from `../utils/abortController`: in the chrome JS
-        // realm where this runs, `AbortController` is not a top-level
-        // global — it lives on the main window instead.
-        const abortController = createAbortController();
-        this.inFlightAbortController = abortController;
-        this.inFlightJobId = record.id;
-        const completion = this.processJob(record, db, abortController.signal);
-        this.inFlight = completion;
-        try {
-            await completion;
-        } finally {
-            this.inFlight = null;
-            this.inFlightAbortController = null;
-            this.inFlightJobId = null;
-        }
+    private laneCapacityFree(jobType: BackgroundJobType): number {
+        const registration = this.executors.get(jobType);
+        if (!registration) return 0;
+        const inFlight = this.laneInFlight.get(jobType)?.size ?? 0;
+        return Math.max(0, registration.maxInFlight - inFlight);
     }
 
-    private async processJob(
-        record: BackgroundJobRecord,
-        db: QueueDB,
-        externalAbortSignal: AbortSignal,
-    ): Promise<void> {
-        dispatchBackgroundEvent('background-job:start', { id: record.id, record });
-
-        let item: Zotero.Item | null = null;
-        try {
-            const lookup = await Zotero.Items.getByLibraryAndKeyAsync(
-                record.libraryId,
-                record.zoteroKey,
-            );
-            item = lookup || null;
-        } catch (e) {
-            logger(
-                `BackgroundExtractor: getByLibraryAndKeyAsync failed for ${record.libraryId}-${record.zoteroKey}: ${e}`,
-                1,
-            );
+    private totalInFlight(): number {
+        let total = 0;
+        for (const lane of this.laneInFlight.values()) {
+            total += lane.size;
         }
-        if (!item || safeIsInTrash(item) === true) {
-            if (this.shouldSkipDbWrites()) return;
-            await db.completeBackgroundJob(record.id);
-            dispatchBackgroundEvent('background-job:done', {
-                id: record.id,
-                reason: !item ? 'item_missing' : 'in_trash',
-            });
-            return;
-        }
-
-        const liveKind = liveAttachmentContentKind(item);
-        const canResolvePdfFromParent =
-            liveKind === null
-            && record.contentKind === 'pdf'
-            && typeof item.isRegularItem === 'function'
-            && item.isRegularItem();
-        if (
-            (liveKind === null && !canResolvePdfFromParent)
-            || (liveKind !== null && liveKind !== record.contentKind)
-        ) {
-            if (this.shouldSkipDbWrites()) return;
-            await db.completeBackgroundJob(record.id);
-            dispatchBackgroundEvent('background-job:done', {
-                id: record.id,
-                reason: 'content_kind_stale',
-            });
-            return;
-        }
-
-        if (record.contentKind !== 'pdf') {
-            await this.handleUnsupportedContentKind(record, db);
-            return;
-        }
-
-        const payload = record.payload;
-        if (!payload || payload.content_kind !== 'pdf') {
-            if (this.shouldSkipDbWrites()) return;
-            await db.completeBackgroundJob(record.id);
-            dispatchBackgroundEvent('background-job:done', {
-                id: record.id,
-                reason: 'missing_payload',
-            });
-            return;
-        }
-
-        let result;
-        try {
-            result = await extractAndCacheDocument({
-                libraryId: record.libraryId,
-                zoteroKey: record.zoteroKey,
-                mode: record.payloadKind,
-                maxPages: payload.maxPages,
-                maxFileSizeMB: payload.maxFileSizeMB,
-                timeoutSeconds: payload.timeoutSeconds,
-                workerName: 'background',
-                externalAbortSignal,
-            });
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            await this.recordFailure(db, record.id, `unexpected: ${message}`);
-            dispatchBackgroundEvent('background-job:failed', {
-                id: record.id,
-                error: message,
-            });
-            return;
-        }
-
-        await this.classifyAndPersist(result, record, db);
+        return total;
     }
-
-    private async handleUnsupportedContentKind(
-        record: BackgroundJobRecord,
-        db: QueueDB,
-    ): Promise<void> {
-        logger(
-            `BackgroundExtractor: job id=${record.id} done (unsupported_content_kind:${record.contentKind})`,
-            2,
-        );
-        if (this.shouldSkipDbWrites()) return;
-        await db.completeBackgroundJob(record.id);
-        dispatchBackgroundEvent('background-job:done', {
-            id: record.id,
-            reason: 'unsupported_content_kind',
-        });
-    }
-
-    private async classifyAndPersist(
-        result: Awaited<ReturnType<typeof extractAndCacheDocument>>,
-        record: BackgroundJobRecord,
-        db: QueueDB,
-    ): Promise<void> {
-        if (this.shouldSkipDbWrites()) return;
-        switch (result.kind) {
-            case 'ok':
-                await db.completeBackgroundJob(record.id);
-                logger(
-                    `BackgroundExtractor: job id=${record.id} done (ok) pages=${result.totalPages}`,
-                    3,
-                );
-                dispatchBackgroundEvent('background-job:done', {
-                    id: record.id,
-                    reason: 'ok',
-                });
-                return;
-            case 'external_abort':
-                await db.releaseBackgroundJob(record.id, Date.now());
-                logger(
-                    `BackgroundExtractor: job id=${record.id} released (external_abort)`,
-                    3,
-                );
-                dispatchBackgroundEvent('background-job:done', {
-                    id: record.id,
-                    reason: 'external_abort',
-                });
-                return;
-            case 'cached_error':
-                await db.completeBackgroundJob(record.id);
-                logger(
-                    `BackgroundExtractor: job id=${record.id} done (cached_error:${result.code})`,
-                    3,
-                );
-                dispatchBackgroundEvent('background-job:done', {
-                    id: record.id,
-                    reason: `cached_error:${result.code}`,
-                });
-                return;
-            case 'timeout':
-                await this.recordFailure(
-                    db,
-                    record.id,
-                    `timeout:${result.phase}`,
-                );
-                dispatchBackgroundEvent('background-job:failed', {
-                    id: record.id,
-                    error: `timeout:${result.phase}`,
-                });
-                return;
-            case 'response_error': {
-                if (isTransientResponseError(result.code)) {
-                    await this.recordFailure(
-                        db,
-                        record.id,
-                        `${result.code}: ${result.message}`,
-                    );
-                    dispatchBackgroundEvent('background-job:failed', {
-                        id: record.id,
-                        error: result.code,
-                    });
-                    return;
-                }
-                await db.completeBackgroundJob(record.id);
-                logger(
-                    `BackgroundExtractor: job id=${record.id} done (terminal:${result.code})`,
-                    3,
-                );
-                dispatchBackgroundEvent('background-job:done', {
-                    id: record.id,
-                    reason: `terminal:${result.code}`,
-                });
-                return;
-            }
-        }
-    }
-
-    private async recordFailure(
-        db: QueueDB,
-        id: number,
-        error: string,
-    ): Promise<void> {
-        if (this.shouldSkipDbWrites()) return;
-        const outcome = await db.failBackgroundJob(id, error, {
-            maxAttempts: MAX_ATTEMPTS,
-            backoffMs: BACKOFF_MS,
-            now: Date.now(),
-        });
-        if (outcome.dead) {
-            logger(
-                `BackgroundExtractor: job id=${id} dead-lettered: ${error}`,
-                1,
-            );
-            dispatchBackgroundEvent('background-job:dead', { id, error });
-        } else {
-            logger(
-                `BackgroundExtractor: job id=${id} failed, retry scheduled: ${error}`,
-                2,
-            );
-        }
-    }
-}
-
-function isTransientResponseError(code: string): boolean {
-    return code === 'download_failed' || code === 'extraction_failed';
 }
 
 function dispatchBackgroundEvent(name: string, detail: unknown): void {
@@ -759,8 +612,3 @@ function dispatchBackgroundEvent(name: string, detail: unknown): void {
         logger(`background event dispatch failed for ${name}: ${e}`, 2);
     }
 }
-
-// Suppress unused warning — the DocumentCache module is required only at
-// runtime by the extraction core; this `import type` keeps the dependency
-// visible in tooling.
-export type _DocumentCacheUsed = DocumentCache;

--- a/src/services/backgroundQueue/documentExtractExecutor.ts
+++ b/src/services/backgroundQueue/documentExtractExecutor.ts
@@ -1,0 +1,141 @@
+import { extractAndCacheDocument } from '../documentExtractionCore';
+import { liveAttachmentContentKind } from '../documentExtraction/attachmentResolution';
+import type { BackgroundJobRecord } from '../database';
+import { logger } from '../../utils/logger';
+import { safeIsInTrash } from '../../utils/zoteroItemUtils';
+import type {
+    JobExecutionContext,
+    JobExecutor,
+    JobOutcome,
+} from './jobExecutor';
+
+/**
+ * Executes local document extraction jobs on the serialized MuPDF lane.
+ */
+export class DocumentExtractExecutor implements JobExecutor {
+    readonly jobType = 'document_extract' as const;
+
+    async execute(
+        record: BackgroundJobRecord,
+        ctx: JobExecutionContext,
+    ): Promise<JobOutcome> {
+        return ctx.runOnMuPDFWorker(() => this.executeOnWorker(record, ctx));
+    }
+
+    describeFailure(): null {
+        return null;
+    }
+
+    private async executeOnWorker(
+        record: BackgroundJobRecord,
+        ctx: JobExecutionContext,
+    ): Promise<JobOutcome> {
+        let item: Zotero.Item | null = null;
+        try {
+            const lookup = await Zotero.Items.getByLibraryAndKeyAsync(
+                record.libraryId,
+                record.zoteroKey,
+            );
+            item = lookup || null;
+        } catch (e) {
+            logger(
+                `DocumentExtractExecutor: getByLibraryAndKeyAsync failed for ${record.libraryId}-${record.zoteroKey}: ${e}`,
+                1,
+            );
+        }
+
+        if (!item || safeIsInTrash(item) === true) {
+            return {
+                kind: 'complete',
+                reason: !item ? 'item_missing' : 'in_trash',
+            };
+        }
+
+        const liveKind = liveAttachmentContentKind(item);
+        const canResolvePdfFromParent =
+            liveKind === null
+            && record.contentKind === 'pdf'
+            && typeof item.isRegularItem === 'function'
+            && item.isRegularItem();
+        if (
+            (liveKind === null && !canResolvePdfFromParent)
+            || (liveKind !== null && liveKind !== record.contentKind)
+        ) {
+            return { kind: 'complete', reason: 'content_kind_stale' };
+        }
+
+        if (record.contentKind !== 'pdf') {
+            logger(
+                `DocumentExtractExecutor: job id=${record.id} done (unsupported_content_kind:${record.contentKind})`,
+                2,
+            );
+            return { kind: 'complete', reason: 'unsupported_content_kind' };
+        }
+
+        const payload = record.payload;
+        if (!payload || payload.content_kind !== 'pdf') {
+            return { kind: 'complete', reason: 'missing_payload' };
+        }
+
+        let result: Awaited<ReturnType<typeof extractAndCacheDocument>>;
+        try {
+            result = await extractAndCacheDocument({
+                libraryId: record.libraryId,
+                zoteroKey: record.zoteroKey,
+                mode: record.payloadKind,
+                maxPages: payload.maxPages,
+                maxFileSizeMB: payload.maxFileSizeMB,
+                timeoutSeconds: payload.timeoutSeconds,
+                workerName: 'background',
+                externalAbortSignal: ctx.externalAbortSignal,
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return { kind: 'retry', error: `unexpected: ${message}` };
+        }
+
+        return this.toOutcome(result);
+    }
+
+    private toOutcome(
+        result: Awaited<ReturnType<typeof extractAndCacheDocument>>,
+    ): JobOutcome {
+        switch (result.kind) {
+            case 'ok':
+                logger(
+                    `DocumentExtractExecutor: extraction done (ok) pages=${result.totalPages}`,
+                    3,
+                );
+                return { kind: 'complete', reason: 'ok' };
+            case 'external_abort':
+                return { kind: 'release', reason: 'external_abort' };
+            case 'cached_error':
+                return {
+                    kind: 'complete',
+                    reason: `cached_error:${result.code}`,
+                };
+            case 'timeout':
+                return {
+                    kind: 'retry',
+                    error: `timeout:${result.phase}`,
+                    reason: `timeout:${result.phase}`,
+                };
+            case 'response_error':
+                if (isTransientResponseError(result.code)) {
+                    return {
+                        kind: 'retry',
+                        error: `${result.code}: ${result.message}`,
+                        reason: result.code,
+                    };
+                }
+                return {
+                    kind: 'complete',
+                    reason: `terminal:${result.code}`,
+                };
+        }
+    }
+}
+
+function isTransientResponseError(code: string): boolean {
+    return code === 'download_failed' || code === 'extraction_failed';
+}

--- a/src/services/backgroundQueue/jobExecutor.ts
+++ b/src/services/backgroundQueue/jobExecutor.ts
@@ -1,0 +1,38 @@
+import type {
+    BackgroundJobInput,
+    BackgroundJobRecord,
+    BackgroundJobType,
+    DocumentProcessingFailureInput,
+} from '../database';
+
+export type QueueDB = NonNullable<typeof Zotero.Beaver.db>;
+
+export interface JobExecutionContext {
+    db: QueueDB;
+    runOnMuPDFWorker<T>(fn: () => Promise<T>): Promise<T>;
+    externalAbortSignal: AbortSignal;
+    shouldSkipDbWrites(): boolean;
+    enqueue(input: BackgroundJobInput): Promise<void>;
+}
+
+export type JobOutcome =
+    | { kind: 'complete'; reason: string }
+    | { kind: 'release'; reason: string }
+    | { kind: 'retry'; error: string; reason?: string }
+    | {
+        kind: 'failPermanent';
+        failure: DocumentProcessingFailureInput;
+        reason?: string;
+    };
+
+export interface JobExecutor {
+    readonly jobType: BackgroundJobType;
+    execute(
+        record: BackgroundJobRecord,
+        ctx: JobExecutionContext,
+    ): Promise<JobOutcome>;
+    describeFailure?(
+        record: BackgroundJobRecord,
+        error: string,
+    ): DocumentProcessingFailureInput | null;
+}

--- a/src/services/backgroundQueue/muPDFLane.ts
+++ b/src/services/backgroundQueue/muPDFLane.ts
@@ -1,0 +1,43 @@
+import { disposeMuPDFWorker } from '../../beaver-extract';
+import { logger } from '../../utils/logger';
+
+/**
+ * Serializes background MuPDF worker use and recycles the worker after a
+ * fixed number of completed worker operations.
+ */
+export class MuPDFLane {
+    private tail: Promise<void> = Promise.resolve();
+    private completedSinceRecycle = 0;
+
+    constructor(private readonly recycleAfter: number) {}
+
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+        const previous = this.tail.catch(() => undefined);
+        let release!: () => void;
+        this.tail = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+
+        await previous;
+        try {
+            return await fn();
+        } finally {
+            try {
+                await this.afterWorkerOperation();
+            } finally {
+                release();
+            }
+        }
+    }
+
+    private async afterWorkerOperation(): Promise<void> {
+        this.completedSinceRecycle += 1;
+        if (this.completedSinceRecycle < this.recycleAfter) return;
+        try {
+            await disposeMuPDFWorker('background');
+        } catch (e) {
+            logger(`MuPDFLane: recycle disposeMuPDFWorker failed: ${e}`, 1);
+        }
+        this.completedSinceRecycle = 0;
+    }
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -176,8 +176,11 @@ export function isExternalFileContentKind(value: string): value is ExternalFileC
     return EXTERNAL_FILE_CONTENT_KINDS.has(value);
 }
 
-/** Background extraction job kinds. */
-export type BackgroundJobType = 'document_timeout_retry';
+/** Background processing job kinds. */
+export type BackgroundJobType =
+    | 'document_extract'
+    | 'document_ocr'
+    | 'fulltext_upsert';
 
 /**
  * Single row in `background_jobs`. Timestamps are epoch milliseconds so
@@ -217,6 +220,36 @@ export interface BackgroundJobEnqueueResult {
     id: number;
 }
 
+export type DocumentProcessingTask = 'ocr' | 'fulltext_upsert';
+
+export interface DocumentProcessingFailureInput {
+    /** Content identity, usually the attachment hash/MD5. */
+    fileHash: string;
+    task: DocumentProcessingTask;
+    /** OCR engine id; empty for tasks without engine versioning. */
+    engineVersion?: string;
+    /** Attribution only; suppression is keyed by file hash, task, and engine. */
+    sourceType?: string;
+    /** Attribution only, e.g. "<libraryId>-<zoteroKey>" for Zotero. */
+    sourceKey?: string;
+    error: string;
+    /** Permanent failure marker; null/undefined records a transient backoff. */
+    terminalCode?: string | null;
+}
+
+export interface DocumentProcessingFailureRecord {
+    fileHash: string;
+    task: DocumentProcessingTask;
+    engineVersion: string;
+    sourceType: string | null;
+    sourceKey: string | null;
+    failureCount: number;
+    terminalCode: string | null;
+    lastError: string | null;
+    lastAttempt: string;
+    nextRetryAfter: string;
+}
+
 export interface BackgroundQueueStats {
     pending: number;
     available: number;
@@ -243,6 +276,10 @@ export const MAX_EMBEDDING_FAILURES = 5;
  * So delays are: 1h, 2h, 4h, 8h, 16h
  */
 export const EMBEDDING_RETRY_BASE_DELAY_MS = 60 * 60 * 1000; // 1 hour
+
+export const MAX_OCR_FAILURES = 5;
+export const MAX_UPSERT_FAILURES = 5;
+export const DOC_PROCESSING_RETRY_BASE_DELAY_MS = 60 * 60 * 1000; // 1 hour
 
 
 /* 
@@ -406,6 +443,22 @@ export class BeaverDB {
             );
         `);
 
+        await this.conn.queryAsync(`
+            CREATE TABLE IF NOT EXISTS document_processing_failures (
+                file_hash        TEXT NOT NULL,
+                task             TEXT NOT NULL,
+                engine_version   TEXT NOT NULL DEFAULT '',
+                source_type      TEXT,
+                source_key       TEXT,
+                failure_count    INTEGER NOT NULL DEFAULT 1,
+                terminal_code    TEXT,
+                last_error       TEXT,
+                last_attempt     TEXT NOT NULL DEFAULT (datetime('now')),
+                next_retry_after TEXT NOT NULL,
+                UNIQUE(file_hash, task, engine_version)
+            );
+        `);
+
         // DB indexes
         await this.conn.queryAsync(`
             CREATE INDEX IF NOT EXISTS idx_messages_user_thread
@@ -465,6 +518,10 @@ export class BeaverDB {
         await this.conn.queryAsync(`
             CREATE INDEX IF NOT EXISTS idx_failed_embeddings_retry
             ON failed_embeddings(next_retry_after);
+        `);
+
+        await this.conn.queryAsync(`
+            DROP INDEX IF EXISTS idx_doc_proc_failures_retry;
         `);
 
         await this.conn.queryAsync(`DROP TABLE IF EXISTS attachment_file_cache`);
@@ -618,6 +675,11 @@ export class BeaverDB {
                 last_error      TEXT,
                 UNIQUE(job_type, library_id, zotero_key, payload_kind)
             );
+        `);
+
+        await this.conn.queryAsync(`
+            DELETE FROM background_jobs
+            WHERE job_type NOT IN ('document_extract','document_ocr','fulltext_upsert')
         `);
 
         await this.conn.queryAsync(`
@@ -1466,6 +1528,38 @@ export class BeaverDB {
         return nextRetry.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
     }
 
+    private static formatSqlDate(date = new Date()): string {
+        return date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+    }
+
+    private static maxDocumentProcessingFailures(task: DocumentProcessingTask): number {
+        return task === 'ocr' ? MAX_OCR_FAILURES : MAX_UPSERT_FAILURES;
+    }
+
+    private static calculateDocumentProcessingRetryTime(
+        failureCount: number,
+    ): string {
+        const delayMs = DOC_PROCESSING_RETRY_BASE_DELAY_MS * Math.pow(2, failureCount - 1);
+        return BeaverDB.formatSqlDate(new Date(Date.now() + delayMs));
+    }
+
+    private static rowToDocumentProcessingFailureRecord(
+        row: any,
+    ): DocumentProcessingFailureRecord {
+        return {
+            fileHash: row.getResultByIndex(0),
+            task: row.getResultByIndex(1) as DocumentProcessingTask,
+            engineVersion: row.getResultByIndex(2),
+            sourceType: row.getResultByIndex(3) ?? null,
+            sourceKey: row.getResultByIndex(4) ?? null,
+            failureCount: row.getResultByIndex(5),
+            terminalCode: row.getResultByIndex(6) ?? null,
+            lastError: row.getResultByIndex(7) ?? null,
+            lastAttempt: row.getResultByIndex(8),
+            nextRetryAfter: row.getResultByIndex(9),
+        };
+    }
+
     /**
      * Record a failed embedding attempt for an item.
      * If the item already has failures, increments the counter.
@@ -1723,6 +1817,124 @@ export class BeaverDB {
 
         const rows = await this.conn.queryAsync(sql, params);
         return rows[0]?.count || 0;
+    }
+
+    /**
+     * Record a content-keyed document processing failure.
+     */
+    public async recordDocumentProcessingFailure(
+        input: DocumentProcessingFailureInput,
+    ): Promise<void> {
+        const engineVersion = input.engineVersion ?? '';
+        const now = BeaverDB.formatSqlDate();
+        const nextRetryAfter = BeaverDB.calculateDocumentProcessingRetryTime(1);
+        const terminalCode = input.terminalCode ?? null;
+
+        await this.conn.queryAsync(
+            `INSERT INTO document_processing_failures (
+                file_hash, task, engine_version, source_type, source_key,
+                failure_count, terminal_code, last_error, last_attempt,
+                next_retry_after
+             ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+             ON CONFLICT(file_hash, task, engine_version) DO UPDATE SET
+                 source_type = excluded.source_type,
+                 source_key = excluded.source_key,
+                 failure_count = document_processing_failures.failure_count + 1,
+                 terminal_code = COALESCE(
+                     excluded.terminal_code,
+                     document_processing_failures.terminal_code
+                 ),
+                 last_error = excluded.last_error,
+                 last_attempt = excluded.last_attempt,
+                 next_retry_after = datetime(
+                     strftime('%s', excluded.last_attempt)
+                     + (? * (1 << document_processing_failures.failure_count)),
+                     'unixepoch'
+                 )`,
+            [
+                input.fileHash,
+                input.task,
+                engineVersion,
+                input.sourceType ?? null,
+                input.sourceKey ?? null,
+                terminalCode,
+                input.error,
+                now,
+                nextRetryAfter,
+                DOC_PROCESSING_RETRY_BASE_DELAY_MS / 1000,
+            ],
+        );
+    }
+
+    /**
+     * Read a document processing failure by its suppression identity.
+     */
+    public async getDocumentProcessingFailure(
+        fileHash: string,
+        task: DocumentProcessingTask,
+        engineVersion = '',
+    ): Promise<DocumentProcessingFailureRecord | null> {
+        const records: DocumentProcessingFailureRecord[] = [];
+        await this.conn.queryAsync(
+            `SELECT file_hash, task, engine_version, source_type, source_key,
+                    failure_count, terminal_code, last_error, last_attempt,
+                    next_retry_after
+             FROM document_processing_failures
+             WHERE file_hash = ? AND task = ? AND engine_version = ?
+             LIMIT 1`,
+            [fileHash, task, engineVersion],
+            {
+                onRow: (row: any) => {
+                    records.push(BeaverDB.rowToDocumentProcessingFailureRecord(row));
+                },
+            },
+        );
+        return records[0] ?? null;
+    }
+
+    /**
+     * Return true when a failure row suppresses future processing attempts.
+     */
+    public async isDocumentProcessingPermanentlyFailed(
+        fileHash: string,
+        task: DocumentProcessingTask,
+        engineVersion = '',
+    ): Promise<boolean> {
+        const record = await this.getDocumentProcessingFailure(fileHash, task, engineVersion);
+        if (!record) return false;
+        return (
+            record.terminalCode !== null
+            || record.failureCount >= BeaverDB.maxDocumentProcessingFailures(task)
+        );
+    }
+
+    /**
+     * Return true when a transient failure row can be retried at `now`.
+     */
+    public async isDocumentProcessingReadyForRetry(
+        fileHash: string,
+        task: DocumentProcessingTask,
+        engineVersion = '',
+        now = BeaverDB.formatSqlDate(),
+    ): Promise<boolean> {
+        const record = await this.getDocumentProcessingFailure(fileHash, task, engineVersion);
+        if (!record || record.terminalCode !== null) return false;
+        return record.nextRetryAfter <= now;
+    }
+
+    /**
+     * Clear a document processing failure after a successful processing pass.
+     */
+    public async clearDocumentProcessingFailure(
+        fileHash: string,
+        task: DocumentProcessingTask,
+        engineVersion = '',
+    ): Promise<void> {
+        await this.conn.queryAsync(
+            `DELETE FROM document_processing_failures
+             WHERE file_hash = ? AND task = ? AND engine_version = ?`,
+            [fileHash, task, engineVersion],
+        );
     }
 
     // =============================================
@@ -2680,6 +2892,7 @@ export class BeaverDB {
         now: number,
         visibilityTimeoutMs: number,
         maxPriority?: number,
+        jobTypes?: BackgroundJobType[],
     ): Promise<BackgroundJobRecord | null> {
         const params: unknown[] = [now];
         let priorityClause = '';
@@ -2687,10 +2900,15 @@ export class BeaverDB {
             priorityClause = ' AND priority < ?';
             params.push(maxPriority);
         }
+        let jobTypesClause = '';
+        if (jobTypes && jobTypes.length > 0) {
+            jobTypesClause = ` AND job_type IN (${jobTypes.map(() => '?').join(',')})`;
+            params.push(...jobTypes);
+        }
         const candidates = await this.selectBackgroundJobs(
             `SELECT ${BACKGROUND_JOB_COLUMNS}
              FROM background_jobs
-             WHERE available_at <= ?${priorityClause}
+             WHERE available_at <= ?${priorityClause}${jobTypesClause}
              ORDER BY priority ASC, available_at ASC
              LIMIT 1`,
             params,

--- a/tests/helpers/cacheInspector.ts
+++ b/tests/helpers/cacheInspector.ts
@@ -832,7 +832,10 @@ export async function syncPause(
 // `useHttpEndpoints.ts` from `react/hooks/httpHandlers/testBackgroundHandlers.ts`.
 // ---------------------------------------------------------------------------
 
-export type BackgroundJobType = 'document_timeout_retry';
+export type BackgroundJobType =
+    | 'document_extract'
+    | 'document_ocr'
+    | 'fulltext_upsert';
 export type BackgroundJobPayloadKind = 'structured' | 'markdown';
 
 export interface PdfBackgroundJobPayload {
@@ -900,6 +903,7 @@ export interface BackgroundEnqueueResponse {
 export interface BackgroundStatsResponse {
     ok: boolean;
     queue?: BackgroundQueueStats;
+    lanes?: Partial<Record<BackgroundJobType, { inFlight: number; capacity: number }>>;
     workers?: {
         hot: WorkerStatsSnapshot | null;
         background: WorkerStatsSnapshot | null;

--- a/tests/live/backgroundContentKind.live.test.ts
+++ b/tests/live/backgroundContentKind.live.test.ts
@@ -82,7 +82,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: pdfPayload(7),
         });
         const peek = await backgroundPeek();
@@ -104,7 +104,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: pdfPayload(null),
         });
         const peek = await backgroundPeek();
@@ -122,7 +122,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             // Column says pdf, JSON discriminator says epub → rejected on read.
             payload: { content_kind: 'epub' } as unknown as BackgroundJobPayload,
         });
@@ -138,7 +138,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             // Missing maxFileSizeMB and timeoutSeconds.
             payload: { content_kind: 'pdf', maxPages: null } as unknown as BackgroundJobPayload,
         });
@@ -152,7 +152,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: {
                 content_kind: 'pdf',
                 maxPages: 'all',
@@ -170,7 +170,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'epub',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'epub' },
         });
         const peek = await backgroundPeek();
@@ -184,7 +184,7 @@ describe('background queue — payload parsing on read', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: null,
         });
         const peek = await backgroundPeek();
@@ -205,7 +205,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: pdfPayload(5),
         });
@@ -219,7 +219,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'epub',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: { content_kind: 'epub' },
         });
@@ -241,7 +241,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: pdfPayload(5),
         });
@@ -250,7 +250,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 200, // numerically lower priority
             payload: pdfPayload(99),
         });
@@ -267,7 +267,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: pdfPayload(5),
         });
@@ -276,7 +276,7 @@ describe('background queue — enqueue merge across content_kind change', () => 
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 10, // numerically higher priority
             payload: pdfPayload(99),
         });
@@ -302,7 +302,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'epub',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'epub' },
         });
 
@@ -329,7 +329,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: IMAGE.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: pdfPayload(null),
         });
 
@@ -353,7 +353,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: NON_PDF.zotero_key,
             content_kind: 'epub',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'epub' },
         });
 
@@ -377,7 +377,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: null,
         });
 
@@ -401,7 +401,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'epub' } as unknown as BackgroundJobPayload,
         });
 
@@ -431,7 +431,7 @@ describe('background queue — content_kind dispatch in processOnce', () => {
             zotero_key: PARENT_ITEM.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: pdfPayload(null),
         });
 

--- a/tests/live/backgroundExtractor.live.test.ts
+++ b/tests/live/backgroundExtractor.live.test.ts
@@ -11,7 +11,7 @@
  *   - processOnce drains a healthy PDF and emits `job_done`
  *   - processOnce on missing items / encrypted / no-text-layer PDFs all
  *     complete the job (no retry)
- *   - hot-path timeout enqueues a `document_timeout_retry` background job that
+ *   - hot-path timeout enqueues a `document_extract` background job that
  *     the processor then drains
  *
  * Prerequisites (per tests/README.md):
@@ -73,7 +73,7 @@ describe('background queue — enqueue endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 50,
             payload: {
                 content_kind: 'pdf',
@@ -102,7 +102,7 @@ describe('background queue — enqueue endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -113,7 +113,7 @@ describe('background queue — enqueue endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 100,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -127,7 +127,7 @@ describe('background queue — enqueue endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         const markdown = await backgroundEnqueue({
@@ -135,7 +135,7 @@ describe('background queue — enqueue endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'markdown',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         expect(structured.enqueued).toBe(true);
@@ -161,7 +161,7 @@ describe('background queue — peek endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 73,
             payload: {
                 content_kind: 'pdf',
@@ -177,7 +177,7 @@ describe('background queue — peek endpoint', () => {
         expect(res.jobs?.length).toBe(1);
         const job = res.jobs![0];
         expect(job.id).toBe(enqueued.id);
-        expect(job.jobType).toBe('document_timeout_retry');
+        expect(job.jobType).toBe('document_extract');
         expect(job.libraryId).toBe(SMALL_PDF.library_id);
         expect(job.zoteroKey).toBe(SMALL_PDF.zotero_key);
         expect(job.payloadKind).toBe('structured');
@@ -200,7 +200,7 @@ describe('background queue — peek endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
@@ -208,7 +208,7 @@ describe('background queue — peek endpoint', () => {
             zotero_key: NORMAL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -226,7 +226,7 @@ describe('background queue — peek endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 200,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -235,7 +235,7 @@ describe('background queue — peek endpoint', () => {
             zotero_key: NORMAL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 10,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -272,14 +272,14 @@ describe('background queue — stats endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         const res = await backgroundStats();
         expect(res.queue!.pending).toBe(1);
         expect(res.queue!.available).toBe(1);
         expect(res.queue!.deferred).toBe(0);
-        expect(res.queue!.byJobType.document_timeout_retry).toBe(1);
+        expect(res.queue!.byJobType.document_extract).toBe(1);
     });
 
     it('exposes per-slot MuPDF worker snapshots (`hot`, `background`)', async () => {
@@ -312,7 +312,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -336,7 +336,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: MISSING_KEY_ZOTERO,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -355,7 +355,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: ENCRYPTED_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -374,7 +374,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: NO_TEXT_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -392,7 +392,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
@@ -400,7 +400,7 @@ describe('background queue — processOnce endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'markdown',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -429,7 +429,7 @@ describe('background queue — enqueue defaults', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         const peek = await backgroundPeek();
@@ -443,7 +443,7 @@ describe('background queue — enqueue defaults', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         const peekNull = await backgroundPeek();
@@ -456,7 +456,7 @@ describe('background queue — enqueue defaults', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             item_id: 42,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -470,7 +470,7 @@ describe('background queue — enqueue defaults', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: null,
         });
         expect(res.enqueued).toBe(true);
@@ -497,7 +497,7 @@ describe('background queue — clear endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
@@ -505,7 +505,7 @@ describe('background queue — clear endpoint', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'markdown',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
@@ -537,18 +537,18 @@ describe('background queue — terminal response_error completes without retry',
             zotero_key: NON_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
-            notify: true,
         });
 
-        // The `notify()` wake races our explicit `processOnce` HTTP call.
         // The live attachment is an EPUB, so its content kind no longer
         // matches the job's recorded `content_kind: 'pdf'` and the job is
-        // dropped (completed without retry) before extraction. That path is
-        // fast, so the queue may already be empty before we call
-        // processOnce. Poll for drain instead.
-        const finalQueue = await waitForQueueDrain({ timeoutMs: 15_000 });
+        // dropped (completed without retry) before extraction.
+        const res = await backgroundProcessOnce();
+        expect(res.processed).toBe(true);
+        expect(res.reason).toBe('job_done');
+
+        const finalQueue = (await backgroundStats()).queue!;
         expect(finalQueue.pending).toBe(0);
         expect(finalQueue.dead).toBe(0);
 
@@ -571,7 +571,7 @@ describe('background queue — group library extraction', () => {
             zotero_key: GROUP_LIB_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
             notify: true,
         });
@@ -599,19 +599,18 @@ describe('background queue — worker slot isolation', () => {
     });
 
     it('spawns a separate background MuPDF worker after a successful drain', async () => {
+        await invalidateCache(SMALL_PDF.library_id, SMALL_PDF.zotero_key);
         await backgroundEnqueue({
             library_id: SMALL_PDF.library_id,
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
-            notify: true,
         });
 
-        // Wait until the auto-tick drains the row. We just need the
-        // background worker to have been instantiated.
-        await waitForQueueDrain({ timeoutMs: 120_000, pollMs: 250 });
+        const res = await backgroundProcessOnce();
+        expect(res.processed).toBe(true);
 
         const stats = await backgroundStats();
         expect(stats.workers).toBeDefined();
@@ -639,7 +638,7 @@ describe('background queue — stats.byJobType across payload kinds', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
@@ -647,13 +646,13 @@ describe('background queue — stats.byJobType across payload kinds', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'markdown',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const stats = await backgroundStats();
         expect(stats.queue!.pending).toBe(2);
-        expect(stats.queue!.byJobType.document_timeout_retry).toBe(2);
+        expect(stats.queue!.byJobType.document_extract).toBe(2);
     });
 });
 
@@ -670,7 +669,7 @@ describe('background queue — peek edge cases', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         const peek = await backgroundPeek({ limit: 0 });
@@ -684,7 +683,7 @@ describe('background queue — peek edge cases', () => {
             zotero_key: SMALL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 5,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -693,7 +692,7 @@ describe('background queue — peek edge cases', () => {
             zotero_key: NORMAL_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 50,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -702,7 +701,7 @@ describe('background queue — peek edge cases', () => {
             zotero_key: NO_TEXT_PDF.zotero_key,
             content_kind: 'pdf',
             payload_kind: 'structured',
-            job_type: 'document_timeout_retry',
+            job_type: 'document_extract',
             priority: 500,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
@@ -722,7 +721,7 @@ describe('background queue — hot-path timeout integration', () => {
         await backgroundClear();
     });
 
-    it('enqueues a document_timeout_retry job when the hot-path timeout fires', async () => {
+    it('enqueues a document_extract job when the hot-path timeout fires', async () => {
         // Force a hot-path timeout with the smallest positive deadline.
         // Cold cache + a non-trivial extraction makes the timeout likely.
         await invalidateCache(NORMAL_PDF.library_id, NORMAL_PDF.zotero_key);
@@ -740,7 +739,7 @@ describe('background queue — hot-path timeout integration', () => {
             const peek = await backgroundPeek();
             expect(peek.jobs?.length).toBe(1);
             const job = peek.jobs![0];
-            expect(job.jobType).toBe('document_timeout_retry');
+            expect(job.jobType).toBe('document_extract');
             expect(job.libraryId).toBe(NORMAL_PDF.library_id);
             expect(job.zoteroKey).toBe(NORMAL_PDF.zotero_key);
             expect(job.payloadKind).toBe('structured');

--- a/tests/unit/services/backgroundExtractor.test.ts
+++ b/tests/unit/services/backgroundExtractor.test.ts
@@ -4,6 +4,11 @@ import {
     BeaverDB,
     BackgroundJobPayload,
 } from '../../../src/services/database';
+import type {
+    JobExecutionContext,
+    JobExecutor,
+    JobOutcome,
+} from '../../../src/services/backgroundQueue/jobExecutor';
 import { MockDBConnection } from '../../mocks/mockDBConnection';
 
 const mockState = {
@@ -18,6 +23,9 @@ const mockState = {
 vi.mock('../../../src/services/documentExtractionCore', () => ({
     extractAndCacheDocument: vi.fn(async (args: any) => {
         mockState.extractCalls.push(args);
+        if (typeof mockState.nextResult === 'function') {
+            return await mockState.nextResult(args);
+        }
         if (mockState.nextResult instanceof Promise) {
             return await mockState.nextResult;
         }
@@ -61,6 +69,28 @@ function payload(overrides: Partial<BackgroundJobPayload> = {}): BackgroundJobPa
         maxFileSizeMB: 50,
         timeoutSeconds: 120,
         ...overrides,
+    };
+}
+
+function okResult(zoteroKey = 'AAAAAAAA') {
+    return {
+        kind: 'ok',
+        cached: false,
+        result: { mode: 'structured', document: { pageCount: 1, pages: [] } },
+        totalPages: 1,
+        resolvedAttachment: { libraryId: 1, zoteroKey },
+        contentType: 'application/pdf',
+    };
+}
+
+function ocrExecutor(
+    execute: JobExecutor['execute'],
+    describeFailure?: JobExecutor['describeFailure'],
+): JobExecutor {
+    return {
+        jobType: 'document_ocr',
+        execute,
+        describeFailure,
     };
 }
 
@@ -140,7 +170,7 @@ describe('BackgroundExtractor', () => {
     it('returns hot_busy when the hot worker has pending dispatches', async () => {
         mockState.hotPendingCount = 1;
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -162,7 +192,7 @@ describe('BackgroundExtractor', () => {
         const { safeIsInTrash } = await import('../../../src/utils/zoteroItemUtils');
         (safeIsInTrash as any).mockReturnValueOnce(true);
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -191,7 +221,7 @@ describe('BackgroundExtractor', () => {
         };
         (Zotero as any).Items.getByLibraryAndKeyAsync = vi.fn(async () => item);
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -228,7 +258,7 @@ describe('BackgroundExtractor', () => {
         };
         (Zotero as any).Items.getByLibraryAndKeyAsync = vi.fn(async () => item);
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'epub',
@@ -257,7 +287,7 @@ describe('BackgroundExtractor', () => {
 
     it('completes PDF jobs with null payload as missing_payload', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -293,7 +323,7 @@ describe('BackgroundExtractor', () => {
         };
         (Zotero as any).Items.getByLibraryAndKeyAsync = vi.fn(async () => item);
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -327,7 +357,7 @@ describe('BackgroundExtractor', () => {
 
     it('removes the row on kind=ok and routes through the background worker', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -363,7 +393,7 @@ describe('BackgroundExtractor', () => {
         ['no_text_layer'],
     ])('terminal cached_error %s completes the job', async (code: string) => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -398,7 +428,7 @@ describe('BackgroundExtractor', () => {
         ['pdf_too_complex'],
     ])('terminal response_error %s completes the job without retry', async (code: string) => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -428,7 +458,7 @@ describe('BackgroundExtractor', () => {
         ['extraction_failed'],
     ])('transient response_error %s bumps attempt_count and slides availability out', async (code: string) => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -456,7 +486,7 @@ describe('BackgroundExtractor', () => {
 
     it('timeout kind counts as a transient failure', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -484,7 +514,7 @@ describe('BackgroundExtractor', () => {
 
     it('external_abort releases the job without bumping attempt_count', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -511,7 +541,7 @@ describe('BackgroundExtractor', () => {
 
     it('dispatches background-job:start on the main window event bus when present', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -544,7 +574,7 @@ describe('BackgroundExtractor', () => {
 
     it('emits worker status only on processing transitions while auto-draining', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -553,7 +583,7 @@ describe('BackgroundExtractor', () => {
             now: 0,
         });
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'BBBBBBBB',
             contentKind: 'pdf',
@@ -600,7 +630,7 @@ describe('BackgroundExtractor', () => {
 
     it('event dispatch is window-guarded — no throw when no main window', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -629,7 +659,7 @@ describe('BackgroundExtractor', () => {
 
     it('stop() aborts an in-flight job and disposes the background worker', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -679,10 +709,51 @@ describe('BackgroundExtractor', () => {
         expect(mockState.disposeCalls).toContain('background');
     });
 
+    it('stop() prevents a job claimed mid-pass from launching after worker disposal', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'AAAAAAAA',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        const originalClaim = db.claimNextBackgroundJob.bind(db);
+        let releaseClaim!: () => void;
+        vi.spyOn(db, 'claimNextBackgroundJob').mockImplementation(
+            async (...args: Parameters<typeof db.claimNextBackgroundJob>) => {
+                await new Promise<void>((resolve) => {
+                    releaseClaim = resolve;
+                });
+                return await originalClaim(...args);
+            },
+        );
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        const processOncePromise = proc.processOnce();
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const stopPromise = proc.stop();
+        await stopPromise;
+
+        releaseClaim();
+        const result = await processOncePromise;
+
+        expect(result).toEqual({ processed: false, reason: 'empty' });
+        expect(mockState.extractCalls).toHaveLength(0);
+        expect(mockState.disposeCalls).toContain('background');
+        const rows = await db.peekBackgroundJobs();
+        expect(rows).toHaveLength(1);
+        expect(rows[0].attemptCount).toBe(0);
+        expect(rows[0].lastError).toBeNull();
+    });
+
     it('abortInFlight() releases the in-flight job without stopping the processor or disposing the worker', async () => {
         // Models the window-unload-but-app-alive case
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -747,9 +818,300 @@ describe('BackgroundExtractor', () => {
         expect(mockState.disposeCalls).toHaveLength(0);
     });
 
+    it('launches extract and OCR lanes concurrently while awaiting the extract lane', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'AAAAAAAA',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        await db.enqueueBackgroundJob({
+            jobType: 'document_ocr',
+            libraryId: 1,
+            zoteroKey: 'BBBBBBBB',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+
+        let resolveExtract!: (value: any) => void;
+        let resolveOcr!: (value: JobOutcome) => void;
+        const events: string[] = [];
+        mockState.nextResult = new Promise<any>((resolve) => {
+            resolveExtract = resolve;
+        });
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        proc.registerExecutor(
+            ocrExecutor(async () => {
+                events.push('ocr:start');
+                return await new Promise<JobOutcome>((resolve) => {
+                    resolveOcr = resolve;
+                });
+            }),
+            { maxInFlight: 1 },
+        );
+
+        const processOncePromise = proc.processOnce();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(mockState.extractCalls).toHaveLength(1);
+        expect(events).toEqual(['ocr:start']);
+        expect(proc.getLaneStatus()).toMatchObject({
+            document_extract: { inFlight: 1, capacity: 1 },
+            document_ocr: { inFlight: 1, capacity: 1 },
+        });
+
+        resolveExtract!(okResult('AAAAAAAA'));
+        await processOncePromise;
+        expect(proc.getLaneStatus().document_ocr?.inFlight).toBe(1);
+
+        resolveOcr!({ kind: 'complete', reason: 'ocr_ok' });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(proc.getLaneStatus().document_ocr?.inFlight).toBe(0);
+    });
+
+    it('does not let an extract backlog starve an OCR lane', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'AAAAAAAA',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'CCCCCCCC',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 1,
+        });
+        await db.enqueueBackgroundJob({
+            jobType: 'document_ocr',
+            libraryId: 1,
+            zoteroKey: 'BBBBBBBB',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        const ocrRuns: string[] = [];
+        mockState.nextResult = okResult('AAAAAAAA');
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        proc.registerExecutor(
+            ocrExecutor(async (record) => {
+                ocrRuns.push(record.zoteroKey);
+                return { kind: 'complete', reason: 'ocr_ok' };
+            }),
+            { maxInFlight: 1 },
+        );
+
+        const result = await proc.processOnce({ awaitLaunchedJobs: true });
+
+        expect(result.processed).toBe(true);
+        expect(ocrRuns).toEqual(['BBBBBBBB']);
+        const remaining = await db.peekBackgroundJobs();
+        expect(remaining.map((row) => row.zoteroKey)).toEqual(['CCCCCCCC']);
+    });
+
+    it('serializes extract and OCR final extraction through the MuPDF lane', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'AAAAAAAA',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        await db.enqueueBackgroundJob({
+            jobType: 'document_ocr',
+            libraryId: 1,
+            zoteroKey: 'BBBBBBBB',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+
+        let resolveExtract!: () => void;
+        let resolveOcr!: () => void;
+        let active = 0;
+        let maxActive = 0;
+        const events: string[] = [];
+        const enter = (name: string) => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            events.push(`${name}:start`);
+        };
+        const leave = (name: string) => {
+            events.push(`${name}:end`);
+            active -= 1;
+        };
+        mockState.nextResult = async () => {
+            enter('extract');
+            await new Promise<void>((resolve) => {
+                resolveExtract = resolve;
+            });
+            leave('extract');
+            return okResult('AAAAAAAA');
+        };
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        proc.registerExecutor(
+            ocrExecutor(async (_record, ctx: JobExecutionContext) => {
+                return await ctx.runOnMuPDFWorker(async () => {
+                    enter('ocr');
+                    await new Promise<void>((resolve) => {
+                        resolveOcr = resolve;
+                    });
+                    leave('ocr');
+                    return { kind: 'complete', reason: 'ocr_ok' };
+                });
+            }),
+            { maxInFlight: 1 },
+        );
+
+        const processOncePromise = proc.processOnce({ awaitLaunchedJobs: true });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(events).toEqual(['extract:start']);
+
+        resolveExtract!();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(events).toEqual(['extract:start', 'extract:end', 'ocr:start']);
+
+        resolveOcr!();
+        await processOncePromise;
+        expect(maxActive).toBe(1);
+        expect(events).toEqual([
+            'extract:start',
+            'extract:end',
+            'ocr:start',
+            'ocr:end',
+        ]);
+    });
+
+    it('stop() aborts and awaits multiple in-flight lane jobs', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_extract',
+            libraryId: 1,
+            zoteroKey: 'AAAAAAAA',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+        await db.enqueueBackgroundJob({
+            jobType: 'document_ocr',
+            libraryId: 1,
+            zoteroKey: 'BBBBBBBB',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+
+        const aborted: string[] = [];
+        mockState.nextResult = async (args: any) => {
+            return await new Promise<any>((resolve) => {
+                args.externalAbortSignal.addEventListener('abort', () => {
+                    aborted.push('extract');
+                    resolve({
+                        kind: 'external_abort',
+                        phase: 'external_abort',
+                        pageCount: null,
+                        resolvedAttachment: { libraryId: 1, zoteroKey: 'AAAAAAAA' },
+                    });
+                });
+            });
+        };
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        proc.registerExecutor(
+            ocrExecutor(async (_record, ctx) => {
+                return await new Promise<JobOutcome>((resolve) => {
+                    ctx.externalAbortSignal.addEventListener('abort', () => {
+                        aborted.push('ocr');
+                        resolve({ kind: 'release', reason: 'external_abort' });
+                    });
+                });
+            }),
+            { maxInFlight: 1 },
+        );
+
+        const processOncePromise = proc.processOnce();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(proc.getLaneStatus().document_extract?.inFlight).toBe(1);
+        expect(proc.getLaneStatus().document_ocr?.inFlight).toBe(1);
+
+        await proc.stop();
+        await processOncePromise;
+
+        expect(aborted.sort()).toEqual(['extract', 'ocr']);
+        expect(proc.getLaneStatus().document_extract?.inFlight).toBe(0);
+        expect(proc.getLaneStatus().document_ocr?.inFlight).toBe(0);
+    });
+
+    it('failPermanent writes a document processing failure and completes the queue row', async () => {
+        await db.enqueueBackgroundJob({
+            jobType: 'document_ocr',
+            libraryId: 1,
+            zoteroKey: 'BBBBBBBB',
+            contentKind: 'pdf',
+            payloadKind: 'structured',
+            payload: payload(),
+            now: 0,
+        });
+
+        const { BackgroundExtractor } = await loadProcessor();
+        const proc = new BackgroundExtractor();
+        proc.registerExecutor(
+            ocrExecutor(async () => ({
+                kind: 'failPermanent',
+                reason: 'terminal:OCR_NO_TEXT',
+                failure: {
+                    fileHash: 'hash-b',
+                    task: 'ocr',
+                    engineVersion: 'engine-1',
+                    sourceType: 'zotero',
+                    sourceKey: '1-BBBBBBBB',
+                    error: 'no text',
+                    terminalCode: 'OCR_NO_TEXT',
+                },
+            })),
+            { maxInFlight: 1 },
+        );
+
+        const result = await proc.processOnce({ awaitLaunchedJobs: true });
+
+        expect(result.processed).toBe(true);
+        await expect(db.peekBackgroundJobs()).resolves.toHaveLength(0);
+        await expect(
+            db.getDocumentProcessingFailure('hash-b', 'ocr', 'engine-1'),
+        ).resolves.toMatchObject({
+            fileHash: 'hash-b',
+            task: 'ocr',
+            terminalCode: 'OCR_NO_TEXT',
+            lastError: 'no text',
+        });
+    });
+
     it('latches db-write disable when stop() is called during shutdown', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -804,7 +1166,7 @@ describe('BackgroundExtractor', () => {
 
     it('returns shutting_down and does not claim when Zotero.__beaverShuttingDown is set', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -839,7 +1201,7 @@ describe('BackgroundExtractor', () => {
     it('skips DB writes when Zotero.__beaverShuttingDown is true', async () => {
         // Models the trailing-async scenario
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',
@@ -926,9 +1288,9 @@ describe('BackgroundExtractor', () => {
             setTimeoutSpy.mockRestore();
         });
 
-        it('records a pendingWake (instead of scheduling) while a job is in flight', async () => {
+        it('schedules a wake while a job is in flight so free lanes can refill', async () => {
             await db.enqueueBackgroundJob({
-                jobType: 'document_timeout_retry',
+                jobType: 'document_extract',
                 libraryId: 1,
                 zoteroKey: 'AAAAAAAA',
                 contentKind: 'pdf',
@@ -950,14 +1312,8 @@ describe('BackgroundExtractor', () => {
 
             const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
             proc.notify();
-            // No new timer installed: the wake is deferred to the active
-            // tick's tail to avoid racing it with a parallel 0ms timer
-            // that could be cleared (losing the wake) or fire concurrently
-            // (two ticks claim, only one inFlight tracked).
-            expect(setTimeoutSpy).not.toHaveBeenCalled();
-            // The wake is recorded as pending so the next tick reschedules
-            // at 0 instead of IDLE_INTERVAL_MS.
-            expect((proc as any).pendingWake).toBe(true);
+            expect(setTimeoutSpy).toHaveBeenCalled();
+            expect((proc as any).pendingWake).toBe(false);
             setTimeoutSpy.mockRestore();
 
             // Clean up: let the in-flight job finish so stop() returns.
@@ -1021,7 +1377,7 @@ describe('BackgroundExtractor', () => {
 
         it('re-entrant tick() bails out cleanly so two ticks do not run processOnce in parallel', async () => {
             await db.enqueueBackgroundJob({
-                jobType: 'document_timeout_retry',
+                jobType: 'document_extract',
                 libraryId: 1,
                 zoteroKey: 'AAAAAAAA',
                 contentKind: 'pdf',
@@ -1076,7 +1432,7 @@ describe('BackgroundExtractor', () => {
             await proc.start();
             try {
                 await db.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: 1,
                     zoteroKey: 'AAAAAAAA',
                     contentKind: 'pdf',
@@ -1107,7 +1463,7 @@ describe('BackgroundExtractor', () => {
                 handler(true);
 
                 await db.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: 1,
                     zoteroKey: 'AAAAAAAA',
                     contentKind: 'pdf',
@@ -1130,7 +1486,7 @@ describe('BackgroundExtractor', () => {
             await proc.start();
             try {
                 await db.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: 1,
                     zoteroKey: 'AAAAAAAA',
                     contentKind: 'pdf',
@@ -1162,7 +1518,7 @@ describe('BackgroundExtractor', () => {
                 observer.notify('stop', 'sync', [], {});
 
                 await db.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: 1,
                     zoteroKey: 'AAAAAAAA',
                     contentKind: 'pdf',
@@ -1183,7 +1539,7 @@ describe('BackgroundExtractor', () => {
             const claimSpy = vi.spyOn(db, 'claimNextBackgroundJob');
             try {
                 await db.enqueueBackgroundJob({
-                    jobType: 'document_timeout_retry',
+                    jobType: 'document_extract',
                     libraryId: 1,
                     zoteroKey: 'AAAAAAAA',
                     contentKind: 'pdf',
@@ -1202,6 +1558,7 @@ describe('BackgroundExtractor', () => {
                     expect.any(Number),
                     expect.any(Number),
                     100,
+                    ['document_extract'],
                 );
                 expect(mockState.extractCalls).toHaveLength(0);
             } finally {
@@ -1216,7 +1573,7 @@ describe('BackgroundExtractor', () => {
             const idleMod = await import('../../../src/utils/idleService');
             (idleMod.getSystemIdleTimeMs as any).mockReturnValueOnce(0);
             await db.enqueueBackgroundJob({
-                jobType: 'document_timeout_retry',
+                jobType: 'document_extract',
                 libraryId: 1,
                 zoteroKey: 'AAAAAAAA',
                 contentKind: 'pdf',
@@ -1239,7 +1596,7 @@ describe('BackgroundExtractor', () => {
             (idleMod.getSystemIdleTimeMs as any).mockReturnValueOnce(Number.MAX_SAFE_INTEGER);
             const claimSpy = vi.spyOn(db, 'claimNextBackgroundJob');
             await db.enqueueBackgroundJob({
-                jobType: 'document_timeout_retry',
+                jobType: 'document_extract',
                 libraryId: 1,
                 zoteroKey: 'AAAAAAAA',
                 contentKind: 'pdf',
@@ -1254,13 +1611,18 @@ describe('BackgroundExtractor', () => {
             const result = await proc.processOnce();
 
             expect(result.processed).toBe(true);
-            expect(claimSpy).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), undefined);
+            expect(claimSpy).toHaveBeenCalledWith(
+                expect.any(Number),
+                expect.any(Number),
+                undefined,
+                ['document_extract'],
+            );
             claimSpy.mockRestore();
         });
 
         it('in-flight job continues even when sync starts and the OS goes active mid-run', async () => {
             await db.enqueueBackgroundJob({
-                jobType: 'document_timeout_retry',
+                jobType: 'document_extract',
                 libraryId: 1,
                 zoteroKey: 'AAAAAAAA',
                 contentKind: 'pdf',
@@ -1353,7 +1715,7 @@ describe('BackgroundExtractor', () => {
 
     it('skips failBackgroundJob during shutdown so transient errors do not write', async () => {
         await db.enqueueBackgroundJob({
-            jobType: 'document_timeout_retry',
+            jobType: 'document_extract',
             libraryId: 1,
             zoteroKey: 'AAAAAAAA',
             contentKind: 'pdf',

--- a/tests/unit/services/backgroundQueue.test.ts
+++ b/tests/unit/services/backgroundQueue.test.ts
@@ -8,7 +8,7 @@ import { MockDBConnection } from '../../mocks/mockDBConnection';
 
 function makeInput(overrides: Partial<BackgroundJobInput> = {}): BackgroundJobInput {
     const base: BackgroundJobInput = {
-        jobType: 'document_timeout_retry',
+        jobType: 'document_extract',
         libraryId: 1,
         zoteroKey: 'ABCD1234',
         contentKind: 'pdf',
@@ -258,6 +258,43 @@ describe('BeaverDB background queue', () => {
         expect(claimed4).toBeNull();
     });
 
+    it('claimNextBackgroundJob can filter by job type without starving other lanes', async () => {
+        await db.enqueueBackgroundJob(
+            makeInput({ jobType: 'document_extract', zoteroKey: 'AAAAAAAA', priority: 100 }),
+        );
+        await db.enqueueBackgroundJob(
+            makeInput({ jobType: 'document_ocr', zoteroKey: 'BBBBBBBB', priority: 10 }),
+        );
+
+        const now = 1_000_000;
+        const visibility = 60_000;
+        const extract = await db.claimNextBackgroundJob(
+            now,
+            visibility,
+            undefined,
+            ['document_extract'],
+        );
+        expect(extract?.jobType).toBe('document_extract');
+        expect(extract?.zoteroKey).toBe('AAAAAAAA');
+
+        const noExtract = await db.claimNextBackgroundJob(
+            now,
+            visibility,
+            undefined,
+            ['document_extract'],
+        );
+        expect(noExtract).toBeNull();
+
+        const ocr = await db.claimNextBackgroundJob(
+            now,
+            visibility,
+            undefined,
+            ['document_ocr'],
+        );
+        expect(ocr?.jobType).toBe('document_ocr');
+        expect(ocr?.zoteroKey).toBe('BBBBBBBB');
+    });
+
     describe('maxPriority gate', () => {
         it('with maxPriority=100, skips priority-100 jobs and claims only lower-priority ones', async () => {
             await db.enqueueBackgroundJob(
@@ -440,7 +477,7 @@ describe('BeaverDB background queue', () => {
         const stats = await db.getBackgroundQueueStats(500);
         expect(stats.pending).toBe(2);
         expect(stats.available + stats.deferred).toBe(stats.pending);
-        expect(stats.byJobType['document_timeout_retry']).toBe(2);
+        expect(stats.byJobType['document_extract']).toBe(2);
         expect(stats.dead).toBe(0);
     });
 
@@ -464,5 +501,124 @@ describe('BeaverDB background queue', () => {
         expect(typeof rows[0].availableAt).toBe('number');
         expect(rows[0].enqueuedAt).toBe(12345);
         expect(rows[0].availableAt).toBe(12345);
+    });
+
+    it('records, increments, gates, and clears document processing failures by content hash', async () => {
+        await db.recordDocumentProcessingFailure({
+            fileHash: 'hash-a',
+            task: 'ocr',
+            engineVersion: 'engine-1',
+            sourceType: 'zotero',
+            sourceKey: '1-AAAAAAAA',
+            error: 'first',
+        });
+
+        let record = await db.getDocumentProcessingFailure('hash-a', 'ocr', 'engine-1');
+        expect(record).toMatchObject({
+            fileHash: 'hash-a',
+            task: 'ocr',
+            engineVersion: 'engine-1',
+            sourceType: 'zotero',
+            sourceKey: '1-AAAAAAAA',
+            failureCount: 1,
+            terminalCode: null,
+            lastError: 'first',
+        });
+        expect(
+            await db.isDocumentProcessingReadyForRetry(
+                'hash-a',
+                'ocr',
+                'engine-1',
+                '0000-01-01 00:00:00',
+            ),
+        ).toBe(false);
+        expect(
+            await db.isDocumentProcessingReadyForRetry(
+                'hash-a',
+                'ocr',
+                'engine-1',
+                '9999-01-01 00:00:00',
+            ),
+        ).toBe(true);
+
+        await db.recordDocumentProcessingFailure({
+            fileHash: 'hash-a',
+            task: 'ocr',
+            engineVersion: 'engine-1',
+            sourceType: 'zotero',
+            sourceKey: '1-BBBBBBBB',
+            error: 'second',
+        });
+
+        record = await db.getDocumentProcessingFailure('hash-a', 'ocr', 'engine-1');
+        expect(record?.failureCount).toBe(2);
+        expect(record?.lastError).toBe('second');
+        expect(record?.sourceKey).toBe('1-BBBBBBBB');
+        expect(await db.isDocumentProcessingPermanentlyFailed('hash-a', 'ocr', 'engine-1')).toBe(false);
+
+        await db.recordDocumentProcessingFailure({
+            fileHash: 'hash-a',
+            task: 'ocr',
+            engineVersion: 'engine-1',
+            error: 'terminal',
+            terminalCode: 'OCR_NO_TEXT',
+        });
+
+        record = await db.getDocumentProcessingFailure('hash-a', 'ocr', 'engine-1');
+        expect(record?.terminalCode).toBe('OCR_NO_TEXT');
+        expect(await db.isDocumentProcessingPermanentlyFailed('hash-a', 'ocr', 'engine-1')).toBe(true);
+        expect(
+            await db.isDocumentProcessingReadyForRetry(
+                'hash-a',
+                'ocr',
+                'engine-1',
+                '9999-01-01 00:00:00',
+            ),
+        ).toBe(false);
+
+        await expect(
+            db.getDocumentProcessingFailure('hash-a', 'ocr', 'engine-2'),
+        ).resolves.toBeNull();
+
+        await db.clearDocumentProcessingFailure('hash-a', 'ocr', 'engine-1');
+        await expect(
+            db.getDocumentProcessingFailure('hash-a', 'ocr', 'engine-1'),
+        ).resolves.toBeNull();
+    });
+
+    it('atomically upserts concurrent document processing failures for the same content hash', async () => {
+        await Promise.all([
+            db.recordDocumentProcessingFailure({
+                fileHash: 'hash-concurrent',
+                task: 'ocr',
+                engineVersion: 'engine-1',
+                error: 'first',
+            }),
+            db.recordDocumentProcessingFailure({
+                fileHash: 'hash-concurrent',
+                task: 'ocr',
+                engineVersion: 'engine-1',
+                error: 'second',
+            }),
+        ]);
+
+        const record = await db.getDocumentProcessingFailure(
+            'hash-concurrent',
+            'ocr',
+            'engine-1',
+        );
+        expect(record?.failureCount).toBe(2);
+        expect(record?.lastError).toBe('second');
+    });
+
+    it('does not create the unused document processing retry index', async () => {
+        const indexes = conn
+            .getRawDB()
+            .prepare(`SELECT name FROM pragma_index_list('document_processing_failures')`)
+            .all() as Array<{ name: string }>;
+
+        expect(indexes.map((index) => index.name)).not.toContain(
+            'idx_doc_proc_failures_retry',
+        );
     });
 });

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -335,6 +335,7 @@ declare namespace Zotero {
                 now: number,
                 visibilityTimeoutMs: number,
                 maxPriority?: number,
+                jobTypes?: import("../src/services/database").BackgroundJobType[],
             ): Promise<import("../src/services/database").BackgroundJobRecord | null>;
 
             peekBackgroundJobs(
@@ -358,6 +359,35 @@ declare namespace Zotero {
             getBackgroundQueueStats(
                 now: number,
             ): Promise<import("../src/services/database").BackgroundQueueStats>;
+
+            recordDocumentProcessingFailure(
+                input: import("../src/services/database").DocumentProcessingFailureInput,
+            ): Promise<void>;
+
+            getDocumentProcessingFailure(
+                fileHash: string,
+                task: import("../src/services/database").DocumentProcessingTask,
+                engineVersion?: string,
+            ): Promise<import("../src/services/database").DocumentProcessingFailureRecord | null>;
+
+            isDocumentProcessingPermanentlyFailed(
+                fileHash: string,
+                task: import("../src/services/database").DocumentProcessingTask,
+                engineVersion?: string,
+            ): Promise<boolean>;
+
+            isDocumentProcessingReadyForRetry(
+                fileHash: string,
+                task: import("../src/services/database").DocumentProcessingTask,
+                engineVersion?: string,
+                now?: string,
+            ): Promise<boolean>;
+
+            clearDocumentProcessingFailure(
+                fileHash: string,
+                task: import("../src/services/database").DocumentProcessingTask,
+                engineVersion?: string,
+            ): Promise<void>;
         }
 
         const backgroundExtractor:


### PR DESCRIPTION
…nt-processing-failure tracking

No production behavior change except dropping stale queue rows on the type rename.

document_ocr/fulltext_upsert are reserved-but-unhandled