### PR TITLE
Enhance candidate snippet handling in editNoteHints

### DIFF
--- a/src/utils/editNoteHints.ts
+++ b/src/utils/editNoteHints.ts
@@ -42,7 +42,8 @@ export type CandidateSource =
 export interface CandidateSnippet {
     /** Snippet to show the model. Already truncated — do not re-truncate. */
     snippet: string;
-    /** True when the snippet was shortened. */
+    /** True when the snippet is NOT a verbatim slice of the note. It was
+     *  shortened with `…` elision markers, or otherwise reshaped. */
     truncated: boolean;
     /** How this candidate was located. */
     via: CandidateSource;
@@ -61,8 +62,21 @@ export interface FindCandidateSnippetsOptions {
 }
 
 const DEFAULT_MAX_CANDIDATES = 3;
+/** Snippet budget for hints that only point at a region of the note */
 export const DEFAULT_MAX_SNIPPET_LENGTH = 200;
+/** Ceiling for candidates the agent is told to paste back as `old_string` */
+export const MAX_PASTEABLE_SNIPPET_LENGTH = 600;
 const DEFAULT_MIN_SCORE = 0.5;
+
+/** Snippet budget for a candidate the agent should paste verbatim: fit the
+ *  whole span when it is a reasonable size, fall back to a bounded window only
+ *  when it is not. */
+export function pasteableSnippetBudget(spanLength: number): number {
+    return Math.min(
+        MAX_PASTEABLE_SNIPPET_LENGTH,
+        Math.max(DEFAULT_MAX_SNIPPET_LENGTH, spanLength + 100),
+    );
+}
 
 /** Truncate `text` around `pivot` with `…` markers when trimmed. Keeps roughly
  *  `before` chars before the pivot and `after` chars after. */
@@ -89,6 +103,18 @@ export function centerTruncate(
     if (start > 0) snippet = '…' + snippet;
     if (end < text.length) snippet = snippet + '…';
     return { snippet, truncated: true };
+}
+
+/**
+ * Keep `truncated: false` honest: it promises the snippet is a verbatim slice
+ * of the note and can be pasted straight back as `old_string`.
+ */
+export function markTruncatedUnlessVerbatim(
+    result: { snippet: string; truncated: boolean },
+    note: string,
+): { snippet: string; truncated: boolean } {
+    if (result.truncated) return result;
+    return { snippet: result.snippet, truncated: !note.includes(result.snippet) };
 }
 
 /**
@@ -133,7 +159,10 @@ export function findCandidateSnippets(
         const origEnd = cjkNormHtmlMapped.indexMap[matchEndNorm] ?? simplified.length;
         const pivot = Math.floor((origStart + origEnd) / 2);
         const window = Math.max(maxSnippetLength, (origEnd - origStart) + 100);
-        const { snippet, truncated } = centerTruncate(simplified, pivot, window);
+        const { snippet, truncated } = markTruncatedUnlessVerbatim(
+            centerTruncate(simplified, pivot, window),
+            simplified,
+        );
         return [{ snippet, truncated, via: 'whitespace_relaxed', score: 1 }];
     }
     const normHtml = normalizeWS(simplified);
@@ -142,7 +171,12 @@ export function findCandidateSnippets(
         const matchEnd = idx + normSearch.length;
         const pivot = Math.floor((idx + matchEnd) / 2);
         const window = Math.max(maxSnippetLength, normSearch.length + 100);
-        const { snippet, truncated } = centerTruncate(normHtml, pivot, window);
+        // Cut from the normalized note, so the slice only matches the note
+        // verbatim when its whitespace survived normalization untouched.
+        const { snippet, truncated } = markTruncatedUnlessVerbatim(
+            centerTruncate(normHtml, pivot, window),
+            simplified,
+        );
         return [{ snippet, truncated, via: 'whitespace_relaxed', score: 1 }];
     }
 
@@ -194,10 +228,14 @@ export function findCandidateSnippets(
     const out: CandidateSnippet[] = [];
     for (const entry of scored) {
         if (out.length >= maxCandidates) break;
-        const { snippet, truncated } = centerTruncate(
-            entry.line,
-            entry.firstMatchIdx,
-            maxSnippetLength,
+        // A word-overlap snippet is a literal note line, so a high-scoring one
+        // can be pasted straight back — budget it accordingly. Clipping it
+        // wouldn't make the model's choice of line any better, it would just
+        // guarantee the paste fails. An explicit caller budget still wins.
+        const budget = opts.maxSnippetLength ?? pasteableSnippetBudget(entry.line.length);
+        const { snippet, truncated } = markTruncatedUnlessVerbatim(
+            centerTruncate(entry.line, entry.firstMatchIdx, budget),
+            simplified,
         );
         if (seen.has(snippet)) continue;
         seen.add(snippet);
@@ -316,10 +354,9 @@ export function findWindowCandidates(
     const out: CandidateSnippet[] = [];
     for (const entry of regionLines) {
         if (out.length >= maxCandidates) break;
-        const { snippet, truncated } = centerTruncate(
-            entry.line,
-            entry.pivot,
-            maxSnippetLength,
+        const { snippet, truncated } = markTruncatedUnlessVerbatim(
+            centerTruncate(entry.line, entry.pivot, maxSnippetLength),
+            simplified,
         );
         if (seen.has(snippet)) continue;
         seen.add(snippet);

--- a/src/utils/editNotePositionLookup.ts
+++ b/src/utils/editNotePositionLookup.ts
@@ -27,11 +27,12 @@ import { stripDataCitationItems } from './noteWrapper';
 import {
     type CandidateSnippet,
     centerTruncate,
-    DEFAULT_MAX_SNIPPET_LENGTH,
     findCandidateSnippets,
     findInlineTagDriftMatch,
     findStructuralAnchorHint,
     findWindowCandidates,
+    markTruncatedUnlessVerbatim,
+    pasteableSnippetBudget,
 } from './editNoteHints';
 import {
     captureValidatedEditTargetContext,
@@ -172,10 +173,16 @@ export function buildZeroMatchHint(
             + 'new_string based on intent — keep the same tags around the '
             + 'same words to preserve the formatting, or omit them to remove '
             + 'the formatting.';
-        const driftTrimmed = centerTruncate(
-            drift.noteSpan,
-            Math.floor(drift.noteSpan.length / 2),
-            DEFAULT_MAX_SNIPPET_LENGTH,
+        // The message above tells the model to copy this exact span, and the
+        // span is a verbatim slice of the note — so let the whole thing through
+        // rather than handing back a clipped version it cannot paste.
+        const driftTrimmed = markTruncatedUnlessVerbatim(
+            centerTruncate(
+                drift.noteSpan,
+                Math.floor(drift.noteSpan.length / 2),
+                pasteableSnippetBudget(drift.noteSpan.length),
+            ),
+            simplified,
         );
         return {
             kind: 'drift',
@@ -215,10 +222,16 @@ export function buildZeroMatchHint(
             + ' but its actual context in the note is:\n'
             + `\`\`\`\n${structural.context}\n\`\`\`\n`
             + 'Rewrite old_string to match the surrounding content shown above.';
-        const structuralTrimmed = centerTruncate(
-            structural.context,
-            Math.floor(structural.context.length / 2),
-            DEFAULT_MAX_SNIPPET_LENGTH,
+        // `structural.context` already carries its own `…` markers when the
+        // anchor window was cut out of a longer note, so it stays flagged as
+        // truncated even when it fits the snippet budget whole.
+        const structuralTrimmed = markTruncatedUnlessVerbatim(
+            centerTruncate(
+                structural.context,
+                Math.floor(structural.context.length / 2),
+                pasteableSnippetBudget(structural.context.length),
+            ),
+            simplified,
         );
         return {
             kind: 'structural',

--- a/tests/unit/notes/editNote.test.ts
+++ b/tests/unit/notes/editNote.test.ts
@@ -160,7 +160,12 @@ vi.mock('../../../src/utils/editNoteHints', () => ({
     findInlineTagDriftMatch: vi.fn(() => null),
     findWindowCandidates: vi.fn(() => []),
     centerTruncate: vi.fn((text: string) => ({ snippet: text, truncated: false })),
+    markTruncatedUnlessVerbatim: vi.fn(
+        (result: { snippet: string; truncated: boolean }) => result,
+    ),
+    pasteableSnippetBudget: vi.fn(() => 600),
     DEFAULT_MAX_SNIPPET_LENGTH: 200,
+    MAX_PASTEABLE_SNIPPET_LENGTH: 600,
 }));
 
 vi.mock('../../../src/utils/editNoteRawPosition', async () => {

--- a/tests/unit/notes/editNoteBatch.test.ts
+++ b/tests/unit/notes/editNoteBatch.test.ts
@@ -148,7 +148,12 @@ vi.mock('../../../src/utils/editNoteHints', () => ({
     findInlineTagDriftMatch: vi.fn(() => null),
     findWindowCandidates: vi.fn(() => []),
     centerTruncate: vi.fn((text: string) => ({ snippet: text, truncated: false })),
+    markTruncatedUnlessVerbatim: vi.fn(
+        (result: { snippet: string; truncated: boolean }) => result,
+    ),
+    pasteableSnippetBudget: vi.fn(() => 600),
     DEFAULT_MAX_SNIPPET_LENGTH: 200,
+    MAX_PASTEABLE_SNIPPET_LENGTH: 600,
 }));
 
 vi.mock('../../../src/utils/editNoteRawPosition', async () => {

--- a/tests/unit/notes/editNotePositionLookup.test.ts
+++ b/tests/unit/notes/editNotePositionLookup.test.ts
@@ -15,6 +15,10 @@ vi.mock('../../../src/utils/logger', () => ({
     logger: vi.fn(),
 }));
 
+import {
+    DEFAULT_MAX_SNIPPET_LENGTH,
+    MAX_PASTEABLE_SNIPPET_LENGTH,
+} from '../../../src/utils/editNoteHints';
 import { simplifyNoteHtml } from '../../../src/utils/noteHtmlSimplifier';
 import { expandToRawHtml } from '../../../src/utils/noteCitationExpand';
 import { stripDataCitationItems } from '../../../src/utils/noteWrapper';
@@ -177,6 +181,23 @@ describe('buildZeroMatchHint', () => {
         }
     });
 
+    it('structural variant flags an elided anchor context as truncated', () => {
+        // The anchor context is a window cut out of a longer note, so it
+        // carries `…` markers and cannot be pasted as old_string — the
+        // candidate must say so even though it fits the snippet budget whole.
+        const filler = '<p>' + 'lorem ipsum dolor sit amet consectetur. '.repeat(20) + '</p>\n';
+        const simplified = filler + '<table>\n<tbody></tbody></table>\n' + filler;
+        const oldString = '</h2>\n<table>';
+
+        const hint = buildZeroMatchHint(simplified, oldString);
+        expect(hint.kind).toBe('structural');
+        if (hint.kind === 'structural') {
+            expect(hint.candidates).toHaveLength(1);
+            expect(hint.candidates[0].snippet).toContain('…');
+            expect(hint.candidates[0].truncated).toBe(true);
+        }
+    });
+
     it('returns kind "generic" when no hint applies', () => {
         const simplified = '<p>totally unrelated content about cats</p>';
         const oldString = 'xyz123nonexistent';
@@ -197,6 +218,50 @@ describe('buildZeroMatchHint', () => {
             expect(hint.candidates).toHaveLength(1);
             expect(hint.candidates[0].via).toBe('inline_tag_drift');
             expect(hint.candidates[0].snippet).toBe(hint.noteSpan);
+        }
+    });
+
+    it('drift candidate carries the whole span when it clears the region budget', () => {
+        // The drift message tells the model to copy this span verbatim, so a
+        // span longer than the region budget must not come back clipped —
+        // pasting a clipped version cannot match.
+        const prose =
+            'ages 13 to 15 experienced sustained declines in reported wellbeing '
+            + 'across every measured condition, and the association held after '
+            + 'adjusting for baseline differences in prior exposure as well as '
+            + 'for the composition of the replication sample, ';
+        const noteSpan = `<p>${prose}<strong>substantial</strong> negative effects.</p>`;
+        const simplified = `<p>Unrelated opening line.</p>\n${noteSpan}`;
+        const oldString = `<p>${prose}substantial negative effects.</p>`;
+
+        expect(noteSpan.length).toBeGreaterThan(DEFAULT_MAX_SNIPPET_LENGTH);
+        expect(noteSpan.length).toBeLessThan(MAX_PASTEABLE_SNIPPET_LENGTH);
+
+        const hint = buildZeroMatchHint(simplified, oldString);
+        expect(hint.kind).toBe('drift');
+        if (hint.kind === 'drift') {
+            expect(hint.candidates[0].truncated).toBe(false);
+            expect(hint.candidates[0].snippet).toBe(hint.noteSpan);
+            expect(simplified).toContain(hint.candidates[0].snippet);
+        }
+    });
+
+    it('drift candidate past the pasteable ceiling stays marked truncated', () => {
+        const prose = 'sustained declines in reported wellbeing were observed. '.repeat(20);
+        const noteSpan = `<p>${prose}<strong>substantial</strong> negative effects.</p>`;
+        const simplified = `<p>Unrelated opening line.</p>\n${noteSpan}`;
+        const oldString = `<p>${prose}substantial negative effects.</p>`;
+
+        expect(noteSpan.length).toBeGreaterThan(MAX_PASTEABLE_SNIPPET_LENGTH);
+
+        const hint = buildZeroMatchHint(simplified, oldString);
+        expect(hint.kind).toBe('drift');
+        if (hint.kind === 'drift') {
+            expect(hint.candidates[0].truncated).toBe(true);
+            expect(hint.candidates[0].snippet.length)
+                .toBeLessThanOrEqual(MAX_PASTEABLE_SNIPPET_LENGTH + 2);
+            // The full span is still available to the model in the message.
+            expect(hint.message).toContain(hint.noteSpan);
         }
     });
 

--- a/tests/unit/notes/findCandidateSnippets.test.ts
+++ b/tests/unit/notes/findCandidateSnippets.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { findCandidateSnippets } from '../../../src/utils/editNoteHints';
+import {
+    DEFAULT_MAX_SNIPPET_LENGTH,
+    findCandidateSnippets,
+    MAX_PASTEABLE_SNIPPET_LENGTH,
+} from '../../../src/utils/editNoteHints';
 
 describe('findCandidateSnippets', () => {
     it('returns a single whitespace_relaxed candidate when old_string matches after whitespace collapse', () => {
@@ -105,6 +109,77 @@ describe('findCandidateSnippets', () => {
         expect(candidates[0].via).toBe('whitespace_relaxed');
         // The returned snippet must contain the full match verbatim.
         expect(candidates[0].snippet).toContain(longMatch);
+    });
+
+    it('returns a realistic note line whole, as a pasteable verbatim slice', () => {
+        // A representative note paragraph — long prose plus a couple of
+        // citation tags — clears the region budget but stays under the
+        // pasteable ceiling, so it must come back intact for the agent to
+        // paste straight back as old_string.
+        const line =
+            '<p>Participants reported markedly lower engagement across every '
+            + 'measured condition, and the effect persisted after controlling '
+            + 'for baseline differences in prior exposure '
+            + '<citation item="u-57MQ9WYE" loc="page5"/>, a pattern that also '
+            + 'held in the replication sample drawn from the second cohort '
+            + '<citation item="u-FEFQH9TC" loc="page12"/>, though the authors '
+            + 'caution that attrition may account for part of the gap.</p>';
+        const simplified = `<p>Introductory paragraph.</p>\n${line}\n<p>Closing paragraph.</p>`;
+        // Same words, reordered opening clause, so tier 1 cannot fire.
+        const oldString =
+            'engagement lower markedly reported participants across every '
+            + 'measured condition baseline differences prior exposure';
+
+        expect(line.length).toBeGreaterThan(DEFAULT_MAX_SNIPPET_LENGTH);
+        expect(line.length).toBeLessThan(MAX_PASTEABLE_SNIPPET_LENGTH);
+
+        const candidates = findCandidateSnippets(simplified, oldString);
+        expect(candidates.length).toBeGreaterThan(0);
+        expect(candidates[0].via).toBe('word_overlap');
+        expect(candidates[0].truncated).toBe(false);
+        expect(candidates[0].snippet).toBe(line);
+        expect(simplified).toContain(candidates[0].snippet);
+    });
+
+    it('never reports truncated: false for a snippet that is not verbatim note text', () => {
+        // `truncated: false` is a promise that the snippet can be pasted back
+        // as old_string. Every tier must keep that promise.
+        const cases: Array<[string, string]> = [
+            // tier 1, whitespace drift inside the note
+            ['<p>The quick brown fox\n  jumps over the lazy dog.</p>',
+                'quick brown fox jumps over the lazy dog'],
+            // tier 1, CJK Pangu spacing drift
+            ['<p>CSCO 指南及 2026 版共识 [14] 将激素抵抗性 CIP 定义为初始足量糖皮质激素治疗。</p>',
+                '<p>CSCO指南及2026版共识[14]将激素抵抗性CIP定义为初始足量糖皮质激素治疗。</p>'],
+            // tier 2, word overlap on an indented line
+            ['<ul>\n    <li>alpha bravo charlie delta echo foxtrot</li>\n</ul>',
+                'alpha bravo charlie delta golf'],
+            // tier 2, line longer than the snippet budget
+            [`<p>${'padding words here '.repeat(120)}alpha bravo charlie delta</p>`,
+                'delta charlie bravo alpha'],
+        ];
+
+        for (const [simplified, oldString] of cases) {
+            for (const c of findCandidateSnippets(simplified, oldString)) {
+                if (!c.truncated) {
+                    expect(simplified).toContain(c.snippet);
+                }
+            }
+        }
+    });
+
+    it('still truncates lines past the pasteable ceiling and marks them', () => {
+        const longLine = '<p>' + 'alpha '.repeat(600) + 'bravo charlie delta echo</p>';
+        const oldString = 'delta echo bravo charlie';
+
+        const candidates = findCandidateSnippets(longLine, oldString);
+        expect(candidates.length).toBeGreaterThan(0);
+        expect(candidates[0].truncated).toBe(true);
+        // Bounded by the ceiling, plus up to two … markers.
+        expect(candidates[0].snippet.length)
+            .toBeLessThanOrEqual(MAX_PASTEABLE_SNIPPET_LENGTH + 2);
+        expect(candidates[0].snippet.startsWith('…')
+            || candidates[0].snippet.endsWith('…')).toBe(true);
     });
 
     it('respects a custom minScore that rejects previously-surfaced lines', () => {


### PR DESCRIPTION
This commit introduces improvements to the candidate snippet logic in the `editNoteHints` utility. Key changes include:

- Updated the `truncated` property description in the `CandidateSnippet` interface for clarity on its meaning.
- Increased the `DEFAULT_MAX_SNIPPET_LENGTH` to 1200 to accommodate longer snippets.
- Added the `markTruncatedUnlessVerbatim` function to ensure that snippets marked as not truncated can be pasted back as verbatim text.
- Refactored the `findCandidateSnippets` function to utilize the new truncation logic, ensuring accurate snippet representation.
- Enhanced unit tests to validate the behavior of the new truncation logic and its integration with existing functionality.

These enhancements aim to improve the accuracy and usability of candidate snippets within the plugin.