### PR TITLE
Enhance search functionality with item category filtering

### DIFF
--- a/react/utils/searchTools.ts
+++ b/react/utils/searchTools.ts
@@ -26,7 +26,11 @@ export interface SearchItemsByMetadataOptions {
     collection_key?: string;
     /** If true, search recursively in subcollections */
     recursive?: boolean;
-    /** "all" for AND logic, "any" for OR logic */
+    /**
+     * "all" for AND logic, "any" for OR logic.
+     *
+     * Use "any" only when every condition below is genuinely optional.
+     */
     join_mode?: 'all' | 'any';
     /** Maximum results to return */
     limit?: number;

--- a/src/services/agentDataProvider/handleZoteroSearchRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroSearchRequest.ts
@@ -22,28 +22,63 @@ import { libraryRefForLibraryID, modelObjectId } from '../../utils/libraryIdenti
 import { validateLibraryAccess, extractYear, formatCreatorsString, getAttachmentInfoForItem } from './utils';
 
 
-async function filterOutAnnotationItemIds(itemIds: number[]): Promise<number[]> {
-    if (itemIds.length === 0) return itemIds;
+/**
+ * How each `item_category` maps onto a set of Zotero item types.
+ *
+ * A Map, not an object literal: `item_category` arrives over the wire, and a
+ * plain-object lookup would resolve inherited keys ("constructor", "toString")
+ * to truthy non-filters. Unrecognized categories must degrade to "no filter".
+ */
+const ITEM_CATEGORY_TYPE_FILTERS = new Map<string, { itemTypes: string[]; mode: 'include' | 'exclude' }>([
+    ['regular', { itemTypes: ['attachment', 'note', 'annotation'], mode: 'exclude' }],
+    ['attachment', { itemTypes: ['attachment'], mode: 'include' }],
+    ['note', { itemTypes: ['note'], mode: 'include' }],
+    // 'all' is absent because it filters nothing; 'annotation' is absent because
+    // it returns early (zotero_search cannot return annotations at all).
+]);
 
-    const annotationItemTypeID = Zotero.ItemTypes.getID('annotation');
-    const returnableItemIds = new Set<number>();
+/**
+ * Keep (`include`) or drop (`exclude`) the given itemIDs by item type,
+ * preserving the incoming order. Chunked to stay under SQLite's bound-variable
+ * limit.
+ */
+async function filterItemIdsByItemType(
+    itemIds: number[],
+    itemTypes: string[],
+    mode: 'include' | 'exclude',
+): Promise<number[]> {
+    if (itemIds.length === 0 || itemTypes.length === 0) return itemIds;
+
+    const itemTypeIDs = itemTypes
+        .map(itemType => Zotero.ItemTypes.getID(itemType))
+        .filter((id): id is number => typeof id === 'number');
+    if (itemTypeIDs.length === 0) return itemIds;
+
+    const comparison = mode === 'include' ? 'IN' : 'NOT IN';
+    const typePlaceholders = itemTypeIDs.map(() => '?').join(', ');
+    const matchingItemIds = new Set<number>();
     const chunkSize = 500;
 
     for (let i = 0; i < itemIds.length; i += chunkSize) {
         const chunk = itemIds.slice(i, i + chunkSize);
-        const placeholders = chunk.map(() => '?').join(', ');
+        const idPlaceholders = chunk.map(() => '?').join(', ');
         await Zotero.DB.queryAsync(
-            `SELECT itemID FROM items WHERE itemID IN (${placeholders}) AND itemTypeID != ?`,
-            [...chunk, annotationItemTypeID],
+            `SELECT itemID FROM items WHERE itemID IN (${idPlaceholders}) `
+                + `AND itemTypeID ${comparison} (${typePlaceholders})`,
+            [...chunk, ...itemTypeIDs],
             {
                 onRow: (row: any) => {
-                    returnableItemIds.add(row.getResultByIndex(0));
+                    matchingItemIds.add(row.getResultByIndex(0));
                 },
             },
         );
     }
 
-    return itemIds.filter(id => returnableItemIds.has(id));
+    return itemIds.filter(id => matchingItemIds.has(id));
+}
+
+function filterOutAnnotationItemIds(itemIds: number[]): Promise<number[]> {
+    return filterItemIdsByItemType(itemIds, ['annotation'], 'exclude');
 }
 
 
@@ -71,6 +106,26 @@ export async function handleZoteroSearchRequest(
             };
         }
         const library = validation.library!;
+
+        const anyItemTypeCondition = request.conditions.some((condition) => condition.field === 'itemType');
+        const itemCategory = request.item_category ?? 'regular';
+
+        // zotero_search has no annotation result shape, so annotations are always
+        // dropped from the result set. An annotation-only search can therefore
+        // never return a row: settle it here rather than running the search and
+        // handing back an empty page the model would read as "no matches".
+        if (!anyItemTypeCondition && itemCategory === 'annotation') {
+            return {
+                type: 'zotero_search',
+                request_id: request.request_id,
+                items: [],
+                total_count: 0,
+                warnings: [
+                    "item_category='annotation' returns no results because zotero_search cannot return annotations. "
+                        + 'Use find_annotations to search annotation text and comments.',
+                ],
+            };
+        }
 
         // Create search object
         const search = new Zotero.Search() as unknown as ZoteroSearchWritable;
@@ -129,24 +184,27 @@ export async function handleZoteroSearchRequest(
             }
         }
 
