### PR TITLE
test(live): make the live suite deterministic (exclusions, idle gate, port pinning)

### DIFF
--- a/react/hooks/httpHandlers/testAnnotationHandlers.ts
+++ b/react/hooks/httpHandlers/testAnnotationHandlers.ts
@@ -55,10 +55,20 @@ async function findCachedGeometry(attachment: Zotero.Item, pageIndex: number) {
     return record?.pages?.[pageIndex] ?? null;
 }
 
+/**
+ * Poll the open reader until the newly created annotation reaches its
+ * annotation manager (the Zotero notifier drives that refresh).
+ *
+ * The budget is deliberately far above how long the refresh takes on an idle
+ * instance (well under a second): it runs on Zotero's main thread, so on an
+ * instance that a long live-test run has loaded up, the notifier round-trip can
+ * take many seconds. A tight budget here reads as "the annotation never reached
+ * the reader" when the refresh was merely slow.
+ */
 async function waitForReaderAnnotation(
     reader: any,
     zoteroKey: string,
-    timeoutMs = 5000,
+    timeoutMs = 15000,
 ): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,51 @@ npx vitest run -t "returns empty"               # tests matching name pattern
 - **Live tests** hit a single Beaver HTTP endpoint against a running Zotero instance. Use these to verify individual handlers produce correct results with real data. Tests skip gracefully when Zotero is unavailable.
 - **Integration tests** exercise multi-step pipelines (e.g., HTTP request -> PDF extraction -> cache write -> cache read). Sequential execution, longer timeout.
 
