### PR TITLE
feat(attachments): implement safe attachment filename handling

### DIFF
--- a/react/compat/legacyToolResults.ts
+++ b/react/compat/legacyToolResults.ts
@@ -19,6 +19,7 @@ import { ToolReturnPart } from "@beaver/agent-core/agents/types";
 import { ZoteroItemReference } from "@beaver/agent-core/types/zotero";
 import { logger } from "@beaver/agent-core/platform/logger";
 import { resolveItemReference } from "../../src/utils/libraryIdentity";
+import { safeAttachmentFilename } from "../../src/utils/attachmentFiles";
 import { truncateText, formatNumberRanges } from "../utils/stringUtils";
 import { EXTERNAL_LIBRARY_ID } from "../../src/services/externalFiles";
 import {
@@ -159,7 +160,7 @@ function titleOf(item: Zotero.Item): string {
 }
 
 function attachmentOwnName(item: Zotero.Item): string {
-    return item.getField?.("title") || item.attachmentFilename || "";
+    return item.getField?.("title") || safeAttachmentFilename(item) || "";
 }
 
 /**

--- a/react/components/ui/ZoteroAttachmentList.tsx
+++ b/react/components/ui/ZoteroAttachmentList.tsx
@@ -4,6 +4,7 @@ import { FailedFileReference, FailedItemReference } from '../../types/fileStatus
 import { errorMapping } from '../../atoms/errors';
 import { selectItemById } from '../../../src/utils/selectItem';
 import { UNRESOLVED_LIBRARY_ID } from '../../../src/utils/libraryIdentity';
+import { safeAttachmentFilename } from '../../../src/utils/attachmentFiles';
 import IconButton from './IconButton';
 
 interface ItemWithSelectionId {
@@ -101,7 +102,7 @@ const ZoteroAttachmentList: React.FC<ZoteroAttachmentListProps> = ({
                             <CSSItemTypeIcon itemType={item.getItemTypeIconName()} />
                         </div>
                         <div className="truncate text-sm font-color-secondary flex-1 min-w-0">
-                            {item.attachmentFilename}
+                            {safeAttachmentFilename(item)}
                         </div>
                         <div className="display-flex flex-row gap-2 fit-content min-w-0 items-center">
                             {errorMessage && (

--- a/src/services/agentDataProvider/handleGetMetadataRequest.ts
+++ b/src/services/agentDataProvider/handleGetMetadataRequest.ts
@@ -12,10 +12,10 @@ import {
     WSGetMetadataRequest,
     WSGetMetadataResponse,
 } from '@beaver/agent-core/protocol/agentProtocol';
-import { ItemStub } from '@beaver/agent-core/types/zotero';
+import { AttachmentInfo, ItemStub } from '@beaver/agent-core/types/zotero';
 import { serializeNote, serializeAnnotation, serializeItemStub } from '../../utils/zoteroSerializers';
 import { libraryRefForLibraryID, modelObjectId, resolveItemReference, resolveObjectId, UNRESOLVED_LIBRARY_ID } from '../../utils/libraryIdentity';
-import { checkLibraryExcluded, getAttachmentInfoForItem, formatCreatorsString, extractYear } from './utils';
+import { checkLibraryExcluded, getAttachmentInfoForItem, degradedAttachmentInfo, formatCreatorsString, extractYear } from './utils';
 import { getCreatorTypeInfo } from '../../utils/zoteroUtils';
 
 
@@ -107,12 +107,22 @@ export async function handleGetMetadataRequest(
                         // getBestAttachment failure is non-fatal — is_primary stays false.
                     }
                 }
-                const info = await getAttachmentInfoForItem(item, {
-                    parentItemId,
-                    isPrimary,
-                    includeAnnotationsCount: true,
-                    skipWorkerFallback: true,
-                });
+                let info: AttachmentInfo;
+                try {
+                    info = await getAttachmentInfoForItem(item, {
+                        parentItemId,
+                        isPrimary,
+                        includeAnnotationsCount: true,
+                        skipWorkerFallback: true,
+                    });
+                } catch (error) {
+                    // Isolate the row so one unreadable record does not fail the
+                    // whole batch. Unlike a child attachment (dropped by the loop
+                    // below), a requested item must still come back — the model
+                    // asked for it by id and needs to know it exists.
+                    logger(`handleGetMetadataRequest: Degrading unreadable attachment ${item.key}: ${error}`, 2);
+                    info = degradedAttachmentInfo(item, parentItemId ?? null, isPrimary);
+                }
                 items.push({
                     ...info,
                     item_id: itemId,

--- a/src/services/agentDataProvider/handleListItemsRequest.ts
+++ b/src/services/agentDataProvider/handleListItemsRequest.ts
@@ -18,7 +18,7 @@ import {
 import { ItemStub } from '@beaver/agent-core/types/zotero';
 import { serializeNote, serializeItemStub } from '../../utils/zoteroSerializers';
 import { libraryRefForLibraryID, modelObjectId } from '../../utils/libraryIdentity';
-import { getCollectionByIdOrName, validateLibraryAccess, isLibrarySearchable, getSearchableLibraries, excludedLibraryMessage, extractYear, formatCreatorsString, getAttachmentInfoForItem } from './utils';
+import { getCollectionByIdOrName, validateLibraryAccess, isLibrarySearchable, getSearchableLibraries, excludedLibraryMessage, extractYear, formatCreatorsString, getAttachmentInfoForItem, degradedAttachmentRow } from './utils';
 
 function isAnnotationItem(item: Zotero.Item): boolean {
     return String(item.itemType) === 'annotation' || (item as { isAnnotation?: () => boolean }).isAnnotation?.() === true;
@@ -362,19 +362,28 @@ export async function handleListItemsRequest(
                 items.push(serializeNote(item, parentInfo));
             } else if (item.isAttachment()) {
                 const parentInfo = item.parentItemID ? parentMap.get(item.parentItemID) : null;
-                const attachmentInfo = await getAttachmentInfoForItem(item, {
-                    parentItemId: parentInfo?.item_id ?? null,
-                    isPrimary: false,
-                    includeAnnotationsCount: true,
-                    skipWorkerFallback: true,
-                });
-                const attachmentItem: AttachmentRowResult = {
-                    ...attachmentInfo,
-                    result_type: 'attachment',
-                    parent_title: parentInfo?.title ?? null,
-                    parent_item: parentInfo ?? null,
-                    date_modified: item.dateModified,
-                };
+                let attachmentItem: AttachmentRowResult;
+                try {
+                    const attachmentInfo = await getAttachmentInfoForItem(item, {
+                        parentItemId: parentInfo?.item_id ?? null,
+                        isPrimary: false,
+                        includeAnnotationsCount: true,
+                        skipWorkerFallback: true,
+                    });
+                    attachmentItem = {
+                        ...attachmentInfo,
+                        result_type: 'attachment',
+                        parent_title: parentInfo?.title ?? null,
+                        parent_item: parentInfo ?? null,
+                        date_modified: item.dateModified,
+                    };
+                } catch (error) {
+                    // Isolate the row: a record Zotero cannot read (e.g. a linked
+                    // file whose stored path is not valid on this platform) must
+                    // degrade to a stub, not empty the whole page.
+                    logger(`handleListItemsRequest: Degrading unreadable attachment ${item.key}: ${error}`, 2);
+                    attachmentItem = degradedAttachmentRow(item, parentInfo ?? null);
+                }
                 items.push(attachmentItem);
             } else {
                 const creators = item.getCreators();

--- a/src/services/agentDataProvider/handleZoteroSearchRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroSearchRequest.ts
@@ -19,7 +19,7 @@ import {
 import { ItemStub } from '@beaver/agent-core/types/zotero';
 import { serializeNote, serializeItemStub } from '../../utils/zoteroSerializers';
 import { libraryRefForLibraryID, modelObjectId } from '../../utils/libraryIdentity';
-import { validateLibraryAccess, extractYear, formatCreatorsString, getAttachmentInfoForItem, isReadableItemField, readItemField } from './utils';
+import { validateLibraryAccess, extractYear, formatCreatorsString, getAttachmentInfoForItem, degradedAttachmentRow, isReadableItemField, readItemField } from './utils';
 
 
 /**
@@ -404,19 +404,28 @@ export async function handleZoteroSearchRequest(
                 items.push(serializeNote(item, parentInfo));
             } else if (item.isAttachment()) {
                 const parentInfo = item.parentItemID ? parentMap.get(item.parentItemID) : null;
-                const attachmentInfo = await getAttachmentInfoForItem(item, {
-                    parentItemId: parentInfo?.item_id ?? null,
-                    isPrimary: false,
-                    includeAnnotationsCount: true,
-                    skipWorkerFallback: true,
-                });
-                const attachmentItem: AttachmentRowResult = {
-                    ...attachmentInfo,
-                    result_type: 'attachment',
-                    parent_title: parentInfo?.title ?? null,
-                    parent_item: parentInfo ?? null,
-                    date_modified: item.dateModified,
-                };
+                let attachmentItem: AttachmentRowResult;
+                try {
+                    const attachmentInfo = await getAttachmentInfoForItem(item, {
+                        parentItemId: parentInfo?.item_id ?? null,
+                        isPrimary: false,
+                        includeAnnotationsCount: true,
+                        skipWorkerFallback: true,
+                    });
+                    attachmentItem = {
+                        ...attachmentInfo,
+                        result_type: 'attachment',
+                        parent_title: parentInfo?.title ?? null,
+                        parent_item: parentInfo ?? null,
+                        date_modified: item.dateModified,
+                    };
+                } catch (error) {
+                    // Isolate the row: a record Zotero cannot read (e.g. a linked
+                    // file whose stored path is not valid on this platform) must
+                    // degrade to a stub, not empty the whole result page.
+                    logger(`handleZoteroSearchRequest: Degrading unreadable attachment ${item.key}: ${error}`, 2);
+                    attachmentItem = degradedAttachmentRow(item, parentInfo ?? null);
+                }
                 items.push(attachmentItem);
             } else {
                 // Get creators

--- a/src/services/agentDataProvider/utils.ts
+++ b/src/services/agentDataProvider/utils.ts
@@ -3,11 +3,15 @@ import {
     ZoteroItemStatus,
     FrontendFileStatus,
     AttachmentInfo,
+    type ItemStub,
     type ZoteroItemReference,
 } from '@beaver/agent-core/types/zotero';
 import { safeIsInTrash, safeFileExists, isLinkedUrlAttachment } from '../../utils/zoteroUtils';
+import { safeAttachmentFilename } from '../../utils/attachmentFiles';
+import { safeStub } from '../../utils/zoteroSerializers';
 import {
     libraryRefForLibraryID,
+    modelObjectId,
     modelObjectIdFromReference,
     parseItemReference,
     parseLibraryRef,
@@ -19,7 +23,7 @@ import { getPref } from '../../utils/prefs';
 import { isAttachmentOnServer } from '../../utils/webAPI';
 import { addPopupMessageAtom } from '../../../react/utils/popupMessageUtils';
 import { wasItemAddedBeforeLastSync } from '../../../react/utils/sourceUtils';
-import { DeferredToolPreference } from '@beaver/agent-core/protocol/agentProtocol';
+import { DeferredToolPreference, type AttachmentRowResult } from '@beaver/agent-core/protocol/agentProtocol';
 import { deferredToolPreferencesAtom } from '../../../react/atoms/deferredToolPreferences';
 import {
     isActionApprovedForCurrentRun,
@@ -414,6 +418,52 @@ export async function getAttachmentInfoForItem(
         ...options,
         nonPdfReadableEnabled: options?.nonPdfReadableEnabled ?? false,
     });
+}
+
+/**
+ * Build a minimal AttachmentInfo for an attachment that could not be resolved.
+ */
+export function degradedAttachmentInfo(
+    item: Zotero.Item,
+    parentItemId: string | null,
+    isPrimary = false,
+): AttachmentInfo {
+    return {
+        attachment_id: modelObjectId(item.libraryID, item.key),
+        library_ref: libraryRefForLibraryID(item.libraryID) ?? undefined,
+        parent_item_id: parentItemId,
+        title: safeStub(() => item.getDisplayTitle?.()) ?? null,
+        filename: safeAttachmentFilename(item),
+        content_kind: 'other',
+        status: 'unreadable',
+        // States what is known (the read failed) without asserting a cause: the
+        // catch this comes from covers any failure, not just a malformed record.
+        status_reason:
+            'Beaver could not read this attachment from Zotero, so only its '
+            + 'identity is available here. Its stored file path may be invalid — '
+            + 'the user can check the attachment in Zotero.',
+        page_count: null,
+        line_count: null,
+        // Callers that resolved the parent's best attachment already know this;
+        // list/search rows never do and leave it at the default.
+        is_primary: isPrimary,
+    };
+}
+
+/**
+ * Search/list row wrapper around {@link degradedAttachmentInfo}.
+ */
+export function degradedAttachmentRow(
+    item: Zotero.Item,
+    parentInfo: ItemStub | null,
+): AttachmentRowResult {
+    return {
+        ...degradedAttachmentInfo(item, parentInfo?.item_id ?? null),
+        result_type: 'attachment',
+        parent_title: parentInfo?.title ?? null,
+        parent_item: parentInfo ?? null,
+        date_modified: safeStub(() => item.dateModified) ?? null,
+    };
 }
 
 /**
@@ -1096,8 +1146,8 @@ export async function getAttachmentInfo(item: Zotero.Item): Promise<{ count: num
             const isPrimary = bestAttachmentKey && key === bestAttachmentKey;
             // return isPrimary ? `${key} (primary)` : key;
             return isPrimary
-                ? `'${attachment.attachmentFilename}' (${key}, primary)`
-                : `'${attachment.attachmentFilename}' (${key})`;
+                ? `'${safeAttachmentFilename(attachment) ?? ''}' (${key}, primary)`
+                : `'${safeAttachmentFilename(attachment) ?? ''}' (${key})`;
         });
 
     return {

--- a/src/services/documentExtraction/attachmentInfo.ts
+++ b/src/services/documentExtraction/attachmentInfo.ts
@@ -10,6 +10,7 @@ import { isReadableContentKind, type AttachmentInfo, type ContentKind } from '@b
 import { getPDFPageCountFromFulltext, getPDFPageCountFromWorker } from './shared/pageCount';
 import type { TimingAccumulator } from '../../utils/timing';
 import { libraryRefForLibraryID, modelObjectId } from '../../utils/libraryIdentity';
+import { safeAttachmentFilename } from '../../utils/attachmentFiles';
 import { createAbortController } from '../../utils/abortController';
 import { MAX_INTERACTIVE_PDF_TIMEOUT_SECONDS } from '../agentDataProvider/timeout';
 
@@ -551,7 +552,7 @@ export async function getAttachmentInfo(
         library_ref: libraryRefForLibraryID(item.libraryID) ?? undefined,
         parent_item_id: options.parentItemId ?? defaultParentItemId(item),
         title: item.getField?.('title') || item.getDisplayTitle?.() || null,
-        filename: item.attachmentFilename || null,
+        filename: safeAttachmentFilename(item),
         content_kind: contentKind,
         status: 'unreadable',
         page_count: null,

--- a/src/services/documentExtraction/attachmentResolution.ts
+++ b/src/services/documentExtraction/attachmentResolution.ts
@@ -8,6 +8,7 @@ import {
 import {
     hasSnapshotContentType,
     isLinkedUrlAttachment,
+    safeAttachmentFilename,
     safeFileExists,
 } from '../../utils/attachmentFiles';
 import { modelObjectId } from '../../utils/libraryIdentity';
@@ -204,8 +205,8 @@ export async function resolveToPdfAttachment(
             );
             if (!resolved) {
                 const label = bestAttachmentKey === onlyKey
-                    ? `'${only.attachmentFilename}' (${onlyKey}, primary)`
-                    : `'${only.attachmentFilename}' (${onlyKey})`;
+                    ? `'${safeAttachmentFilename(only) ?? ''}' (${onlyKey}, primary)`
+                    : `'${safeAttachmentFilename(only) ?? ''}' (${onlyKey})`;
                 return {
                     resolved: false,
                     error: `The id '${uniqueKey}' is a regular item with one attachment (${label}) but it could not be resolved.`,
@@ -220,8 +221,8 @@ export async function resolveToPdfAttachment(
             .map((a) => {
                 const k = modelObjectId(a.libraryID, a.key);
                 return k === bestAttachmentKey
-                    ? `'${a.attachmentFilename}' (${k}, primary)`
-                    : `'${a.attachmentFilename}' (${k})`;
+                    ? `'${safeAttachmentFilename(a) ?? ''}' (${k}, primary)`
+                    : `'${safeAttachmentFilename(a) ?? ''}' (${k})`;
             })
             .join(', ');
         const message = pdfAttachments.length > 0
@@ -305,7 +306,7 @@ export async function resolveToImageAttachment(
             if (!resolved) {
                 return {
                     resolved: false,
-                    error: `The id '${uniqueKey}' is a regular item with one image attachment ('${only.attachmentFilename}' (${onlyKey})) but it could not be resolved.`,
+                    error: `The id '${uniqueKey}' is a regular item with one image attachment ('${safeAttachmentFilename(only) ?? ''}' (${onlyKey})) but it could not be resolved.`,
                     error_code: 'not_attachment',
                 };
             }
@@ -314,7 +315,7 @@ export async function resolveToImageAttachment(
         }
 
         const text = imageAttachments
-            .map((a) => `'${a.attachmentFilename}' (${modelObjectId(a.libraryID, a.key)})`)
+            .map((a) => `'${safeAttachmentFilename(a) ?? ''}' (${modelObjectId(a.libraryID, a.key)})`)
             .join(', ');
         const message = imageAttachments.length > 0
             ? `The id '${uniqueKey}' is a regular item, not an attachment. The item has ${imageAttachments.length} image attachments: ${text}`
@@ -357,7 +358,7 @@ function labelReadableAttachment(
 ): string {
     const key = modelObjectId(item.libraryID, item.key);
     const primary = key === bestAttachmentKey ? ', primary' : '';
-    return `'${item.attachmentFilename}' (${key}${primary}, ${contentKind})`;
+    return `'${safeAttachmentFilename(item) ?? ''}' (${key}${primary}, ${contentKind})`;
 }
 
 /**

--- a/src/services/documentExtraction/snapshot/SnapshotExtractor.ts
+++ b/src/services/documentExtraction/snapshot/SnapshotExtractor.ts
@@ -23,6 +23,7 @@ import {
 } from "@beaver/agent-core/extract/document/snapshot/schema";
 import { getDeclaredCharset, isLikelyNonUtf8Charset, parseSnapshotHtml } from "./snapshotDom";
 import { getReadableContentKind } from "../attachmentResolution";
+import { safeAttachmentFilename } from "../../../utils/attachmentFiles";
 import { effectiveMaxSnapshotFileSizeMB } from "@beaver/agent-core/transport/attachmentLimits";
 import { isRemoteAccessAvailable } from "../attachmentSource";
 import { logger } from "@beaver/agent-core/platform/logger";
@@ -122,7 +123,7 @@ export async function resolveSnapshotSectionMeta(
     } catch {
         title = undefined;
     }
-    const filename = item.attachmentFilename || undefined;
+    const filename = safeAttachmentFilename(item) ?? undefined;
     return {
         rawHref: url || filename,
         fallbackLabel: title || filename,

--- a/src/services/reports/createReportSnapshot.ts
+++ b/src/services/reports/createReportSnapshot.ts
@@ -9,6 +9,7 @@
 
 import { logger } from '@beaver/agent-core/platform/logger';
 import { getZoteroSelectURI } from '../../utils/zoteroUtils';
+import { safeAttachmentFilename } from '../../utils/attachmentFiles';
 import { checkLibraryExcluded } from '../agentDataProvider/utils';
 import { buildReportHtml, CSS_RULE_BUDGET, type ReportSpec } from './reportHtml';
 
@@ -139,7 +140,7 @@ export async function createReportSnapshot(options: CreateReportOptions): Promis
         key: attachment.key,
         libraryID: attachment.libraryID,
         title,
-        filename: attachment.attachmentFilename || null,
+        filename: safeAttachmentFilename(attachment),
         byteLength: new TextEncoder().encode(html).length,
         cssRuleCount,
         selectUri: getZoteroSelectURI(attachment.libraryID, attachment.key),

--- a/src/utils/attachmentFiles.ts
+++ b/src/utils/attachmentFiles.ts
@@ -18,6 +18,35 @@ export async function safeFileExists(item: Zotero.Item): Promise<boolean> {
 }
 
 /**
+ * Safely read an attachment's filename.
+ *
+ * Zotero's `attachmentFilename` getter calls `PathUtils.filename()` for any
+ * attachment path not prefixed `storage:` or `attachments:` — i.e. a linked
+ * file stored with an absolute path. Gecko throws
+ * `NS_ERROR_FILE_UNRECOGNIZED_PATH` when that path is not valid for the current
+ * platform: a library carried across Windows and macOS, a `file://` URL stored
+ * as a path, or a `~`-prefixed or relative path. The stored path itself is a
+ * plain field read, so fall back to its trailing segment.
+ *
+ * Always use this instead of reading `item.attachmentFilename` directly — one
+ * malformed row must never take out a whole response.
+ *
+ * @param item - Zotero item to read
+ * @returns the filename, a best-effort basename, or null
+ */
+export function safeAttachmentFilename(item: Zotero.Item): string | null {
+    try {
+        return item.attachmentFilename || null;
+    } catch {
+        try {
+            return item.attachmentPath?.split(/[\\/]/).pop() || null;
+        } catch {
+            return null;
+        }
+    }
+}
+
+/**
  * Check if an attachment is a linked URL, which has no associated file.
  *
  * @param item - Zotero item to check

--- a/src/utils/webAPI.ts
+++ b/src/utils/webAPI.ts
@@ -1,4 +1,5 @@
 import { logger } from "@beaver/agent-core/platform/logger";
+import { safeAttachmentFilename } from "./attachmentFiles";
 
 function redactUrlCredentials(message: string): string {
     if (!message) return message;
@@ -297,7 +298,7 @@ async function extractFileFromZip(zipData: Uint8Array, item: Zotero.Item): Promi
 
         try {
             // Find the entry to extract - prefer the expected filename, fallback to first entry
-            const expectedFilename = item.attachmentFilename;
+            const expectedFilename = safeAttachmentFilename(item);
             let entryName: string;
             
             if (expectedFilename && zipReader.hasEntry(expectedFilename)) {

--- a/src/utils/zoteroSerializers.ts
+++ b/src/utils/zoteroSerializers.ts
@@ -4,6 +4,7 @@ import { logger } from '@beaver/agent-core/platform/logger';
 import { libraryRefForLibraryID, modelObjectId } from './libraryIdentity';
 import { ItemDataHashedFields, AttachmentDataHashedFields, ItemData, ItemStub, ItemSummary, CollectionSummary, ZoteroCreator, ZoteroCollection, BibliographicIdentifier, AttachmentDataWithMimeType, ZoteroLibrary, AttachmentStub } from '@beaver/agent-core/types/zotero';
 import { getCollectionClientDateModifiedAsISOString, getCitationKeyFromItem, getMimeType, safeIsInTrash, safeFileExists } from './zoteroUtils';
+import { safeAttachmentFilename } from './attachmentFiles';
 import { syncingItemFilterAsync } from './sync';
 import { isAttachmentOnServer } from './webAPI';
 import { skippedItemsManager } from '../services/skippedItemsManager';
@@ -459,7 +460,7 @@ export function serializeAttachmentStub(item: Zotero.Item, contentKind?: Content
         library_ref: libraryRefForLibraryID(item.libraryID) ?? undefined,
         parent_item_id: item.parentKey ? modelObjectId(item.libraryID, item.parentKey) : null,
         title: item.getField?.('title') || item.getDisplayTitle?.() || null,
-        filename: item.attachmentFilename || null,
+        filename: safeAttachmentFilename(item),
         content_kind: contentKind ?? getContentKind(item),
     };
 }
@@ -546,7 +547,9 @@ export async function serializeAttachment(
             return trashState;
         })(),
         title: item.getField('title', false, true),
-        filename: item.attachmentFilename,
+        // `?? ''` keeps the hash identical to a direct `attachmentFilename` read
+        // for healthy rows (the getter returns '' for an empty path).
+        filename: safeAttachmentFilename(item) ?? '',
     };
 
     // 3. Metadata Hash: Calculate hash from the prepared hashed fields object

--- a/src/utils/zoteroUtils.ts
+++ b/src/utils/zoteroUtils.ts
@@ -3,6 +3,7 @@ import { ZoteroItemReference } from "@beaver/agent-core/types/zotero";
 import type { CreatorJSON } from "@beaver/agent-core/types/agentActions/base";
 import { logger } from "@beaver/agent-core/platform/logger";
 import { libraryRefForLibraryID, UNRESOLVED_LIBRARY_ID } from "./libraryIdentity";
+import { safeAttachmentFilename } from "./attachmentFiles";
 import type { ZoteroInstanceRef } from "@beaver/agent-core/transport/threadService";
 import { getSelectedLibraryId, getSelectedCollection } from "./zoteroSelection";
 
@@ -624,7 +625,7 @@ export function getMimeTypeFromData(attachment: Zotero.Item, fileData: Uint8Arra
         }
 
         // Get the file extension from the attachment's filename as a hint.
-        const extension = (attachment.attachmentFilename.split('.').pop() || '').toLowerCase();
+        const extension = ((safeAttachmentFilename(attachment) ?? '').split('.').pop() || '').toLowerCase();
 
         // Use Zotero's internal data-based MIME type detection
         return Zotero.MIME.getMIMETypeFromData(sampleString, extension);

--- a/tests/unit/handlers/degradedAttachment.test.ts
+++ b/tests/unit/handlers/degradedAttachment.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for degradedAttachmentInfo / degradedAttachmentRow
+ * (src/services/agentDataProvider/utils.ts) — the stubs the list, search, and
+ * metadata handlers fall back to when one record throws while being read.
+ *
+ * The module has a wide transitive dependency surface these functions never
+ * touch, so every unrelated dependency is stubbed out just to make the module
+ * importable in isolation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({
+    logger: vi.fn(),
+}));
+vi.mock('../../../src/utils/sync', () => ({
+    syncingItemFilterAsync: vi.fn(),
+}));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: vi.fn(),
+}));
+vi.mock('../../../src/utils/webAPI', () => ({
+    isAttachmentOnServer: vi.fn(),
+}));
+vi.mock('../../../react/utils/popupMessageUtils', () => ({
+    addPopupMessageAtom: {},
+}));
+vi.mock('../../../react/utils/sourceUtils', () => ({
+    wasItemAddedBeforeLastSync: vi.fn(),
+}));
+vi.mock('../../../react/atoms/deferredToolPreferences', () => ({
+    deferredToolPreferencesAtom: {},
+}));
+vi.mock('../../../src/utils/agentItemSupport', () => ({
+    isAgentSupportedItem: vi.fn(),
+}));
+vi.mock('../../../react/store', () => ({
+    store: { get: vi.fn() },
+}));
+vi.mock('../../../react/agents/atoms', () => ({
+    activeRunAtom: Symbol('activeRunAtom'),
+}));
+vi.mock('../../../react/atoms/profile', () => ({
+    searchableLibraryIdsAtom: Symbol('searchableLibraryIdsAtom'),
+}));
+vi.mock('../../../src/services/documentExtraction/attachmentInfo', () => ({
+    getAttachmentInfo: vi.fn(),
+}));
+vi.mock('../../../src/services/documentExtraction/attachmentInfoBatch', () => ({
+    getBestAttachmentBatch: vi.fn(),
+    prepareAttachmentInfoBatchData: vi.fn(),
+    processAttachmentInfoBatch: vi.fn(),
+}));
+vi.mock('../../../src/services/documentExtraction', () => ({
+    loadPdfData: vi.fn(),
+    isRemoteAccessAvailable: vi.fn(),
+    validateZoteroItemReference: vi.fn(),
+    checkRemotePdfSize: vi.fn(),
+    preflightCachedPdfMeta: vi.fn(),
+    resolveToPdfAttachment: vi.fn(),
+    resolveToImageAttachment: vi.fn(),
+}));
+
+import {
+    degradedAttachmentInfo,
+    degradedAttachmentRow,
+} from '../../../src/services/agentDataProvider/utils';
+
+/**
+ * An attachment whose `attachmentFilename` getter throws the way Zotero's does
+ * when `PathUtils.filename()` cannot parse the stored path.
+ */
+function makeMalformedAttachment(overrides: Record<string, unknown> = {}): Zotero.Item {
+    return {
+        libraryID: 1,
+        key: 'BADATT1',
+        dateModified: '2024-05-01 12:00:00',
+        getDisplayTitle: () => 'Broken PDF',
+        get attachmentFilename(): string {
+            throw new Error(
+                'OperationError: PathUtils.filename: Could not initialize path: '
+                + 'NS_ERROR_FILE_UNRECOGNIZED_PATH'
+            );
+        },
+        attachmentPath: '/Volumes/other/paper.pdf',
+        ...overrides,
+    } as unknown as Zotero.Item;
+}
+
+describe('degradedAttachmentInfo', () => {
+    let previousZotero: any;
+
+    beforeEach(() => {
+        previousZotero = (globalThis as any).Zotero;
+        (globalThis as any).Zotero = {
+            Libraries: { userLibraryID: 1 },
+            Groups: { getGroupIDFromLibraryID: vi.fn(() => false) },
+        };
+    });
+
+    afterEach(() => {
+        (globalThis as any).Zotero = previousZotero;
+    });
+
+    it('identifies the row and recovers what it can without throwing', () => {
+        const info = degradedAttachmentInfo(makeMalformedAttachment(), 'u-PARENT12');
+
+        expect(info).toEqual(expect.objectContaining({
+            attachment_id: 'u-BADATT1',
+            parent_item_id: 'u-PARENT12',
+            title: 'Broken PDF',
+            // Recovered from attachmentPath, since the getter throws.
+            filename: 'paper.pdf',
+            content_kind: 'other',
+            status: 'unreadable',
+        }));
+        expect(info.status_reason).toBeTruthy();
+    });
+
+    it('defaults is_primary to false for callers that do not know', () => {
+        expect(degradedAttachmentInfo(makeMalformedAttachment(), null).is_primary).toBe(false);
+    });
+
+    it('preserves is_primary when the caller resolved the best attachment', () => {
+        // get_metadata computes this before resolving the attachment; losing it
+        // would tell the model the parent item has no primary attachment.
+        const info = degradedAttachmentInfo(makeMalformedAttachment(), 'u-PARENT12', true);
+        expect(info.is_primary).toBe(true);
+    });
+
+    it('survives an item whose title and dateModified also throw', () => {
+        // Built literally rather than via makeMalformedAttachment: an object
+        // spread would evaluate these getters before the helper ever runs.
+        const hostile = {
+            libraryID: 1,
+            key: 'BADATT1',
+            getDisplayTitle: () => {
+                throw new Error('unavailable');
+            },
+            get dateModified(): string {
+                throw new Error('unavailable');
+            },
+            get attachmentFilename(): string {
+                throw new Error('NS_ERROR_FILE_UNRECOGNIZED_PATH');
+            },
+            attachmentPath: undefined,
+        } as unknown as Zotero.Item;
+
+        const row = degradedAttachmentRow(hostile, null);
+        expect(row).toEqual(expect.objectContaining({
+            result_type: 'attachment',
+            attachment_id: 'u-BADATT1',
+            title: null,
+            filename: null,
+            date_modified: null,
+            status: 'unreadable',
+        }));
+    });
+});
+
+describe('degradedAttachmentRow', () => {
+    let previousZotero: any;
+
+    beforeEach(() => {
+        previousZotero = (globalThis as any).Zotero;
+        (globalThis as any).Zotero = {
+            Libraries: { userLibraryID: 1 },
+            Groups: { getGroupIDFromLibraryID: vi.fn(() => false) },
+        };
+    });
+
+    afterEach(() => {
+        (globalThis as any).Zotero = previousZotero;
+    });
+
+    it('carries the parent anchor through to the search/list row', () => {
+        const parent = {
+            item_id: 'u-PARENT12',
+            item_type: 'journalArticle',
+            title: 'Parent Paper',
+            creators: null,
+            year: null,
+        };
+
+        const row = degradedAttachmentRow(makeMalformedAttachment(), parent as any);
+
+        expect(row).toEqual(expect.objectContaining({
+            result_type: 'attachment',
+            parent_item_id: 'u-PARENT12',
+            parent_title: 'Parent Paper',
+            parent_item: parent,
+            date_modified: '2024-05-01 12:00:00',
+            // list/search rows never resolve the parent's best attachment.
+            is_primary: false,
+        }));
+    });
+});

--- a/tests/unit/handlers/listItems.test.ts
+++ b/tests/unit/handlers/listItems.test.ts
@@ -32,6 +32,24 @@ vi.mock('../../../src/services/agentDataProvider/utils', () => ({
     extractYear: vi.fn(() => null),
     formatCreatorsString: vi.fn(() => ''),
     getAttachmentInfoForItem: vi.fn(),
+    // Mirrors the real stub's shape. The guarded reads it is built from are
+    // covered directly by tests/unit/utils/attachmentFiles.test.ts.
+    degradedAttachmentRow: vi.fn((item: any, parentInfo: any) => ({
+        result_type: 'attachment',
+        attachment_id: `${item.libraryID}-${item.key}`,
+        parent_item_id: parentInfo?.item_id ?? null,
+        title: null,
+        filename: null,
+        content_kind: 'other',
+        status: 'unreadable',
+        status_reason: 'malformed',
+        page_count: null,
+        line_count: null,
+        is_primary: false,
+        parent_title: parentInfo?.title ?? null,
+        parent_item: parentInfo ?? null,
+        date_modified: null,
+    })),
 }));
 
 // Keep the real serializeNote; stub serializeItemStub so parent serialization
@@ -340,5 +358,73 @@ describe('handleListItemsRequest', () => {
             item_id: 'u-PORTABLE1',
             result_type: 'regular',
         }));