-        // Item category filter
-        const anyItemTypeCondition = request.conditions.some((condition) => condition.field === 'itemType');
-        if (!anyItemTypeCondition) {
-            const itemCategory = request.item_category ?? 'regular';
-            if (itemCategory === 'regular') {
-                search.addCondition('itemType', 'isNot', 'attachment');
-                search.addCondition('itemType', 'isNot', 'note');
-                search.addCondition('itemType', 'isNot', 'annotation');
-            } else if (itemCategory === 'attachment') {
-                search.addCondition('itemType', 'is', 'attachment');
-            } else if (itemCategory === 'note') {
-                search.addCondition('itemType', 'is', 'note');
-            } else if (itemCategory === 'annotation') {
-                search.addCondition('itemType', 'is', 'annotation');
+        // Item category filter.
+        //
+        // Zotero ORs together every non-special condition when joinMode is 'any';
+        // only the special conditions (joinMode/noChildren/recursive/…) and the
+        // search's libraryID *property* — set above, not added as a condition —
+        // are ANDed outside the join. Adding itemType conditions there would make
+        // the category an always-true disjunct — e.g. "isNot attachment OR isNot
+        // note" holds for every item — so an 'any' search would silently match
+        // the whole library. For 'any' the category is therefore applied as a
+        // post-filter on the matched itemIDs instead; 'all' keeps the
+        // condition-based filter so Zotero's SQL does the work.
+        const categoryFilter = anyItemTypeCondition ? undefined : ITEM_CATEGORY_TYPE_FILTERS.get(itemCategory);
+        const categoryNeedsPostFilter = request.join_mode === 'any';
+
+        if (categoryFilter && !categoryNeedsPostFilter) {
+            const operator = categoryFilter.mode === 'include' ? 'is' : 'isNot';
+            for (const itemType of categoryFilter.itemTypes) {
+                search.addCondition('itemType', operator, itemType);
             }
-            // 'all' = no filter, do nothing
         }
-        
+
         // Search recursively within collections (only affects collectionID conditions)
         if (request.recursive) {
             search.addCondition('recursive', 'true', '');
@@ -159,6 +217,13 @@ export async function handleZoteroSearchRequest(
         
         // Execute search
         let itemIds = await search.search();
+
+        // Apply the item category as a post-filter for 'any' searches (see above).
+        // Runs before every other filter so the cheap itemType query shrinks the
+        // set before items get loaded, and before total_count/pagination.
+        if (categoryFilter && categoryNeedsPostFilter) {
+            itemIds = await filterItemIdsByItemType(itemIds, categoryFilter.itemTypes, categoryFilter.mode);
+        }
 
         // Post-filter by attachment status if requested
         if (request.has_attachments != null) {
@@ -185,12 +250,10 @@ export async function handleZoteroSearchRequest(
         // zotero_search has no annotation result shape. When annotations can
         // reach the result set, drop them BEFORE counting and paginating, so
         // total_count and page boundaries reflect only returnable items.
-        const itemCategory = request.item_category ?? 'regular';
-        const mayContainAnnotations =
-            request.join_mode === 'any'
-            || anyItemTypeCondition
-            || itemCategory === 'all'
-            || itemCategory === 'annotation';
+        // A category filter has already excluded them (as conditions or as the
+        // post-filter above); the remaining cases — an explicit itemType
+        // condition, 'all', or an unrecognized category — still need this pass.
+        const mayContainAnnotations = !categoryFilter;
         if (mayContainAnnotations) {
             itemIds = await filterOutAnnotationItemIds(itemIds);
         }

--- a/tests/live/tidyUpExplore.live.test.ts
+++ b/tests/live/tidyUpExplore.live.test.ts
@@ -129,25 +129,41 @@ describe('tidy-up explore recipes', () => {
             expect(res.total_count).toBeLessThanOrEqual(all.total_count);
         }, 30000);
 
-        it('join_mode=any with a category filter is NOT used (it inflates the count past the whole library)', async () => {
-            // The category filter shares the global join mode with user
-            // conditions, so `any` can include non-regular items in the count.
-            const regularOnly = await search([]);
-            const inflated = await post<SearchResponse>(
+        it('join_mode=any with a category filter stays within the category', async () => {
+            // Regression guard: Zotero ORs every non-special condition together
+            // under joinMode 'any', so applying item_category as search
+            // conditions made it an always-true disjunct that matched the whole
+            // library. The category is now a post-filter, so an `any` search can
+            // never exceed the number of items in that category.
+            const noDoi = { field: 'DOI', operator: 'doesNotContain', value: '' };
+            const noAbstract = { field: 'abstractNote', operator: 'doesNotContain', value: '' };
+
+            const allRegular = await search([]);
+            const anyOfBoth = await post<SearchResponse>(
                 '/beaver/library/search',
                 {
                     library_id: USER_LIBRARY_ID,
                     item_category: 'regular',
                     join_mode: 'any',
-                    conditions: [
-                        { field: 'DOI', operator: 'doesNotContain', value: '' },
-                        { field: 'abstractNote', operator: 'doesNotContain', value: '' },
-                    ],
+                    conditions: [noDoi, noAbstract],
                     limit: 1,
                 },
                 { timeout: 30000 },
             );
-            expect(inflated.total_count).toBeGreaterThan(regularOnly.total_count);
+
+            expect(anyOfBoth.error).toBeFalsy();
+            expect(anyOfBoth.total_count).toBeLessThanOrEqual(allRegular.total_count);
+
+            // ...and it is a genuine union: at least as large as either branch
+            // alone, and no larger than their sum.
+            const doiOnly = await search([noDoi]);
+            const abstractOnly = await search([noAbstract]);
+            expect(anyOfBoth.total_count).toBeGreaterThanOrEqual(
+                Math.max(doiOnly.total_count, abstractOnly.total_count),
+            );
+            expect(anyOfBoth.total_count).toBeLessThanOrEqual(
+                doiOnly.total_count + abstractOnly.total_count,
+            );
         }, 30000);
     });
 

--- a/tests/live/zoteroSearchJoinModeAny.live.test.ts
+++ b/tests/live/zoteroSearchJoinModeAny.live.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Live coverage for `item_category` under `join_mode="any"` in zotero_search
+ * (`/beaver/library/search`).
+ *
+ * Zotero ORs together every non-special condition when joinMode is 'any', so
+ * expressing `item_category` as itemType conditions turned it into an
+ * always-true disjunct ("isNot attachment OR isNot note" holds for every item)
+ * and an `any` search silently matched the entire library. The category is now
+ * applied as a post-filter on the matched itemIDs instead.
+ *
+ * The assertions below are data-independent invariants, so they hold against
+ * any library:
+ *   - with a SINGLE condition, `any` and `all` must produce identical results;
+ *   - an `any` search can never return more than the whole category;
+ *   - results never carry a result_type outside the requested category.
+ *
+ * Prerequisites:
+ *   - Dev build running against Zotero (npm start) with the library management
+ *     endpoints registered.
+ *   - Authenticated, with a synced user library (library_id 1).
+ *
+ * Run: npm run test:live -- zoteroSearchJoinModeAny
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
+import { post } from '../helpers/zoteroHttpClient';
+
+const USER_LIBRARY_ID = 1;
+
+/** Matches a broad but bounded slice of any real library. */
+const COMMON_TERM = 'a';
+/** Same, for note bodies — notes are matched on content, not title. */
+const COMMON_NOTE_TERM = 'the';
+/** Matches nothing — the single-condition proof from the bug report. */
+const NONSENSE_TERM = 'zzzz-no-such-term-zzzz';
+
+let available = false;
+
+beforeAll(async () => {
+    available = await isZoteroAvailable();
+});
+
+interface SearchResultItem {
+    item_id?: string;
+    attachment_id?: string;
+    result_type?: string;
+}
+
+interface SearchResponse {
+    items: SearchResultItem[];
+    total_count: number;
+    warnings?: string[];
+    error?: string | null;
+    error_code?: string | null;
+}
+
+async function search(options: {
+    conditions: Array<Record<string, unknown>>;
+    join_mode: 'all' | 'any';
+    item_category: string;
+    include_children?: boolean;
+    limit?: number;
+}): Promise<SearchResponse> {
+    return post<SearchResponse>(
+        '/beaver/library/search',
+        {
+            library_id: USER_LIBRARY_ID,
+            conditions: options.conditions,
+            join_mode: options.join_mode,
+            item_category: options.item_category,
+            include_children: options.include_children ?? true,
+            limit: options.limit ?? 50,
+        },
+        { timeout: 30000 },
+    );
+}
+
+const titleContains = (value: string) => ({ field: 'title', operator: 'contains', value });
+const noteContains = (value: string) => ({ field: 'note', operator: 'contains', value });
+
+/**
+ * A condition per category that actually matches rows in that category.
+ * Notes carry no `title` field, so a title condition would match zero notes and
+ * every assertion over the result rows would pass vacuously.
+ * `resultType` is null where the response mixes shapes (`all`).
+ */
+const MATCHING_CASES: Array<{ item_category: string; condition: Record<string, unknown>; resultType: string | null }> = [
+    { item_category: 'regular', condition: titleContains(COMMON_TERM), resultType: 'regular' },
+    { item_category: 'note', condition: noteContains(COMMON_NOTE_TERM), resultType: 'note' },
+    { item_category: 'attachment', condition: titleContains(COMMON_TERM), resultType: 'attachment' },
+    { item_category: 'all', condition: titleContains(COMMON_TERM), resultType: null },
+];
+
+/** Stable identity across the regular/note (item_id) and attachment shapes. */
+const idsOf = (res: SearchResponse) =>
+    res.items.map(item => item.item_id ?? item.attachment_id ?? '');
+
+describe('zotero_search item_category under join_mode="any"', () => {
+    beforeEach((ctx) => {
+        skipIfNoZotero(ctx, available);
+    });
+
+    describe('a single condition makes join_mode irrelevant', () => {
+        for (const { item_category, condition } of MATCHING_CASES) {
+            it(`any === all for item_category="${item_category}"`, async () => {
+                const conditions = [condition];
+                const anyMode = await search({ conditions, join_mode: 'any', item_category });
+                const allMode = await search({ conditions, join_mode: 'all', item_category });
+
+                expect(anyMode.error).toBeFalsy();
+                expect(allMode.error).toBeFalsy();
+                // Guard against a vacuous pass: both sides must actually match.
+                expect(anyMode.total_count).toBeGreaterThan(0);
+                expect(anyMode.total_count).toBe(allMode.total_count);
+                expect(idsOf(anyMode)).toEqual(idsOf(allMode));
+            }, 30000);
+        }
+    });
+
+    it('returns nothing when the only condition matches nothing', async () => {
+        // The production symptom: this used to return the whole library.
+        const res = await search({
+            conditions: [titleContains(NONSENSE_TERM)],
+            join_mode: 'any',
+            item_category: 'regular',
+        });
+
+        expect(res.error).toBeFalsy();
+        expect(res.total_count).toBe(0);
+        expect(res.items).toEqual([]);
+    }, 30000);
+
+    it('never exceeds the size of the requested category', async () => {
+        const wholeCategory = await search({
+            conditions: [],
+            join_mode: 'all',
+            item_category: 'regular',
+            limit: 1,
+        });
+        const anyMode = await search({
+            conditions: [titleContains(COMMON_TERM), titleContains(NONSENSE_TERM)],
+            join_mode: 'any',
+            item_category: 'regular',
+            limit: 1,
+        });
+
+        expect(anyMode.error).toBeFalsy();
+        expect(anyMode.total_count).toBeLessThanOrEqual(wholeCategory.total_count);
+    }, 30000);
+
+    // The production trigger: a long OR-list of conditions plus a category.
+    describe('an OR-list stays inside the requested category', () => {
+        for (const { item_category, condition, resultType } of MATCHING_CASES) {
+            if (!resultType) continue;
+            it(`item_category="${item_category}" yields only ${resultType} rows`, async () => {
+                // One matching branch OR one that matches nothing — the union is
+                // exactly the matching branch, so 'all' over that branch alone is
+                // the expected answer.
+                const conditions = [condition, titleContains(NONSENSE_TERM)];
+                const res = await search({ conditions, join_mode: 'any', item_category });
+                const expected = await search({ conditions: [condition], join_mode: 'all', item_category });
+
+                expect(res.error).toBeFalsy();
+                // Guard against a vacuous pass: an empty page proves nothing
+                // about which rows survive the category filter.
+                expect(res.items.length).toBeGreaterThan(0);
+                expect(res.items.map(item => item.result_type)).toEqual(
+                    res.items.map(() => resultType),
+                );
+                // Catches a category leak that inflates the count without
+                // changing row types (e.g. "itemType is note" ORing in every note).
+                expect(res.total_count).toBe(expected.total_count);
+            }, 30000);
+        }
+    });
+
+    it('still ORs the caller conditions together', async () => {
+        const left = titleContains(COMMON_TERM);
+        const right = titleContains('e');
+
+        const leftOnly = await search({ conditions: [left], join_mode: 'any', item_category: 'regular', limit: 1 });
+        const rightOnly = await search({ conditions: [right], join_mode: 'any', item_category: 'regular', limit: 1 });
+        const union = await search({ conditions: [left, right], join_mode: 'any', item_category: 'regular', limit: 1 });
+        const intersection = await search({ conditions: [left, right], join_mode: 'all', item_category: 'regular', limit: 1 });
+
+        expect(union.error).toBeFalsy();
+        // A union is at least either branch and at most their sum...
+        expect(union.total_count).toBeGreaterThanOrEqual(Math.max(leftOnly.total_count, rightOnly.total_count));
+        expect(union.total_count).toBeLessThanOrEqual(leftOnly.total_count + rightOnly.total_count);
+        // ...and never smaller than the corresponding intersection.
+        expect(union.total_count).toBeGreaterThanOrEqual(intersection.total_count);
+    }, 30000);
+
+    it('drops annotations for item_category="all"', async () => {
+        const res = await search({
+            conditions: [titleContains(COMMON_TERM)],
+            join_mode: 'any',
+            item_category: 'all',
+        });
+
+        expect(res.error).toBeFalsy();
+        expect(res.items.some(item => item.result_type === 'annotation')).toBe(false);
+    }, 30000);
+});

--- a/tests/unit/handlers/zoteroSearch.test.ts
+++ b/tests/unit/handlers/zoteroSearch.test.ts
@@ -47,10 +47,11 @@ vi.mock('../../../src/utils/zoteroSerializers', async (importOriginal) => {
     };
 });
 
+import type { WSZoteroSearchResponse } from '../../../src/services/agentProtocol';
 import { handleZoteroSearchRequest } from '../../../src/services/agentDataProvider/handleZoteroSearchRequest';
 import { getAttachmentInfoForItem, validateLibraryAccess } from '../../../src/services/agentDataProvider/utils';
 
-type MockItem = Partial<Zotero.Item> & {
+type MockItem = {
     id: number;
     key: string;
     libraryID: number;
@@ -58,7 +59,7 @@ type MockItem = Partial<Zotero.Item> & {
     isNote: ReturnType<typeof vi.fn>;
     isAttachment: ReturnType<typeof vi.fn>;
     isRegularItem: ReturnType<typeof vi.fn>;
-};
+} & Record<string, any>;
 
 function makeItem(overrides: Partial<MockItem> = {}): MockItem {
     const itemType = overrides.itemType ?? 'journalArticle';
@@ -82,12 +83,39 @@ function makeItem(overrides: Partial<MockItem> = {}): MockItem {
     };
 }
 
+type MockSearchInstance = { addCondition: ReturnType<typeof vi.fn>; search: ReturnType<typeof vi.fn> };
+
+/** Stable fake itemTypeIDs so the DB mock can map params back to item types. */
+const ITEM_TYPE_IDS: Record<string, number> = {
+    journalArticle: 2,
+    book: 3,
+    note: 10,
+    attachment: 11,
+    annotation: 12,
+};
+
 describe('handleZoteroSearchRequest', () => {
     const itemsById = new Map<number, MockItem>();
+    let searchResultIds: number[] = [1, 2, 3, 4];
+    let lastSearch: MockSearchInstance | null = null;
+
+    /** Conditions added to the Zotero search, as [field, operator, value] tuples. */
+    const addedConditions = () =>
+        (lastSearch?.addCondition.mock.calls ?? []).map(call => call.slice(0, 3));
+
+    // Result rows are a discriminated union: attachments carry attachment_id,
+    // every other shape carries item_id. Narrow on result_type rather than
+    // casting, so a shape change surfaces here instead of silently reading
+    // undefined.
+    const itemIds = (response: WSZoteroSearchResponse) =>
+        response.items.map(item => (item.result_type === 'attachment' ? undefined : item.item_id));
+    const attachmentIds = (response: WSZoteroSearchResponse) =>
+        response.items.map(item => (item.result_type === 'attachment' ? item.attachment_id : undefined));
 
     beforeEach(() => {
         vi.clearAllMocks();
         itemsById.clear();
+        searchResultIds = [1, 2, 3, 4];
 
         vi.mocked(validateLibraryAccess).mockReturnValue({
             valid: true,
@@ -106,13 +134,17 @@ describe('handleZoteroSearchRequest', () => {
             annotations_count: item.isFileAttachment?.() ? item.getAnnotations?.().length ?? 0 : 0,
         } as any));
 
-        class MockSearch {
+        lastSearch = null;
+        // Records the instance so tests can assert which conditions the handler
+        // handed to Zotero (the crux of the join-mode fix).
+        (globalThis as any).Zotero.Search = class MockSearch {
             libraryID = 1;
             addCondition = vi.fn();
-            search = vi.fn(async () => [1, 2, 3, 4]);
-        }
-
-        (globalThis as any).Zotero.Search = MockSearch;
+            search = vi.fn(async () => searchResultIds);
+            constructor() {
+                lastSearch = this as unknown as MockSearchInstance;
+            }
+        };
         (globalThis as any).Zotero.Items = {
             getAsync: vi.fn(async (ids: number | number[]) => {
                 if (!Array.isArray(ids)) {
@@ -125,14 +157,22 @@ describe('handleZoteroSearchRequest', () => {
             loadDataTypes: vi.fn(async () => undefined),
         };
         (globalThis as any).Zotero.ItemTypes = {
-            getID: vi.fn((itemType: string) => itemType === 'annotation' ? 1 : 0),
+            getID: vi.fn((itemType: string) => ITEM_TYPE_IDS[itemType]),
         };
+        // Stands in for `SELECT itemID FROM items WHERE itemID IN (...) AND
+        // itemTypeID [NOT] IN (...)`: the leading params are itemIDs, the
+        // trailing ones itemTypeIDs, split by the placeholder counts in the SQL.
         (globalThis as any).Zotero.DB = {
-            queryAsync: vi.fn(async (_sql: string, params: any[], options: { onRow: (row: any) => void }) => {
-                const annotationItemTypeID = params[params.length - 1];
-                for (const id of params.slice(0, -1)) {
+            queryAsync: vi.fn(async (sql: string, params: any[], options: { onRow: (row: any) => void }) => {
+                const idCount = (sql.match(/itemID IN \(([^)]*)\)/)![1].match(/\?/g) ?? []).length;
+                const ids: number[] = params.slice(0, idCount);
+                const typeIDs: number[] = params.slice(idCount);
+                const exclude = /itemTypeID NOT IN/.test(sql);
+                for (const id of ids) {
                     const item = itemsById.get(id);
-                    if (item && item.itemType !== 'annotation' && annotationItemTypeID === 1) {
+                    if (!item) continue;
+                    const inSet = typeIDs.includes(ITEM_TYPE_IDS[item.itemType]);
+                    if (exclude ? !inSet : inSet) {
                         options.onRow({ getResultByIndex: () => id });
                     }
                 }
@@ -180,10 +220,11 @@ describe('handleZoteroSearchRequest', () => {
 
         expect(response.error).toBeUndefined();
         expect(response.total_count).toBe(3);
-        expect(response.items.map(item => item.item_id)).toEqual(['1-FIRST', '1-THIRD']);
+        expect(itemIds(response)).toEqual(['1-FIRST', '1-THIRD']);
     });
 
     it('filters annotations before pagination for any-mode regular searches', async () => {
+        searchResultIds = [1, 2, 3];
         itemsById.set(1, makeItem({
             id: 1,
             key: 'FIRST',
@@ -217,10 +258,273 @@ describe('handleZoteroSearchRequest', () => {
 
         expect(response.error).toBeUndefined();
         expect(response.total_count).toBe(2);
-        expect(response.items.map(item => item.item_id)).toEqual(['1-FIRST', '1-THIRD']);
+        expect(itemIds(response)).toEqual(['1-FIRST', '1-THIRD']);
         expect((globalThis as any).Zotero.DB.queryAsync).toHaveBeenCalledOnce();
         expect((globalThis as any).Zotero.Items.getAsync).not.toHaveBeenCalledWith([1, 2, 3]);
     });
+
+    // Regression guard: Zotero ORs non-special conditions together under
+    // joinMode 'any', so itemType conditions there match the entire library.
+    describe('item_category under join_mode="any"', () => {
+        function seedMixedLibrary() {
+            searchResultIds = [1, 2, 3, 4];
+            itemsById.set(1, makeItem({
+                id: 1,
+                key: 'ARTICLE',
+                getField: vi.fn((field: string) => field === 'title' ? 'Article' : ''),
+                getDisplayTitle: vi.fn(() => 'Article'),
+            }));
+            itemsById.set(2, makeItem({
+                id: 2,
+                key: 'NOTE',
+                itemType: 'note',
+                getNote: vi.fn(() => '<p>Note body</p>'),
+                getNoteTitle: vi.fn(() => 'Note'),
+                getDisplayTitle: vi.fn(() => 'Note'),
+            } as Partial<MockItem>));
+            itemsById.set(3, makeItem({
+                id: 3,
+                key: 'ANNOT',
+                itemType: 'annotation',
+                isAnnotation: vi.fn(() => true),
+            } as Partial<MockItem>));
+            itemsById.set(4, makeItem({
+                id: 4,
+                key: 'BOOK',
+                itemType: 'book',
+                getField: vi.fn((field: string) => field === 'title' ? 'Book' : ''),
+                getDisplayTitle: vi.fn(() => 'Book'),
+            }));
+        }
+
+        const baseRequest = {
+            event: 'zotero_search_request',
+            request_id: 'req-any',
+            conditions: [{ field: 'title', operator: 'contains', value: 'search term' }],
+            join_mode: 'any',
+            include_children: true,
+            recursive: false,
+            limit: 50,
+            offset: 0,
+        } as const;
+
+        it('does not add itemType conditions to the search', async () => {
+            seedMixedLibrary();
+
+            await handleZoteroSearchRequest({ ...baseRequest, item_category: 'regular' } as any);
+
+            expect(addedConditions()).not.toContainEqual(
+                expect.arrayContaining(['itemType']),
+            );
+        });
+
+        it('post-filters to regular items, so total_count excludes notes and annotations', async () => {
+            seedMixedLibrary();
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                item_category: 'regular',
+            } as any);
+
+            expect(response.error).toBeUndefined();
+            expect(response.total_count).toBe(2);
+            expect(itemIds(response)).toEqual(['1-ARTICLE', '1-BOOK']);
+        });
+
+        it('post-filters to notes for item_category="note"', async () => {
+            seedMixedLibrary();
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                item_category: 'note',
+            } as any);
+
+            expect(response.error).toBeUndefined();
+            expect(response.total_count).toBe(1);
+            expect(itemIds(response)).toEqual(['1-NOTE']);
+        });
+
+        it('post-filters to attachments for item_category="attachment"', async () => {
+            seedMixedLibrary();
+            itemsById.set(4, makeItem({
+                id: 4,
+                key: 'ATTACH',
+                itemType: 'attachment',
+                isFileAttachment: vi.fn(() => true),
+                getAnnotations: vi.fn(() => []),
+                getDisplayTitle: vi.fn(() => 'Attachment'),
+            } as Partial<MockItem>));
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                item_category: 'attachment',
+            } as any);
+
+            expect(response.error).toBeUndefined();
+            expect(response.total_count).toBe(1);
+            expect(attachmentIds(response)).toEqual(['1-ATTACH']);
+        });
+
+        it('leaves item_category="all" unfiltered apart from annotations', async () => {
+            seedMixedLibrary();
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                item_category: 'all',
+            } as any);
+
+            expect(response.error).toBeUndefined();
+            expect(response.total_count).toBe(3);
+            expect(itemIds(response)).toEqual(['1-ARTICLE', '1-NOTE', '1-BOOK']);
+            expect(addedConditions()).not.toContainEqual(expect.arrayContaining(['itemType']));
+        });
+
+        it('applies the post-filter before pagination', async () => {
+            seedMixedLibrary();
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                item_category: 'regular',
+                limit: 1,
+                offset: 0,
+            } as any);
+
+            // Without pre-pagination filtering the page would be the note/annotation.
+            expect(response.total_count).toBe(2);
+            expect(itemIds(response)).toEqual(['1-ARTICLE']);
+        });
+
+        it('skips the category filter when the request supplies its own itemType condition', async () => {
+            seedMixedLibrary();
+
+            const response = await handleZoteroSearchRequest({
+                ...baseRequest,
+                conditions: [{ field: 'itemType', operator: 'is', value: 'book' }],
+                item_category: 'regular',
+            } as any);
+
+            // The caller's itemType condition wins; annotations are still dropped
+            // because zotero_search has no annotation result shape.
+            expect(addedConditions()).toContainEqual(['itemType', 'is', 'book']);
+            expect(response.total_count).toBe(3);
+            expect(itemIds(response)).toEqual(['1-ARTICLE', '1-NOTE', '1-BOOK']);
+        });
+    });
+
+    it('keeps the condition-based category filter for join_mode="all"', async () => {
+        searchResultIds = [1];
+        itemsById.set(1, makeItem({ id: 1, key: 'ARTICLE' }));
+
+        await handleZoteroSearchRequest({
+            event: 'zotero_search_request',
+            request_id: 'req-all',
+            conditions: [{ field: 'title', operator: 'contains', value: 'search term' }],
+            join_mode: 'all',
+            item_category: 'regular',
+            include_children: true,
+            recursive: false,
+            limit: 50,
+            offset: 0,
+        });
+
+        expect(addedConditions()).toEqual(
+            expect.arrayContaining([
+                ['itemType', 'isNot', 'attachment'],
+                ['itemType', 'isNot', 'note'],
+                ['itemType', 'isNot', 'annotation'],
+            ]),
+        );
+        // Zotero's SQL already applied the filter — no post-filter query needed.
+        expect((globalThis as any).Zotero.DB.queryAsync).not.toHaveBeenCalled();
+    });
+
+    describe('item_category="annotation"', () => {
+        it.each(['any', 'all'] as const)(
+            'returns an explanatory warning without searching (join_mode="%s")',
+            async (join_mode) => {
+                itemsById.set(1, makeItem({ id: 1, key: 'ARTICLE' }));
+
+                const response = await handleZoteroSearchRequest({
+                    event: 'zotero_search_request',
+                    request_id: `req-annot-${join_mode}`,
+                    conditions: [{ field: 'title', operator: 'contains', value: 'search term' }],
+                    join_mode,
+                    item_category: 'annotation',
+                    include_children: true,
+                    recursive: false,
+                    limit: 50,
+                    offset: 0,
+                } as any);
+
+                expect(response.error).toBeUndefined();
+                expect(response.total_count).toBe(0);
+                expect(response.items).toEqual([]);
+                // Point the agent at the tool that can actually answer this.
+                expect(response.warnings?.join(' ')).toContain('find_annotations');
+                // The result is knowable up front — no search, no itemType scans.
+                expect(lastSearch).toBeNull();
+                expect((globalThis as any).Zotero.DB.queryAsync).not.toHaveBeenCalled();
+            },
+        );
+
+        it('defers to an explicit itemType condition instead of short-circuiting', async () => {
+            searchResultIds = [1];
+            itemsById.set(1, makeItem({ id: 1, key: 'BOOK', itemType: 'book' }));
+
+            const response = await handleZoteroSearchRequest({
+                event: 'zotero_search_request',
+                request_id: 'req-annot-override',
+                conditions: [{ field: 'itemType', operator: 'is', value: 'book' }],
+                join_mode: 'any',
+                item_category: 'annotation',
+                include_children: true,
+                recursive: false,
+                limit: 50,
+                offset: 0,
+            } as any);
+
+            expect(response.warnings).toBeUndefined();
+            expect(addedConditions()).toContainEqual(['itemType', 'is', 'book']);
+            expect(itemIds(response)).toEqual(['1-BOOK']);
+        });
+    });
+
+    // item_category arrives over the wire, so the category lookup must not
+    // resolve inherited object keys ("constructor", "toString") to a bogus
+    // filter. Unrecognized values degrade to "no category filter".
+    describe.each(['constructor', 'toString', 'hasOwnProperty', 'unknown-category'])(
+        'item_category="%s"',
+        (item_category) => {
+            it.each(['any', 'all'] as const)('degrades to no filter under join_mode="%s"', async (join_mode) => {
+                searchResultIds = [1, 2];
+                itemsById.set(1, makeItem({ id: 1, key: 'ARTICLE' }));
+                itemsById.set(2, makeItem({
+                    id: 2,
+                    key: 'ANNOT',
+                    itemType: 'annotation',
+                    isAnnotation: vi.fn(() => true),
+                }));
+
+                const response = await handleZoteroSearchRequest({
+                    event: 'zotero_search_request',
+                    request_id: `req-${item_category}-${join_mode}`,
+                    conditions: [{ field: 'title', operator: 'contains', value: 'search term' }],
+                    join_mode,
+                    item_category,
+                    include_children: true,
+                    recursive: false,
+                    limit: 50,
+                    offset: 0,
+                } as any);
+
+                expect(response.error).toBeUndefined();
+                expect(addedConditions()).not.toContainEqual(expect.arrayContaining(['itemType']));
+                // Annotations are still dropped — there is no result shape for them.
+                expect(response.total_count).toBe(1);
+                expect(itemIds(response)).toEqual(['1-ARTICLE']);
+            });
+        },
+    );
 
     it('returns attachment rows with attachment_id and resolver metadata', async () => {
         const parent = makeItem({


### PR DESCRIPTION
This commit improves the search functionality by refining how item categories are handled under the `join_mode="any"` condition. Key changes include:

- Introduced a new post-filtering mechanism for item categories to prevent unintended matches across the entire library.
- Updated the `handleZoteroSearchRequest` function to apply item category filters correctly, ensuring that searches return results strictly within the specified category.
- Added tests to validate the behavior of the new filtering logic, ensuring that `any` searches do not exceed the size of the requested category.

These enhancements aim to provide more accurate search results and improve the overall user experience when filtering items in Zotero.