+## Shared state on the live instance
+
+Live and integration tests all drive **one** Zotero instance, so anything a test
+changes there outlives the test file. Two pieces of that state have bitten whole
+suites at once; both are handled for you, but new tests need to respect them.
+
+### Excluded libraries
+
+Beaver's excluded-libraries set is a **user preference stored on the account
+profile**, so every instance that logs in inherits it — including a freshly
+cloned worktree profile. The fixtures assume every local library is readable, so
+an exclusion set in Beaver Preferences shows up as a spray of `library_excluded`
+failures in unrelated suites (group-library tests, or every note test when the
+user library is excluded). A suite that excludes a library and then fails before
+its own teardown poisons every file after it in the same way.
+
+`vitest.live.config.ts` and `vitest.integration.config.ts` therefore wire two
+hooks (see `helpers/liveExclusions.ts`):
+
+- **`globalSetup`** (`helpers/liveGlobalSetup.ts`) captures the excluded set once
+  per run, clears it, and restores it in teardown. It prints a `[live-setup]`
+  notice naming what it re-enabled.
+- **`setupFiles`** (`helpers/liveSetupFile.ts`) re-clears at the start of every
+  test file, so a leak stays contained to the file that produced it.
+
+Both write through `/beaver/test/excluded-libraries`, which mutates the
+in-memory profile only — nothing reaches the backend, and a run that dies before
+teardown is undone by restarting Zotero. A suite that tests exclusion behavior
+(`libraryExclusion`, `readerContextTracking`) still captures and restores its own
+set; it just starts from a normalized one.
+
+### The background queue's idle gate
+
+`BackgroundExtractor` claims jobs at or above priority 100 — **the enqueue
+default** — only once the OS has been idle for 30 seconds. A test that enqueues
+at the default and asserts the job drains therefore passes or fails depending on
+whether someone is at the keyboard, and the symptom is confusing: `processOnce`
+returns `reason: "empty"` while `/beaver/test/background-stats` reports
+`available: 1`.
+
+Any test that needs a deterministic drain must enqueue **below** 100 (the
+suites use `DRAIN_PRIORITY = 10`, which is also what production uses for
+hot-path timeout retries). Tests that only assert queue bookkeeping — ordering,
+dedup, stats, the `priority` default itself — can use any priority.
+
 ## Directory structure
 
 ```
@@ -221,6 +266,19 @@ Integration tests exercise full pipelines. Same prerequisites as live tests plus
 - Test attachments present (see `helpers/fixtures.ts`)
 - Set `ZOTERO_HTTP_PORT` if not 23119: `ZOTERO_HTTP_PORT=23124 npm run test:integration`
 
+`ZOTERO_HTTP_PORT` **pins** the run to that instance — there is no fallback to
+23119/23124, because several Zotero instances often run side by side and the
+fixtures exist in all of them, so a fallback would run the suite against the
+wrong library without saying so. A run whose named instance does not answer
+`/beaver/test/ping` **fails** rather than skipping every test; without the env
+var, suites still skip gracefully when no Zotero is running.
+
+Read the `Tests` line before calling a run green: every live suite skips itself
+when the instance is unreachable, so `530 skipped` and exit 0 means nothing ran.
+The usual cause is Beaver being logged out — `/beaver/test/*` is registered by
+the React bundle only once the plugin is authenticated, so the port answers
+`/connector/ping` while every dev endpoint returns `No endpoint found`.
+
 ### Test-only endpoints
 
 | Endpoint | Purpose |
@@ -270,3 +328,4 @@ The reader's dev menu has a "Copy Fixture Capture Command" item that builds the 
 - **Shared factories**: Use `helpers/factories.ts` for mock Zotero items. File-local helpers (`makeRecord`, etc.) go at the top of the test file.
 - **Cleanup**: Close DB connections in `afterEach`. Call `vi.clearAllMocks()` in `beforeEach`.
 - **Fixture updates**: Fixtures in `helpers/fixtures.ts` reference real items by `library_id + zotero_key`. Update keys to match your library.
+- **Don't pipe a live run through `tail`/`head`**: the pipe buffers everything until vitest exits, so a multi-minute run shows no progress and an interrupted one shows nothing at all. Redirect to a file (`npm run test:live > run.log 2>&1`) and read that instead.

--- a/tests/helpers/cacheInspector.ts
+++ b/tests/helpers/cacheInspector.ts
@@ -1079,10 +1079,20 @@ export async function waitForQueueDrain(
         }
         await new Promise((r) => setTimeout(r, pollMs));
     }
+    // A row that stays `available` was never claimed, which almost always means
+    // the idle gate: `BackgroundExtractor` only claims priority >= 100 (the
+    // enqueue default) after the OS has been idle for 30s, so such a job drains
+    // or not depending on whether someone is at the keyboard. Say so here — the
+    // raw stats look like a stuck queue.
+    const idleGated = (lastStats?.available ?? 0) > 0;
     throw new Error(
         `background queue did not drain within ${timeoutMs}ms; last stats: ${JSON.stringify(
             lastStats,
-        )}`,
+        )}`
+        + (idleGated
+            ? '. The row is still available (never claimed) — enqueue it with a '
+              + 'priority below 100 if the test needs a deterministic drain.'
+            : ''),
     );
 }
 

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -5,20 +5,22 @@
  * live and integration tests.
  */
 
-// Candidate ports probed by `isZoteroAvailable()`. The env var (if set) wins;
-// otherwise we try Zotero 7's default (23119) and the Zotero 10 beta default
-// (23124). The first port that answers `/beaver/test/ping` becomes the
-// resolved port for the rest of the run.
+// Candidate ports probed by `isZoteroAvailable()`. The first one that answers
+// `/beaver/test/ping` becomes the resolved port for the rest of the run.
+//
+// `ZOTERO_HTTP_PORT` is exclusive, not merely first: several Zotero instances
+// commonly run side by side (the main dev profile plus one per worktree), and
+// falling back to a different instance when the named one is briefly down would
+// run the suite against the wrong library — silently, since the fixtures exist
+// in both. Without the env var we probe Zotero 7's default (23119) and the
+// Zotero 10 beta default (23124).
 const ENV_PORT = process.env.ZOTERO_HTTP_PORT
     ? parseInt(process.env.ZOTERO_HTTP_PORT, 10)
     : null;
-export const ZOTERO_PORT_CANDIDATES: number[] = Array.from(
-    new Set(
-        [ENV_PORT, 23119, 23124].filter(
-            (p): p is number => typeof p === 'number' && Number.isFinite(p),
-        ),
-    ),
-);
+export const ZOTERO_PORT_IS_EXPLICIT = ENV_PORT !== null && Number.isFinite(ENV_PORT);
+export const ZOTERO_PORT_CANDIDATES: number[] = ZOTERO_PORT_IS_EXPLICIT
+    ? [ENV_PORT as number]
+    : [23119, 23124];
 
 let resolvedPort: number = ZOTERO_PORT_CANDIDATES[0] ?? 23119;
 

