### PR TITLE
feat(diffPreview): enhance diff preview handling and recovery

### DIFF
--- a/react/utils/diffPreviewCoordinator.ts
+++ b/react/utils/diffPreviewCoordinator.ts
@@ -18,6 +18,7 @@ import {
     showDiffPreview,
     dismissDiffPreview,
     isDiffPreviewActive,
+    isDiffPreviewPendingFor,
     isDiffPreviewSupported,
     isNoteInSelectedTab,
     getPreviewNoteKey,
@@ -102,7 +103,10 @@ export function updateDiffPreviewForNote(libraryId: number, zoteroKey: string): 
     }
 
     if (edits.length === 0) {
-        if (isDiffPreviewActive(libraryId, zoteroKey)) {
+        // Also dismiss when a show for this note is still in its async setup
+        // phase (e.g. the approval was answered before the preview applied):
+        // dismissDiffPreview()'s generation bump aborts the pending show.
+        if (isDiffPreviewActive(libraryId, zoteroKey) || isDiffPreviewPendingFor(libraryId, zoteroKey)) {
             dismissDiffPreview();
             store.set(diffPreviewNoteKeyAtom, null);
         }

--- a/react/utils/editNoteActions.ts
+++ b/react/utils/editNoteActions.ts
@@ -55,7 +55,7 @@ import { clearNoteEditorSelection } from './sourceUtils';
 import { store } from '../store';
 import { currentThreadIdAtom } from '../atoms/threads';
 import { addOrUpdateEditFooter, getBeaverFooterAppendPoint } from '../../src/utils/noteEditFooter';
-import { assertNoPreviewMarkers } from '../../src/utils/notePreviewGuard';
+import { assertNoPreviewMarkers, containsPreviewMarkers, stripPreviewMarkers } from '../../src/utils/notePreviewGuard';
 import {
     externalReferenceMappingAtom,
     externalReferenceItemMappingAtom,
@@ -201,6 +201,23 @@ export async function executeEditNoteAction(
     // 2b. Promote any unsaved editor content into the DB so this apply sees
     //     the same HTML validation saw. See flushLiveEditorToDB for rationale.
     await flushLiveEditorToDB(item);
+
+    // 2c. Repair notes that contain persisted diff-preview markup, mirroring
+    //     the agent execute path.
+    {
+        const persistedHtml: string = item.getNote();
+        if (containsPreviewMarkers(persistedHtml)) {
+            const repaired = stripPreviewMarkers(persistedHtml);
+            if (!containsPreviewMarkers(repaired)) {
+                logger(`executeEditNoteAction: repairing persisted diff-preview markup in ${library_id}-${zotero_key}`, 1);
+                item.setNote(repaired);
+                await item.saveTx();
+                await waitForNoteSaveStabilization(item, repaired);
+            } else {
+                logger(`executeEditNoteAction: diff-preview markup in ${library_id}-${zotero_key} could not be fully stripped; save will be refused by the preview guard`, 1);
+            }
+        }
+    }
 
     // 3. Get current note HTML
     const oldHtml: string = item.getNote();

--- a/react/utils/noteEditorDiffPreview.ts
+++ b/react/utils/noteEditorDiffPreview.ts
@@ -41,6 +41,7 @@ import {
     ENTITY_FORMS,
 } from '../../src/utils/noteHtmlEntities';
 import { getBeaverFooterAppendPoint } from '../../src/utils/noteEditFooter';
+import { containsPreviewMarkers } from '../../src/utils/notePreviewGuard';
 import { store } from '../store';
 import {
     externalReferenceMappingAtom,
@@ -136,6 +137,12 @@ interface DiffPreviewState {
 }
 
 let activePreview: DiffPreviewState | null = null;
+
+/**
+ * Marker for a showDiffPreview call whose async setup is still running (the
+ * preview is not yet active). Lets callers abort an in-flight show.
+ */
+let pendingShow: { key: string } | null = null;
 
 /**
  * Generation counter: incremented on every show/dismiss to abort stale async calls.
@@ -257,6 +264,7 @@ export async function showDiffPreview(
     options?: DiffPreviewOptions,
 ): Promise<boolean> {
     const noteKey = `${libraryId}-${zoteroKey}`;
+    let myPendingShow: { key: string } | null = null;
     try {
         if (edits.length === 0) {
             logger(`showDiffPreview: aborting for ${noteKey}, edits array is empty`, 1);
@@ -282,8 +290,19 @@ export async function showDiffPreview(
             return true;
         }
 
-        // Dismiss existing and claim this generation
-        await dismissDiffPreview();
+        // Mark this show as in flight so callers can abort it (see
+        // pendingShow). Cleared in the finally block below.
+        myPendingShow = { key: noteKey };
+        pendingShow = myPendingShow;
+
+        // Dismiss any existing preview
+        const dismissal = dismissDiffPreview();
+        const genAfterOwnDismiss = generation;
+        await dismissal;
+        if (generation !== genAfterOwnDismiss) {
+            logger(`showDiffPreview: aborting for ${noteKey}, dismissed while awaiting prior teardown`, 1);
+            return false;
+        }
         const myGeneration = ++generation;
 
         if (!areEditorApisAvailable()) {
@@ -464,7 +483,17 @@ export async function showDiffPreview(
     } catch (e: any) {
         logger(`showDiffPreview: error for ${noteKey}: ${e.message}\n${e.stack ?? ''}`, 1);
         return false;
+    } finally {
+        if (pendingShow === myPendingShow) pendingShow = null;
     }
+}
+
+/**
+ * True while a showDiffPreview call for this note is still in its async
+ * setup phase (not yet active).
+ */
+export function isDiffPreviewPendingFor(libraryId: number, zoteroKey: string): boolean {
+    return pendingShow?.key === `${libraryId}-${zoteroKey}`;
 }
 
 /**
@@ -536,15 +565,43 @@ export function dismissDiffPreview(): Promise<void> {
         // for that message guarantees ProseMirror holds the clean HTML
         // before saving resumes — unlike a fixed timeout.
         return new Promise<void>((resolve) => {
-            let savingRestored = false;
+            let settled = false;
             let quietTimer: ReturnType<typeof setTimeout> | null = null;
+            let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
             const QUIET_DURATION_MS = 50;
-            const restoreSaving = () => {
-                if (savingRestored) return;
-                savingRestored = true;
+            const cleanup = () => {
                 if (quietTimer) clearTimeout(quietTimer);
+                if (fallbackTimer) clearTimeout(fallbackTimer);
                 try { inst._iframeWindow?.removeEventListener('message', onIframeMsg); } catch { /* ignore */ }
-                try { inst._disableSaving = wasSavingDisabled; } catch { /* ignore */ }
+            };
+            const restoreSaving = () => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                restoreSavingGuarded(inst, wasSavingDisabled);
+                resolve();
+            };
+            // The iframe could not apply the restore, so its document still
+            // holds the diff HTML
+            const deferToEditorReinit = () => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                logger('dismissDiffPreview: incremental restore failed; deferring to the editor reinit', 1);
+                const tabID = inst.tabID;
+                setTimeout(() => {
+                    try {
+                        // Zotero's reinit drops the tab association; restore
+                        // it so tab-based preview gating keeps working.
+                        if (tabID && !inst._tabID) inst._tabID = tabID;
+                        if (inst._disableSaving && isEditorInstanceUsable(inst)) {
+                            const html = readLiveEditorHtml(inst);
+                            if (html !== null && !containsPreviewMarkers(html)) {
+                                inst._disableSaving = wasSavingDisabled;
+                            }
+                        }
+                    } catch { /* ignore */ }
+                }, 3000);
                 resolve();
             };
             const scheduleQuietRestore = () => {
@@ -555,20 +612,87 @@ export function dismissDiffPreview(): Promise<void> {
                 try {
                     if (e.data?.instanceID !== inst.instanceID) return;
                     const action = e.data?.message?.action;
-                    if ((action === 'update' && e.data?.message?.system) || action === 'incrementalUpdateFailed') {
+                    if (action === 'update' && e.data?.message?.system) {
                         scheduleQuietRestore();
+                    } else if (action === 'incrementalUpdateFailed') {
+                        deferToEditorReinit();
                     }
                 } catch { /* ignore */ }
             };
             try { inst._iframeWindow.addEventListener('message', onIframeMsg); } catch { /* ignore */ }
-            // Fallback: restore after 1.5s even if no 'update' arrives
-            // (e.g., iframe destroyed or update silently dropped).
-            setTimeout(restoreSaving, 1500);
+            // Fallback: run the guarded restore after 1.5s even if no
+            // 'update' arrives (e.g., iframe destroyed or update silently
+            // dropped).
+            fallbackTimer = setTimeout(restoreSaving, 1500);
         });
     } catch (e: any) {
         logger(`dismissDiffPreview: error: ${e.message}`, 1);
-        try { inst._disableSaving = wasSavingDisabled; } catch { /* ignore */ }
+        restoreSavingGuarded(inst, wasSavingDisabled);
         return Promise.resolve();
+    }
+}
+
+/**
+ * Read the current ProseMirror document HTML from an editor instance's
+ * iframe, or null if it cannot be read.
+ *
+ * Must pass onlyChanged=false: getDataSync(true) returns null whenever the
+ * editor's docChanged flag is unset, and applyExternalChanges clears that
+ * flag — so after a preview apply or restore the true-variant reports
+ * nothing and a marker check against it would silently pass.
+ */
+function readLiveEditorHtml(inst: any): string | null {
+    try {
+        const noteData = inst._iframeWindow?.wrappedJSObject?.getDataSync(false);
+        return typeof noteData?.html === 'string' ? noteData.html : null;
+    } catch { return null; }
+}
+
+/**
+ * Re-enable an editor instance's save path after a preview teardown, but
+ * only if its document no longer shows the diff markup. If the diff is
+ * still present (the restore never landed), re-enabling saves would let the
+ * editor's next autosave persist the presentation-only markup into the note
+ * — permanent corruption, since the preview guard then refuses every
+ * subsequent save. Instead, reinitialize the editor from the item's saved
+ * note: reinit() resets _disableSaving itself, and saveSync() inside
+ * uninit() is a no-op while saving is still disabled.
+ */
+function restoreSavingGuarded(inst: any, wasSavingDisabled: boolean): void {
+    const liveHtml = readLiveEditorHtml(inst);
+    if (liveHtml !== null && containsPreviewMarkers(liveHtml)) {
+        logger('dismissDiffPreview: editor still shows diff markup; reinitializing editor from saved note', 1);
+        reinitEditorInstance(inst);
+        return;
+    }
+    try { inst._disableSaving = wasSavingDisabled; } catch { /* ignore */ }
+}
+
+/**
+ * Reinitialize an editor instance, preserving its tab association.
+ * Zotero's reinit() rebuilds init options without tabID, so a plain reinit
+ * permanently breaks tab-based gating (isNoteInSelectedTab and therefore
+ * the automatic preview) for that editor until the tab is reopened.
+ */
+function reinitEditorInstance(inst: any): void {
+    const tabID = inst.tabID;
+    const restoreTabId = () => {
+        try { if (tabID && !inst._tabID) inst._tabID = tabID; } catch { /* ignore */ }
+    };
+    try {
+        const p = inst.reinit();
+        if (p?.then) {
+            p.then(restoreTabId, (e: any) => {
+                restoreTabId();
+                logger(`dismissDiffPreview: reinit failed: ${e?.message}`, 1);
+            });
+        } else {
+            restoreTabId();
+        }
+    } catch (e: any) {
+        // Leave saving disabled — a stuck editor (recovered by reopening
+        // the note) is preferable to persisting the diff markup.
+        logger(`dismissDiffPreview: reinit threw: ${e?.message}`, 1);
     }
 }
 