+    });
+
+    it('degrades an unreadable attachment to a stub instead of failing the page', async () => {
+        const good1 = makeItem({
+            id: 1,
+            key: 'GOOD1',
+            itemType: 'attachment',
+            isAttachment: vi.fn(() => true),
+            isRegularItem: vi.fn(() => false),
+            attachmentFilename: 'good1.pdf',
+            attachmentContentType: 'application/pdf',
+        });
+        // Stands in for a linked file whose stored path Zotero cannot parse:
+        // reading it throws NS_ERROR_FILE_UNRECOGNIZED_PATH.
+        const bad = makeItem({
+            id: 2,
+            key: 'BAD',
+            itemType: 'attachment',
+            isAttachment: vi.fn(() => true),
+            isRegularItem: vi.fn(() => false),
+        });
+        const good2 = makeItem({
+            id: 3,
+            key: 'GOOD2',
+            itemType: 'attachment',
+            isAttachment: vi.fn(() => true),
+            isRegularItem: vi.fn(() => false),
+            attachmentFilename: 'good2.pdf',
+            attachmentContentType: 'application/pdf',
+        });
+
+        const resolveInfo = vi.mocked(getAttachmentInfoForItem).getMockImplementation()!;
+        vi.mocked(getAttachmentInfoForItem).mockImplementation(async (item: any, options: any = {}) => {
+            if (item.key === 'BAD') {
+                throw new Error(
+                    'OperationError: PathUtils.filename: Could not initialize path: '
+                    + 'NS_ERROR_FILE_UNRECOGNIZED_PATH'
+                );
+            }
+            return resolveInfo(item, options);
+        });
+
+        for (const item of [good1, bad, good2]) {
+            itemsById.set(item.id, item);
+        }
+        searchResults.push([good1.id, bad.id, good2.id]);
+
+        const response = await handleListItemsRequest({
+            event: 'list_items_request',
+            request_id: 'req-6',
+            item_category: 'attachment',
+            recursive: true,
+            sort_by: 'dateModified',
+            sort_order: 'desc',
+            limit: 20,
+            offset: 0,
+        });
+
+        expect(response.error).toBeUndefined();
+        expect(response.error_code).toBeUndefined();
+        expect(response.total_count).toBe(3);
+        expect(response.items).toHaveLength(3);
+        expect(response.items.map((i: any) => i.attachment_id)).toEqual(
+            expect.arrayContaining(['1-GOOD1', '1-BAD', '1-GOOD2'])
+        );
+        expect(response.items.find((i: any) => i.attachment_id === '1-BAD')).toEqual(
+            expect.objectContaining({ result_type: 'attachment', status: 'unreadable' })
+        );
     });
 });