--- a/tests/helpers/liveExclusions.ts
+++ b/tests/helpers/liveExclusions.ts
@@ -1,0 +1,74 @@
+/**
+ * Library-exclusion normalization for live/integration runs.
+ *
+ * Beaver's excluded-libraries set is a user preference stored on the account
+ * profile, so it is inherited by every Zotero instance that logs in — including
+ * a freshly cloned worktree profile. The live fixtures assume every local
+ * library is readable, so an exclusion the developer set in Beaver Preferences
+ * (or a leak from an interrupted earlier run) turns into a spray of failures
+ * that read like product bugs: `library_excluded` errors from group-library
+ * tests, or note tests failing because the user library is excluded.
+ *
+ * These helpers clear the set for the duration of a run and put it back
+ * afterwards. Writes go through `/beaver/test/excluded-libraries`, which mutates
+ * the in-memory profile only — nothing is persisted to the backend, so a run
+ * that dies before teardown is undone by restarting Zotero.
+ */
+
+import {
+    getExcludedLibraries,
+    restoreExcludedLibraries,
+    setExcludedLibraries,
+    type ExcludedLibraryEntry,
+} from './cacheInspector';
+import { isZoteroAvailable } from './zoteroAvailability';
+
+/** What was excluded before we cleared it, or null when nothing was changed. */
+export type ExclusionSnapshot = ExcludedLibraryEntry[] | null;
+
+/**
+ * Make every local library searchable, returning what to pass to
+ * `restoreExclusions()`. No-op (returns null) when Zotero is unavailable, no
+ * profile is loaded, or nothing was excluded to begin with.
+ */
+export async function clearExclusions(): Promise<ExclusionSnapshot> {
+    if (!(await isZoteroAvailable())) return null;
+
+    let state;
+    try {
+        state = await getExcludedLibraries();
+    } catch {
+        return null;
+    }
+    if (!state?.has_profile) return null;
+
+    const original = state.excluded_libraries ?? [];
+    if (original.length === 0) return null;
+
+    const cleared = await setExcludedLibraries([]);
+    if (!cleared?.ok) {
+        throw new Error(
+            'Could not clear the excluded-libraries set for this run: '
+            + (cleared?.error ?? 'unknown error'),
+        );
+    }
+    return original;
+}
+
+/** Put back a set captured by `clearExclusions()`. Safe to call with null. */
+export async function restoreExclusions(snapshot: ExclusionSnapshot): Promise<void> {
+    if (!snapshot) return;
+    try {
+        await restoreExcludedLibraries(snapshot);
+    } catch {
+        // Best effort: the set is in-memory only, so a failure here is undone
+        // by the next Zotero restart rather than corrupting anything.
+    }
+}
+
+/** Human-readable summary of a captured set, for the one-time run notice. */
+export function describeExclusions(snapshot: NonNullable<ExclusionSnapshot>): string {
+    return snapshot
+        .map((entry) => (entry.type === 'group' ? `group:${entry.group_id}` : 'user'))
+        .join(', ');
+}

