### PR TITLE
Add caret navigation functionality for range selections

### DIFF
--- a/react/components/input/lexical/LexicalEditorInput.tsx
+++ b/react/components/input/lexical/LexicalEditorInput.tsx
@@ -43,6 +43,7 @@ import { isImeKeyEvent } from '../../../utils/ime';
 import { getHost } from '../../../host';
 import { getPref } from '../../../../src/utils/prefs';
 import { registerCompositionEndDeferral, registerImeTrace } from './imeComposition';
+import { collapsesToRangeEnd } from './caretNavigation';
 import { SlashCommandHoverCardPlugin } from './SlashCommandHoverCardPlugin';
 import {
     $getFlatSelectionOffsets,
@@ -863,6 +864,18 @@ const CaretNavigationPlugin: React.FC<{
                     if (sel.focusNode === prevNode && sel.focusOffset === prevOffset) break;
                 }
             };
+            // Collapse a range selection to its leading (start) or trailing
+            // (end) edge in document order. Returns whether a range was
+            // actually collapsed.
+            const collapseRangeTo = (toEnd: boolean): boolean => {
+                if (sel.isCollapsed || sel.rangeCount === 0) return false;
+                const range = sel.getRangeAt(0);
+                try {
+                    if (toEnd) sel.collapse(range.endContainer, range.endOffset);
+                    else sel.collapse(range.startContainer, range.startOffset);
+                } catch { /* boundary point may be unresolvable */ }
+                return true;
+            };
             // Jump to the very start/end of the editable content - used for the
             // document-boundary moves Gecko's Selection.modify() can't perform.
             const docEdge = (forward: boolean) => {
@@ -896,13 +909,23 @@ const CaretNavigationPlugin: React.FC<{
                 }
             };
 
+            // An unmodified caret move out of a range selection starts from the
+            // selection's leading/trailing edge, as in the platform's native
+            // text fields. Selection.modify('move', ...) instead moves relative
+            // to the focus edge, so a forward selection (e.g. select-all) would
+            // land one step short of the intended edge.
+            const collapsedRange = alter === 'move' && collapseRangeTo(collapsesToRangeEnd(key));
+
             switch (key) {
                 case 'ArrowLeft':
                 case 'ArrowRight': {
                     const fwd = key === 'ArrowRight';
                     if (isMac && e.metaKey) modifySkippingPills(fwd ? 'forward' : 'backward', 'lineboundary');
                     else if ((isMac && e.altKey) || (!isMac && e.ctrlKey)) modifySkippingPills(fwd ? 'right' : 'left', 'word');
-                    else modifySkippingPills(fwd ? 'right' : 'left', 'character');
+                    // Plain left/right out of a range selection only collapses
+                    // to that edge - it does not additionally step a character.
+                    else if (!collapsedRange) modifySkippingPills(fwd ? 'right' : 'left', 'character');
+                    else if (isStrictlyInsidePill()) modifySkippingPills(fwd ? 'right' : 'left', 'character');
                     break;
                 }
                 case 'ArrowUp':

--- a/react/components/input/lexical/caretNavigation.ts
+++ b/react/components/input/lexical/caretNavigation.ts
@@ -1,0 +1,26 @@
+/**
+ * Which edge of a range selection an unmodified (non-extending) caret
+ * navigation key collapses to: `true` for the range's document-order end,
+ * `false` for its start.
+ *
+ * The mapping is purely logical - it is NOT mirrored for right-to-left text.
+ * That matches the host engine's native text fields, where a physical arrow
+ * key maps to a logical direction based on the writing mode only (vertical
+ * writing modes swap left/right; bidi direction does not), and the resulting
+ * collapse takes the anchor-focus range's start or end container directly.
+ * Caret *movement* is bidi-aware (hence the visual 'left'/'right' granularity
+ * used for the character and word steps), but the collapse deliberately is
+ * not; keeping both halves aligned with the native fields is what makes the
+ * editor feel consistent with the rest of the application.
+ */
+export function collapsesToRangeEnd(key: string): boolean {
+    switch (key) {
+        case 'ArrowLeft':
+        case 'ArrowUp':
+        case 'Home':
+        case 'PageUp':
+            return false;
+        default:
+            return true;
+    }
+}

--- a/tests/unit/input/caretNavigation.test.ts
+++ b/tests/unit/input/caretNavigation.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { collapsesToRangeEnd } from '../../../react/components/input/lexical/caretNavigation';
+
+describe('collapsesToRangeEnd', () => {
+    it('collapses a range to its start for backward keys', () => {
+        for (const key of ['ArrowLeft', 'ArrowUp', 'Home', 'PageUp']) {
+            expect(collapsesToRangeEnd(key)).toBe(false);
+        }
+    });
+
+    it('collapses a range to its end for forward keys', () => {
+        for (const key of ['ArrowRight', 'ArrowDown', 'End', 'PageDown']) {
+            expect(collapsesToRangeEnd(key)).toBe(true);
+        }
+    });
+
+    // The edge is chosen in document order for every key, so a right-to-left
+    // block behaves exactly like the platform's native fields: ArrowLeft out of
+    // a selection lands on the range's start, not its visually left end.
+    it('does not mirror the mapping for text direction', () => {
+        expect(collapsesToRangeEnd('ArrowLeft')).toBe(false);
+        expect(collapsesToRangeEnd('ArrowRight')).toBe(true);
+    });
+});


### PR DESCRIPTION
This commit introduces a new utility function, `collapsesToRangeEnd`, to determine which edge of a range selection an unmodified caret navigation key collapses to. The function is integrated into the `CaretNavigationPlugin` to enhance caret movement behavior in the editor.

Key changes include:
- Added `collapsesToRangeEnd` function to handle logical edge collapsing based on navigation keys.
- Updated `CaretNavigationPlugin` to utilize the new function for collapsing range selections appropriately.
- Introduced unit tests for `collapsesToRangeEnd` to ensure correct behavior for various navigation keys and text directions.

These enhancements aim to improve the user experience by aligning caret navigation with native text field behavior in the Zotero plugin.