--- a/tests/unit/utils/attachmentFiles.test.ts
+++ b/tests/unit/utils/attachmentFiles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeAttachmentFilename } from '../../../src/utils/attachmentFiles';
+
+/**
+ * Build an attachment whose `attachmentFilename` getter throws, the way
+ * Zotero's does when `PathUtils.filename()` cannot parse the stored path.
+ */
+function makeUnparseableAttachment(attachmentPath: string | undefined): Zotero.Item {
+    return {
+        get attachmentFilename(): string {
+            throw new Error(
+                'OperationError: PathUtils.filename: Could not initialize path: '
+                + 'NS_ERROR_FILE_UNRECOGNIZED_PATH'
+            );
+        },
+        attachmentPath,
+    } as unknown as Zotero.Item;
+}
+
+describe('safeAttachmentFilename', () => {
+    it('returns the filename for a healthy attachment', () => {
+        const item = { attachmentFilename: 'paper.pdf' } as unknown as Zotero.Item;
+        expect(safeAttachmentFilename(item)).toBe('paper.pdf');
+    });
+
+    it('normalizes an empty filename to null', () => {
+        const item = { attachmentFilename: '' } as unknown as Zotero.Item;
+        expect(safeAttachmentFilename(item)).toBeNull();
+    });
+
+    it('falls back to the basename of a Windows path the getter cannot parse', () => {
+        const item = makeUnparseableAttachment('C:\\Users\\x\\Zotero\\storage\\paper.pdf');
+        expect(safeAttachmentFilename(item)).toBe('paper.pdf');
+    });
+
+    it('falls back to the basename of a POSIX path the getter cannot parse', () => {
+        const item = makeUnparseableAttachment('~/Documents/library/paper.pdf');
+        expect(safeAttachmentFilename(item)).toBe('paper.pdf');
+    });
+
+    it('returns null when the getter throws and there is no usable path', () => {
+        expect(safeAttachmentFilename(makeUnparseableAttachment(undefined))).toBeNull();
+        expect(safeAttachmentFilename(makeUnparseableAttachment(''))).toBeNull();
+    });
+
+    it('returns null when reading the path throws too', () => {
+        const item = {
+            get attachmentFilename(): string {
+                throw new Error('NS_ERROR_FILE_UNRECOGNIZED_PATH');
+            },
+            get attachmentPath(): string {
+                throw new Error('unavailable');
+            },
+        } as unknown as Zotero.Item;
+        expect(safeAttachmentFilename(item)).toBeNull();
+    });
+});


### PR DESCRIPTION
This update introduces the `safeAttachmentFilename` utility function to safely retrieve attachment filenames, preventing errors from invalid paths. The function is integrated across various components and services, ensuring that unreadable attachments are handled gracefully by degrading to stubs without failing the entire process. Additionally, unit tests for `degradedAttachmentInfo` and `safeAttachmentFilename` have been added to ensure robust functionality and error handling.