--- a/tests/helpers/liveGlobalSetup.ts
+++ b/tests/helpers/liveGlobalSetup.ts
@@ -1,0 +1,63 @@
+/**
+ * Vitest `globalSetup` for the live and integration suites.
+ *
+ * Runs once per run, before any test file: clears Beaver's excluded-libraries
+ * set so the fixtures' libraries are all readable, and restores the original
+ * set in teardown. See `liveExclusions.ts` for why this is needed.
+ */
+
+import { ZOTERO_PORT_CANDIDATES, ZOTERO_PORT_IS_EXPLICIT } from './fixtures';
+import {
+    clearExclusions,
+    describeExclusions,
+    restoreExclusions,
+    type ExclusionSnapshot,
+} from './liveExclusions';
+import { isZoteroAvailable } from './zoteroAvailability';
+
+let snapshot: ExclusionSnapshot = null;
+
+/**
+ * Fail the run when a named instance isn't answering.
+ *
+ * Every live suite skips itself when Zotero is unreachable, so a run against a
+ * dead instance reports "N skipped" and exits 0 — a green result that proves
+ * nothing, and the easiest way to believe a broken branch is fine. That
+ * forgiving behavior is right when nobody named an instance (a developer
+ * running `npm test`-adjacent commands without Zotero), but `ZOTERO_HTTP_PORT`
+ * is an assertion that a specific instance is there, so silence is an error.
+ *
+ * The usual causes are the plugin still booting, being logged out, or having
+ * just hot-reloaded: `/beaver/test/*` is registered by the React bundle and
+ * gated on authentication, so editing source mid-run can deregister it.
+ */
+async function requireNamedInstance(): Promise<void> {
+    if (!ZOTERO_PORT_IS_EXPLICIT) return;
+    if (await isZoteroAvailable()) return;
+    const port = ZOTERO_PORT_CANDIDATES[0];
+    throw new Error(
+        `ZOTERO_HTTP_PORT=${port} was set but http://127.0.0.1:${port}/beaver/test/ping `
+        + `did not answer, so every test would silently skip.\n`
+        + `  - Is that instance running? (scripts/worktree-ready.sh <branch>)\n`
+        + `  - Is Beaver logged in? The dev endpoints live in the React bundle and are\n`
+        + `    registered only once the plugin is authenticated.\n`
+        + `  - Did a source edit hot-reload the plugin mid-run? Let it settle, then re-run.`,
+    );
+}
+
+export async function setup(): Promise<void> {
+    await requireNamedInstance();
+    snapshot = await clearExclusions();
+    if (snapshot) {
+        console.warn(
+            `\n[live-setup] Temporarily re-enabled excluded libraries for this run: `
+            + `${describeExclusions(snapshot)}.\n`
+            + `            The change is in-memory only and is restored when the run ends.\n`,
+        );
+    }
+}
+
+export async function teardown(): Promise<void> {
+    await restoreExclusions(snapshot);
+    snapshot = null;
+}

--- a/tests/helpers/liveSetupFile.ts
+++ b/tests/helpers/liveSetupFile.ts
@@ -1,0 +1,22 @@
+/**
+ * Vitest `setupFiles` entry for the live and integration suites.
+ *
+ * `globalSetup` clears the excluded-libraries set once per run, but the set
+ * lives in the running Zotero and any test file may leave one behind — a suite
+ * that excludes a library and then fails before its teardown poisons every file
+ * that runs after it, usually as a wall of `library_excluded` errors far from
+ * the file that caused them. Re-normalizing at the start of each file keeps a
+ * leak contained to the file that produced it.
+ *
+ * Registering the hook here (rather than in each suite) means it runs before
+ * every test file's own `beforeAll`, so suites that capture the exclusion set
+ * to restore it later capture the already-normalized one.
+ */
+
+import { beforeAll } from 'vitest';
+
+import { clearExclusions } from './liveExclusions';
+
+beforeAll(async () => {
+    await clearExclusions();
+}, 30000);

--- a/tests/live/backgroundExtractor.live.test.ts
+++ b/tests/live/backgroundExtractor.live.test.ts
@@ -60,6 +60,19 @@ const EXTRACT_OPTS = { timeout: 120_000 } as const;
 const MISSING_KEY_LIB = 1;
 const MISSING_KEY_ZOTERO = 'ZZZZTEST';
 