--- a/src/services/agentDataProvider/actions/editNote.ts
+++ b/src/services/agentDataProvider/actions/editNote.ts
@@ -62,7 +62,8 @@ import {
 import { renderToHTML, type RenderContextData } from '../../../../react/utils/citationRenderers';
 import { prepareCitationRenderContext } from '../../../../react/utils/citationRenderContext';
 import { addOrUpdateEditFooter, getBeaverFooterAppendPoint } from '../../../utils/noteEditFooter';
-import { assertNoPreviewMarkers } from '../../../utils/notePreviewGuard';
+import { assertNoPreviewMarkers, containsPreviewMarkers, stripPreviewMarkers } from '../../../utils/notePreviewGuard';
+import { dismissDiffPreview, isDiffPreviewActive, isDiffPreviewPendingFor } from '../../../../react/utils/noteEditorDiffPreview';
 import {
     WSAgentActionValidateRequest,
     WSAgentActionValidateResponse,
@@ -516,7 +517,15 @@ async function validateEditNoteAction(
 
     // 6. Load note data
     await item.loadDataType('note');
-    const rawHtml = getLatestNoteHtml(item);
+    let rawHtml = getLatestNoteHtml(item);
+    // Recovery path: if diff-preview markup was ever accidentally persisted
+    // into this note, validate against the stripped content. Execution
+    // repairs the stored note the same way before applying, so old_string
+    // matching stays consistent across validate and execute.
+    if (containsPreviewMarkers(rawHtml)) {
+        logger(`validateEditNoteAction: note ${resolvedLibraryId}-${zotero_key} contains persisted diff-preview markup; validating against stripped content`, 1);
+        rawHtml = stripPreviewMarkers(rawHtml);
+    }
 
     // 7. Note not empty
     if (!rawHtml || rawHtml.trim() === '') {
@@ -876,12 +885,45 @@ async function executeEditNoteAction(
     // 2. Load note
     await item.loadDataType('note');
 
+    // 2a. If the in-editor diff preview is still showing for this note (or a
+    //     show is in flight), dismiss it and wait for the editor restore to
+    //     finish before reading or writing. Approval paths dismiss the
+    //     preview fire-and-forget, so an execute arriving over WS can
+    //     otherwise race the restore.
+    if (isDiffPreviewActive(resolvedLibraryId, zotero_key) || isDiffPreviewPendingFor(resolvedLibraryId, zotero_key)) {
+        await dismissDiffPreview();
+    }
+
     // 2b. Promote any unsaved content from the open editor into the DB so that
     //     this execute reads the same HTML validation saw. Without this, a
     //     rewrite could clobber the user's in-flight typing, and a str_replace
     //     could fail with no_match against matches that only exist in the
     //     editor's unsaved state.
     await flushLiveEditorToDB(item);
+
+    // 2c. Repair notes that contain persisted diff-preview markup. The
+    //     preview is presentation-only; if a teardown failure ever let an
+    //     editor autosave persist it, assertNoPreviewMarkers below would
+    //     refuse every subsequent save of this note with no recovery path.
+    //     Strip the markup (drop proposed-addition spans, unwrap deletion
+    //     spans back to the original text) and save the repaired note before
+    //     applying the edit. This writes even when the edit itself later
+    //     fails to match — intentional, so a failed attempt still un-bricks
+    //     the note for subsequent edits.
+    {
+        const persistedHtml: string = item.getNote();
+        if (containsPreviewMarkers(persistedHtml)) {
+            const repaired = stripPreviewMarkers(persistedHtml);
+            if (!containsPreviewMarkers(repaired)) {
+                logger(`executeEditNoteAction: repairing persisted diff-preview markup in ${resolvedLibraryId}-${zotero_key}`, 1);
+                item.setNote(repaired);
+                await item.saveTx();
+                await waitForNoteSaveStabilization(item, repaired);
+            } else {
+                logger(`executeEditNoteAction: diff-preview markup in ${resolvedLibraryId}-${zotero_key} could not be fully stripped; save will be refused by the preview guard`, 1);
+            }
+        }
+    }
 
     // 3. Pre-load page labels so new citations resolve page indices to labels.
     //    Done before reading the note to avoid async gaps between read and write.

--- a/src/services/agentDataProvider/handleReadNoteRequest.ts
+++ b/src/services/agentDataProvider/handleReadNoteRequest.ts
@@ -9,6 +9,7 @@ import { logger } from '../../utils/logger';
 import { getOrSimplify } from '../../utils/noteHtmlSimplifier';
 import { preloadNotePageLabels } from '../../utils/noteCitationExpand';
 import { getNoteHtmlForRead } from '../../utils/noteEditorIO';
+import { containsPreviewMarkers, stripPreviewMarkers } from '../../utils/notePreviewGuard';
 import {
     WSReadNoteRequest,
     WSReadNoteResponse,
@@ -277,11 +278,18 @@ export async function handleReadNoteRequest(
         //    back to item.getNote() when the live snapshot is empty. Critically
         //    NEVER calls item.setNote() — flushLiveEditorToDB would persist a
         //    transient empty PM-render snapshot and erase the note's content.
-        const rawHtml = await getNoteHtmlForRead(item);
+        let rawHtml = await getNoteHtmlForRead(item);
         if (!rawHtml || rawHtml.trim() === '') {
             return errorResponse(
                 `Note ${note_id} is empty. There is no content to read.`
             );
+        }
+        // Recovery path: if diff-preview markup was ever accidentally
+        // persisted into this note, read the stripped content so the model
+        // sees the same HTML the edit_note validate/execute paths repair to.
+        if (containsPreviewMarkers(rawHtml)) {
+            logger(`handleReadNoteRequest: note ${note_id} contains persisted diff-preview markup; reading stripped content`, 1);
+            rawHtml = stripPreviewMarkers(rawHtml);
         }
 
         // 6. Simplify (also warms cache for subsequent edit_note calls).

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -340,15 +340,30 @@ export class BeaverUIFactory {
                         const view = inst._iframeWindow?.wrappedJSObject
                             ?._currentEditorInstance?._editorCore?.view;
                         if (view?.dom) view.dom.contentEditable = 'true';
-                        // Restore content from DB and re-enable saving
+                        // Restore the editor from the saved note via Zotero's
+                        // own reinit(). Do NOT re-enable saving manually: the
+                        // editor still shows the diff HTML at this point (the
+                        // restore is asynchronous and this bundle is being
+                        // torn down), and a single autosave would persist the
+                        // presentation-only markup into the note. reinit()
+                        // reloads item.note and resets _disableSaving itself;
+                        // saveSync() inside uninit() is a no-op while saving
+                        // is still disabled.
                         const itemId = inst.itemID ?? inst._item?.id;
-                        if (itemId) {
-                            const item = Zotero.Items.get(itemId);
-                            if (item) {
-                                inst.applyIncrementalUpdate({ html: item.getNote() }, false);
-                            }
+                        try {
+                            // reinit() drops the tab association; restore it
+                            // (best effort) so tab-based behavior survives.
+                            const tabID = inst.tabID;
+                            const restoreTabId = () => {
+                                try { if (tabID && !inst._tabID) inst._tabID = tabID; } catch (e) { /* ignore */ }
+                            };
+                            const p = inst.reinit?.();
+                            if (p?.then) p.then(restoreTabId, restoreTabId);
+                            else restoreTabId();
+                        } catch (e) {
+                            // Best effort — leave saving disabled rather than
+                            // risk persisting the diff markup.
                         }
-                        inst._disableSaving = false;
                         ztoolkit.log(`removeChatPanel: cleaned up diff preview for editor ${itemId}`);
                     } catch (e) {
                         // Best effort — don't let preview cleanup block React unmount

--- a/src/utils/notePreviewGuard.ts
+++ b/src/utils/notePreviewGuard.ts
@@ -37,3 +37,113 @@ export function assertNoPreviewMarkers(html: string, context: string): void {
     logger(`notePreviewGuard: refusing setNote at ${context} — diff preview markers detected`, 1);
     throw new Error(`Beaver: refusing to save note containing diff-preview markers (${context})`);
 }
+
+const DEL_RGBA = /rgba\(\s*210\s*,\s*40\s*,\s*40\s*,/;
+const ADD_RGBA = /rgba\(\s*16\s*,\s*150\s*,\s*72\s*,/;
+
+/**
+ * Remove diff-preview markup from note HTML, restoring the pre-preview
+ * content:
+ *  - the preview banner `<div>` and `<style>` elements are removed entirely;
+ *  - deletion-styled spans (red) wrap original note text — unwrapped, keeping
+ *    their content;
+ *  - addition-styled spans (green) wrap proposed replacement text that was
+ *    never real note content — removed together with their content.
+ *
+ * This is the read-side recovery path for notes where preview markup was
+ * accidentally persisted (e.g. an editor autosave slipped through during a
+ * preview teardown failure). Without it, the write-side guard
+ * `assertNoPreviewMarkers` refuses every subsequent save of the note and
+ * there is no way to repair it from the product. Handles both the source
+ * form (`rgba(210,40,40,…)`) and the browser/ProseMirror-normalized spaced
+ * form (`rgba(210, 40, 40, …)`).
+ */
+export function stripPreviewMarkers(html: string): string {
+    if (!html || !containsPreviewMarkers(html)) return html;
+    let out = html
+        .replace(/<style\b[^>]*\bid=["']beaver-diff-preview-style["'][^>]*>[\s\S]*?<\/style>/gi, '')
+        .replace(/<div\b[^>]*\bid=["']beaver-preview-banner["'][^>]*>[\s\S]*?<\/div>/gi, '');
+    // Marker spans wrap plain text runs when created, but ProseMirror can
+    // nest other inline markup inside them after a round trip, so each pass
+    // matches closing tags depth-aware. A pass appends unwrapped deletion
+    // content without rescanning it, so nested marker spans are picked up by
+    // the next pass; the cap only bounds pathological nesting.
+    for (let pass = 0; pass < 10; pass++) {
+        const next = stripMarkerSpansOnce(out);
+        if (next === out) break;
+        out = next;
+    }
+    return out;
+}
+
+/**
+ * A bare line-through span exactly as the note editor's `strike` mark
+ * serializes it. The diff's deletion style combines line-through with the
+ * red background in one span, but ProseMirror stores them as two marks and
+ * serializes the strike OUTSIDE the background-color span (schema mark
+ * order), so persisted deletions look like:
+ *   <span style="text-decoration: line-through"><span style="background-color: rgba(210, 40, 40, 0.28)">old</span></span>
+ */
+const STRIKE_OPEN_AT_END = /<span\b[^>]*style=["']\s*text-decoration:\s*line-through;?\s*["'][^>]*>$/i;
+const CLOSE_SPAN_AT_START = /^<\/span\s*>/i;
+
+/**
+ * Single pass over `html` removing addition-marker spans (with content) and
+ * unwrapping deletion-marker spans (keeping content). Closing tags are
+ * matched by tracking nested `<span>` depth. A strike span that directly and
+ * exclusively wraps a deletion span is unwrapped with it — it is the
+ * ProseMirror-serialized half of the deletion style, and leaving it would
+ * strike through all recovered text. Strike spans anywhere else (user
+ * formatting) are untouched.
+ */
+function stripMarkerSpansOnce(html: string): string {
+    const openRe = /<span\b[^>]*>/gi;
+    let result = '';
+    let pos = 0;
+    for (;;) {
+        openRe.lastIndex = pos;
+        let open: RegExpExecArray | null = null;
+        let isAddition = false;
+        let m: RegExpExecArray | null;
+        while ((m = openRe.exec(html)) !== null) {
+            if (DEL_RGBA.test(m[0])) { open = m; isAddition = false; break; }
+            if (ADD_RGBA.test(m[0])) { open = m; isAddition = true; break; }
+        }
+        if (!open) return result + html.slice(pos);
+        const segment = html.slice(pos, open.index);
+        const innerStart = open.index + open[0].length;
+        const tokenRe = /<\/span\s*>|<span\b[^>]*>/gi;
+        tokenRe.lastIndex = innerStart;
+        let depth = 1;
+        let innerEnd = -1;
+        let closeEnd = -1;
+        let tok: RegExpExecArray | null;
+        while ((tok = tokenRe.exec(html)) !== null) {
+            depth += tok[0][1] === '/' ? -1 : 1;
+            if (depth === 0) {
+                innerEnd = tok.index;
+                closeEnd = tok.index + tok[0].length;
+                break;
+            }
+        }
+        if (innerEnd === -1) {
+            // Unbalanced markup: drop just the marker open tag and continue.
+            result += segment;
+            pos = innerStart;
+            continue;
+        }
+        let head = segment;
+        let afterEnd = closeEnd;
+        if (!isAddition) {
+            const strikeOpen = head.match(STRIKE_OPEN_AT_END);
+            const closeAfter = strikeOpen ? html.slice(afterEnd).match(CLOSE_SPAN_AT_START) : null;
+            if (strikeOpen && closeAfter) {
+                head = head.slice(0, head.length - strikeOpen[0].length);
+                afterEnd += closeAfter[0].length;
+            }
+        }
+        result += head;
+        if (!isAddition) result += html.slice(innerStart, innerEnd);
+        pos = afterEnd;
+    }
+}

--- a/tests/unit/utils/notePreviewGuard.test.ts
+++ b/tests/unit/utils/notePreviewGuard.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../src/utils/logger', () => ({
 import {
     containsPreviewMarkers,
     assertNoPreviewMarkers,
+    stripPreviewMarkers,
 } from '../../../src/utils/notePreviewGuard';
 import { logger } from '../../../src/utils/logger';
 
@@ -113,6 +114,128 @@ describe('notePreviewGuard', () => {
             } catch (e: any) {
                 expect(e.message).toContain('my-custom-label');
             }
+        });
+    });
+
+    describe('stripPreviewMarkers', () => {
+        it('returns clean HTML unchanged (same reference)', () => {
+            for (const html of CLEAN_NOTES) {
+                expect(stripPreviewMarkers(html)).toBe(html);
+            }
+        });
+
+        it('removes the banner element with its content', () => {
+            const html = '<div id="beaver-preview-banner"><span class="banner-title">Preview of Note Edits</span><button>Apply</button></div><p>body</p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>body</p>');
+        });
+
+        it('removes the preview style element with its content', () => {
+            const html = '<style id="beaver-diff-preview-style">.beaver-preview-banner { background: rgba(16,150,72,0.32); }</style><p>body</p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>body</p>');
+        });
+
+        it('unwraps deletion spans, keeping the original text', () => {
+            const html = '<p>before <span style="background-color:rgba(210,40,40,0.28);text-decoration:line-through;border-radius:2px;padding:0 1px">old text</span> after</p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>before old text after</p>');
+        });
+
+        it('removes addition spans together with their text', () => {
+            const html = '<p>before <span style="background-color:rgba(16,150,72,0.28);border-radius:2px;padding:0 1px">proposed text</span> after</p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>before  after</p>');
+        });
+
+        it('restores the pre-preview content of a full str_replace diff', () => {
+            const html = '<div data-schema-version="9"><p>The '
+                + '<span style="background-color:rgba(210,40,40,0.28);text-decoration:line-through;border-radius:2px;padding:0 1px">quick</span>'
+                + '<span style="background-color:rgba(16,150,72,0.28);border-radius:2px;padding:0 1px">fast</span>'
+                + ' brown fox.</p></div>';
+            expect(stripPreviewMarkers(html)).toBe('<div data-schema-version="9"><p>The quick brown fox.</p></div>');
+        });
+
+        it('handles the browser/ProseMirror-normalized spaced rgba form', () => {
+            const html = '<p><span style="background-color: rgba(210, 40, 40, 0.28); text-decoration: line-through">kept</span>'
+                + '<span style="background-color: rgba(16, 150, 72, 0.28)">dropped</span></p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>kept</p>');
+        });
+
+        it('handles marker spans spread across interleaved tags', () => {
+            // wrapTextNodesWithStyle wraps each text run separately, leaving
+            // structural tags between the marker spans.
+            const html = '<p><span style="background-color:rgba(210,40,40,0.28);text-decoration:line-through">a </span>'
+                + '<strong><span style="background-color:rgba(210,40,40,0.28);text-decoration:line-through">bold</span></strong>'
+                + '<span style="background-color:rgba(16,150,72,0.28)">b </span>'
+                + '<em><span style="background-color:rgba(16,150,72,0.28)">it</span></em></p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>a <strong>bold</strong><em></em></p>');
+        });
+
+        it('handles nested inline markup inside marker spans', () => {
+            const html = '<p><span style="background-color: rgba(210, 40, 40, 0.28)">old <span style="color: red">colored</span> text</span>'
+                + '<span style="background-color: rgba(16, 150, 72, 0.28)">new <span style="color: blue">colored</span> text</span></p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>old <span style="color: red">colored</span> text</p>');
+        });
+
+        it('leaves non-marker colored spans untouched', () => {
+            const html = '<p><span style="background-color:rgba(255,235,59,0.4)">highlight</span></p>';
+            expect(stripPreviewMarkers(html)).toBe(html);
+        });
+
+        it('produces output that passes the write-side guard', () => {
+            const html = '<div id="beaver-preview-banner"><button>Apply</button></div>'
+                + '<style id="beaver-diff-preview-style">.x { color: rgba(210,40,40,0.28); }</style>'
+                + '<div data-schema-version="9"><p>'
+                + '<span style="background-color:rgba(210,40,40,0.28);text-decoration:line-through">old</span>'
+                + '<span style="background-color:rgba(16,150,72,0.28)">new</span>'
+                + '</p></div>';
+            const stripped = stripPreviewMarkers(html);
+            expect(containsPreviewMarkers(stripped)).toBe(false);
+            expect(() => assertNoPreviewMarkers(stripped, 'test')).not.toThrow();
+            expect(stripped).toContain('<p>old</p>');
+        });
+
+        it('drops an unbalanced marker open tag without losing following content', () => {
+            const html = '<p><span style="background-color:rgba(210,40,40,0.28)">unclosed text</p>';
+            expect(stripPreviewMarkers(html)).toBe('<p>unclosed text</p>');
+        });
+
+        // The persisted corruption is ProseMirror's re-serialization, not the
+        // injected source form: the deletion style splits into a strike mark
+        // and a backgroundColor mark, serialized as nested spans with the
+        // line-through OUTSIDE the background span (schema mark order), and
+        // border-radius/padding are dropped.
+        describe('ProseMirror-serialized (persisted) corruption shape', () => {
+            const PM_DEL = (text: string) =>
+                `<span style="text-decoration: line-through"><span style="background-color: rgba(210, 40, 40, 0.28)">${text}</span></span>`;
+            const PM_ADD = (text: string) =>
+                `<span style="background-color: rgba(16, 150, 72, 0.28)">${text}</span>`;
+
+            it('recovers a str_replace diff without leaving strikethrough remnants', () => {
+                const html = `<div data-schema-version="9"><p>The ${PM_DEL('quick')}${PM_ADD('fast')} brown fox.</p></div>`;
+                expect(stripPreviewMarkers(html)).toBe('<div data-schema-version="9"><p>The quick brown fox.</p></div>');
+            });
+
+            it('recovers a rewrite diff (whole body struck through) to plain text', () => {
+                const html = `<div data-schema-version="9">${PM_DEL('First para.')}${PM_DEL('Second para.')}${PM_ADD('Proposed body.')}</div>`;
+                expect(stripPreviewMarkers(html)).toBe('<div data-schema-version="9">First para.Second para.</div>');
+            });
+
+            it('keeps a user strike span that does not wrap a deletion marker', () => {
+                const html = `<p><span style="text-decoration: line-through">user struck</span> and ${PM_DEL('old')}</p>`;
+                expect(stripPreviewMarkers(html)).toBe('<p><span style="text-decoration: line-through">user struck</span> and old</p>');
+            });
+
+            it('keeps a strike wrapper that contains more than the deletion span', () => {
+                const html = `<p><span style="text-decoration: line-through">prefix ${PM_DEL('old')}</span></p>`;
+                const stripped = stripPreviewMarkers(html);
+                expect(stripped).toBe('<p><span style="text-decoration: line-through">prefix old</span></p>');
+                expect(containsPreviewMarkers(stripped)).toBe(false);
+            });
+
+            it('output passes the write-side guard', () => {
+                const html = `<div data-schema-version="9"><p>${PM_DEL('a')}${PM_ADD('b')} rest</p></div>`;
+                const stripped = stripPreviewMarkers(html);
+                expect(containsPreviewMarkers(stripped)).toBe(false);
+                expect(() => assertNoPreviewMarkers(stripped, 'test')).not.toThrow();
+            });
         });
     });
 });


### PR DESCRIPTION
- Introduced `stripPreviewMarkers` function to remove diff-preview markup from notes, ensuring that persisted content is restored correctly.
- Updated `executeEditNoteAction` to repair notes containing diff-preview markup before applying edits, preventing save failures.
- Enhanced `showDiffPreview` to manage pending preview states, allowing for better control over asynchronous preview displays.
- Added tests for `stripPreviewMarkers` to validate the removal of diff-preview elements and ensure proper note recovery.