+/**
+ * Priority for every job a test expects to be claimed.
+ *
+ * `BackgroundExtractor` claims jobs at or above `LOW_PRIORITY_CEILING` (100,
+ * also the enqueue default) only once the OS has been idle for 30s, so a job
+ * enqueued at the default drains or not depending on whether someone is
+ * touching the keyboard. Anything below the ceiling — the priority production
+ * uses for hot-path timeout retries — is claimed regardless of idle time, which
+ * is the behavior these tests are actually about. Tests that assert queue
+ * bookkeeping rather than draining still use explicit priorities of their own.
+ */
+const DRAIN_PRIORITY = 10;
+
 describe('background queue — enqueue endpoint', () => {
     beforeEach(async (ctx) => {
         skipIfNoZotero(ctx, available);
@@ -313,12 +326,13 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
         expect(res.ok).toBe(true);
-        expect(res.processed).toBe(true);
+        expect(res.processed, `processOnce declined the job: ${res.reason}`).toBe(true);
         expect(res.reason).toBe('job_done');
 
         // The row must be gone after a successful drain (no retry).
@@ -337,11 +351,12 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
-        expect(res.processed).toBe(true);
+        expect(res.processed, `processOnce declined the job: ${res.reason}`).toBe(true);
         expect(res.reason).toBe('job_done');
 
         const peek = await backgroundPeek();
@@ -356,11 +371,12 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
-        expect(res.processed).toBe(true);
+        expect(res.processed, `processOnce declined the job: ${res.reason}`).toBe(true);
         expect(res.reason).toBe('job_done');
 
         const peek = await backgroundPeek();
@@ -375,11 +391,12 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
-        expect(res.processed).toBe(true);
+        expect(res.processed, `processOnce declined the job: ${res.reason}`).toBe(true);
         expect(res.reason).toBe('job_done');
 
         const peek = await backgroundPeek();
@@ -393,6 +410,7 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
@@ -401,14 +419,15 @@ describe('background queue — processOnce endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'markdown',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
         });
 
         const first = await backgroundProcessOnce();
-        expect(first.processed).toBe(true);
+        expect(first.processed, `processOnce declined the first job: ${first.reason}`).toBe(true);
 
         const second = await backgroundProcessOnce();
-        expect(second.processed).toBe(true);
+        expect(second.processed, `processOnce declined the second job: ${second.reason}`).toBe(true);
 
         const third = await backgroundProcessOnce();
         expect(third.processed).toBe(false);
@@ -538,6 +557,7 @@ describe('background queue — terminal response_error completes without retry',
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
             notify: true,
         });
@@ -548,13 +568,13 @@ describe('background queue — terminal response_error completes without retry',
         // dropped (completed without retry) before extraction. That path is
         // fast, so the queue may already be empty before we call
         // processOnce. Poll for drain instead.
-        const finalQueue = await waitForQueueDrain({ timeoutMs: 15_000 });
+        const finalQueue = await waitForQueueDrain({ timeoutMs: 30_000 });
         expect(finalQueue.pending).toBe(0);
         expect(finalQueue.dead).toBe(0);
 
         const peek = await backgroundPeek();
         expect(peek.jobs?.length).toBe(0);
-    });
+    }, 60_000);
 });
 
 describe('background queue — group library extraction', () => {
@@ -572,6 +592,7 @@ describe('background queue — group library extraction', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
             notify: true,
         });
@@ -605,6 +626,7 @@ describe('background queue — worker slot isolation', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
+            priority: DRAIN_PRIORITY,
             payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
             notify: true,
         });
@@ -616,7 +638,11 @@ describe('background queue — worker slot isolation', () => {
         const stats = await backgroundStats();
         expect(stats.workers).toBeDefined();
         expect(stats.workers!.background).not.toBeNull();
-        expect(stats.workers!.background!.hasWorker).toBe(true);
+        // `spawnCount`, not `hasWorker`: the processor recycles the background
+        // worker every `RECYCLE_AFTER_N` completed jobs, and that counter runs
+        // for the life of the instance, so a drain that happens to be the Nth
+        // one leaves the slot legitimately empty. The cumulative spawn count is
+        // the durable evidence that this slot got its own worker.
         expect(stats.workers!.background!.spawnCount).toBeGreaterThanOrEqual(1);
         // hot may or may not have a worker depending on prior tests — but
         // when both exist they must be distinct instances tracked under
@@ -749,7 +775,7 @@ describe('background queue — hot-path timeout integration', () => {
 
             // The processor must now be able to drain the retry job.
             const drained = await backgroundProcessOnce();
-            expect(drained.processed).toBe(true);
+            expect(drained.processed, `processOnce declined the retry job: ${drained.reason}`).toBe(true);
             expect(drained.reason).toBe('job_done');
         } else {
             // Extraction beat the 1s budget — that's fine, no retry was

--- a/tests/live/createAnnotation.live.test.ts
+++ b/tests/live/createAnnotation.live.test.ts
@@ -310,7 +310,9 @@ describe("headless annotation creation primitives", () => {
 
     expectSuccessfulCreate(res);
     expect(res.reader_visible).toBe(true);
-  }, 30000);
+    // Opening the reader plus the handler's own notifier-refresh poll can take
+    // most of a minute on an instance loaded down by a full live run.
+  }, 60000);
 
   it("creates a multi-box highlight whose rects share the page index sort prefix", async () => {
     await triggerFileStatus(

--- a/tests/live/itemValidation.live.test.ts
+++ b/tests/live/itemValidation.live.test.ts
@@ -123,7 +123,13 @@ describe('validateItem — attachment content kinds (default capabilities)', () 
     it('marks a local HTML snapshot as unreadable', async (ctx) => {
         const res = await validateItem(SNAPSHOT_ATTACHMENT.library_id, SNAPSHOT_ATTACHMENT.zotero_key);
         expect(res.ok).toBe(true);
-        if (res.status_code === 'file_not_local_remote') ctx.skip();
+        // The fixture lives in a group library, so its file may not be synced
+        // down on this machine. Validation reports that as `file_not_local`
+        // or `file_not_local_remote` depending on whether it has already seen
+        // the remote copy — which of the two comes back also varies with how
+        // long the instance has been up. Either means the file isn't here, and
+        // this test is about content-kind classification, not availability.
+        if (res.status_code?.startsWith('file_not_local')) ctx.skip();
         expect(res.state).toBe('unreadable');
         expect(res.content_kind).toBe('snapshot');
         expect(res.reason).toContain('snapshot');

--- a/tests/live/mupdfWorker.live.test.ts
+++ b/tests/live/mupdfWorker.live.test.ts
@@ -367,6 +367,14 @@ describe('MuPDF worker — doc cache', () => {
 
         await pdfPageCount(SMALL_PDF);
         const before = await workerStats();
+        // `cacheStats` is null when no worker is alive, which would otherwise
+        // surface as an opaque TypeError on the next line. The op above just
+        // ran, so a missing worker means something disposed the hot slot
+        // underneath us — name that rather than letting it read as a cache bug.
+        expect(
+            before.stats.hasWorker,
+            'hot worker was gone right after a successful op, so cacheStats is null',
+        ).toBe(true);
         expect(before.cacheStats!.entries).toBeGreaterThanOrEqual(1);
 
         await workerMarkStale({ reason: 'doc-cache test' });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -8,8 +8,17 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['tests/integration/**/*.integration.test.ts'],
-        // No setupFiles — integration tests run against live Zotero, no stubs
+        // No stubs — integration tests run against live Zotero. These two only
+        // normalize the instance's excluded-libraries set (see
+        // tests/helpers/liveExclusions.ts): once per run, and again at the
+        // start of each file so a leak stays contained to its own file.
+        globalSetup: ['tests/helpers/liveGlobalSetup.ts'],
+        setupFiles: ['tests/helpers/liveSetupFile.ts'],
         testTimeout: 30000,
+        // The tier is scaffolded but currently has no files. Without this,
+        // `npm run test:integration` exits 1 on "No test files found" and takes
+        // `npm run test:all` down with it.
+        passWithNoTests: true,
         sequence: {
             concurrent: false,
         },

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -8,7 +8,12 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['tests/live/**/*.live.test.ts'],
-        // No setupFiles — live tests run against live Zotero, no stubs
+        // No stubs — live tests run against live Zotero. These two only
+        // normalize the instance's excluded-libraries set (see
+        // tests/helpers/liveExclusions.ts): once per run, and again at the
+        // start of each file so a leak stays contained to its own file.
+        globalSetup: ['tests/helpers/liveGlobalSetup.ts'],
+        setupFiles: ['tests/helpers/liveSetupFile.ts'],
         testTimeout: 15000,
         sequence: {
             concurrent: false,


### PR DESCRIPTION
Makes the live suite deterministic. It went from **13 failed / 503 passed / 14 skipped** to **520 passed / 10 skipped / 0 failed**, verified over three consecutive full runs, and the runtime halved (293s → ~142s).

**None of the failures was a product bug** — every one was test-environment or test-design.

## Root causes

**All 6 "group-library" failures — a persisted user preference.** A local group library sits in the account profile's `excluded_libraries`. That set lives on the *Beaver account profile*, so every instance that logs in inherits it, cloned worktree profiles included, and `/beaver/library/libraries` hides excluded libraries — which makes the library look deleted. The same mechanism explains previously-reported "note tests fail in a full run but pass in isolation": `libraryExclusion.live.test.ts` excludes the user library, and a teardown that doesn't run leaks that into every later file.

Fixed by normalizing the set for the duration of a run:
- `globalSetup` (`tests/helpers/liveGlobalSetup.ts`) captures and clears it once per run, restores it in teardown, and prints a `[live-setup]` notice naming what it re-enabled.
- `setupFiles` (`tests/helpers/liveSetupFile.ts`) re-clears at the start of every file, so a leak stays contained to the file that produced it.

Both write through `/beaver/test/excluded-libraries`, which mutates the in-memory profile only — nothing reaches the backend, and a run that dies before teardown is undone by restarting Zotero.

**All 7 background-queue failures — the idle gate.** `BackgroundExtractor` claims jobs at priority >= 100 (the enqueue default) only after the OS has been idle 30s, so a test asserting a drain at the default priority passes or fails depending on whether someone is at the keyboard. Confirmed live: a priority-100 job plus `processOnce` returns `reason:"empty"` while stats report `available: 1`. Drain-asserting tests now enqueue at `DRAIN_PRIORITY = 10` — below the ceiling, and the priority production already uses for hot-path timeout retries. `backgroundContentKind.live.test.ts` already did this; `backgroundExtractor.live.test.ts` had not been updated.

**Three more surfaced once those two were out of the way:**
- `createAnnotation > appears in an open reader` — the dev handler's notifier-refresh poll was 5s, too tight on an instance loaded by a full run (it completes in under a second in isolation). Raised to 15s.
- `itemValidation > marks a local HTML snapshot as unreadable` — the group-library fixture's file isn't synced locally, and the skip guard covered only `file_not_local_remote`, not `file_not_local`. Which of the two comes back varies with how long the instance has been up.
- `backgroundExtractor > spawns a separate background MuPDF worker` — asserted `hasWorker` right after a drain, but `RECYCLE_AFTER_N = 8` disposes the background worker and that counter runs for the life of the instance. Only became reachable once auto-ticks actually started draining. Now asserts the cumulative `spawnCount`.

## Guardrails

- **`ZOTERO_HTTP_PORT` now pins the run** to that instance — no fallback to 23119/23124. Several Zotero instances commonly run side by side and the fixtures exist in all of them, so a fallback silently runs the suite against the wrong library.
- **A named instance that doesn't answer now fails the run** instead of skipping every test. This is not hypothetical: during development one run reported `530 skipped` and exit 0 — a green result where nothing ran, because Beaver had signed itself out and its dev endpoints deregistered.
- **`passWithNoTests` on the integration config.** `tests/integration/` does not exist, so `npm run test:integration` exited 1 on "No test files found" and took `npm run test:all` down with it.
- `waitForQueueDrain` now names the idle gate when rows stay `available`, and the `processOnce` assertions report the returned `reason`.

## Verification

- Full live suite: 3 consecutive clean runs (520 passed / 10 skipped), plus one run each confirming the two failure modes above are genuinely fixed.
- Unit suite: 276 files, 4535 passed.
- `tsc --noEmit`, `eslint` on the changed files: clean.
- The fail-loud guard verified against a bogus port; exclusion teardown verified to restore the original set after every run.

## Known residual

`mupdfWorker > cache is cleared after worker-mark-stale` returned `cacheStats: null` once in five full runs — the **hot** worker was gone right after a successful op. It passed 5/5 in isolation. The assertion is left in place with a message naming the cause rather than papered over, since it may point at a real disposal-under-load issue.

## Docs

`tests/README.md` gains a "Shared state on the live instance" section covering both traps and the `ZOTERO_HTTP_PORT` semantics.
