### PR TITLE
feat(agent-core): implement deferred approval stale handling

### DIFF
--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -1598,6 +1598,28 @@ export interface WSDeferredApprovalResponse {
     user_instructions?: string | null;
 }
 
+/**
+ * The backend is no longer waiting on an approval we responded to.
+ *
+ * Sent when a `deferred_approval_response` arrives after the backend's wait
+ * expired (the tool already returned `pending` and the run moved on). Without
+ * it the client cannot tell a swallowed response from one still being
+ * processed, and would show the card as "awaiting approval" indefinitely.
+ *
+ * The proposal itself is unaffected — it is still stored and still applicable —
+ * so the client should restore the card's local apply/reject controls.
+ */
+export interface WSDeferredApprovalStale extends WSBaseEvent {
+    event: 'deferred_approval_stale';
+    /** The AgentAction ID whose approval response was too late */
+    action_id: string;
+    /**
+     * `timed_out`: the backend was waiting and gave up.
+     * `unknown`: no record of this action on this connection.
+     */
+    reason: 'timed_out' | 'unknown';
+}
+
 /** One selectable option of an ask_user_question item (ids are server-assigned) */
 export interface AskUserQuestionOption {
     /** Server-assigned option id (e.g. 'q0-o1') */
@@ -1706,6 +1728,7 @@ export type WSEvent =
     | WSAgentActionValidateRequest
     | WSAgentActionExecuteRequest
     | WSDeferredApprovalRequest
+    | WSDeferredApprovalStale
     // User interaction events
     | WSAskUserQuestionRequest;
 
@@ -2157,6 +2180,14 @@ export interface WSCallbacks {
      * @param event The deferred approval request with action details
      */
     onDeferredApprovalRequest?: (event: WSDeferredApprovalRequest) => void;
+
+    /**
+     * Called when an approval response we sent arrived too late to be used.
+     * The frontend should stop showing the action as awaiting a decision and
+     * restore its local apply/reject controls.
+     * @param event The stale-approval notice, keyed by action id
+     */
+    onDeferredApprovalStale?: (event: WSDeferredApprovalStale) => void;
 
     /**
      * Called when the backend asks the user structured multiple-choice

--- a/packages/agent-core/src/transport/agentService.ts
+++ b/packages/agent-core/src/transport/agentService.ts
@@ -425,8 +425,24 @@ export class AgentService {
                     logger('AgentService: Server ready, sending agent run request', 1);
                     // Call the original onReady callback first
                     callbacks.onReady(data);
-                    // Send the chat request now that server is ready
-                    this.send(request);
+                    // Send the chat request now that server is ready. A socket
+                    // that reports OPEN can still refuse the write (half-open
+                    // channel); failing the connect here is what surfaces that
+                    // instead of leaving the user on an endless thinking state
+                    // for a run the server never received.
+                    if (!this.send(request)) {
+                        // Reject before close(), matching the timeout path:
+                        // close() settles this same promise, so closing first
+                        // would let the failure resolve as a success. The socket
+                        // must still be torn down — `ready` already marked the
+                        // connection live, so nothing else would reclaim it.
+                        finish(new AgentConnectionError(
+                            'Connection closed before the request could be sent',
+                            attemptEvidence(attempt, { requestNeverSent: true }),
+                        ));
+                        this.close(1000, 'Request could not be sent');
+                        return;
+                    }
                     // Resolve the connect promise
                     finish();
                 },
@@ -545,12 +561,16 @@ export class AgentService {
     }
 
     /**
-     * Send a message to the server
+     * Send a message to the server.
+     *
+     * Returns false when the socket is not open, so callers whose message
+     * carries a user decision can recover locally instead of assuming it went
+     * out. Most callers can ignore the result.
      */
-    send(data: AgentRunRequest | Record<string, any> | PreparedJsonMessage): void {
+    send(data: AgentRunRequest | Record<string, any> | PreparedJsonMessage): boolean {
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
             logger('AgentService: Cannot send - WebSocket not connected', 1);
-            return;
+            return false;
         }
 
         // Attach a completion-time busy-context snapshot to request responses
@@ -616,8 +636,14 @@ export class AgentService {
         }
         // Log the sanitized and stripped data
         logger(`AgentService: Sending "${sanitizedData.type}"`, sanitizedData, 1);
-        
-        this.ws.send(message);
+
+        try {
+            this.ws.send(message);
+        } catch (error) {
+            logger(`AgentService: Send failed: ${error}`, 1);
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -809,6 +835,11 @@ export class AgentService {
                     }
                     break;
 
+                case 'deferred_approval_stale':
+                    logger("AgentService: Received deferred_approval_stale", event, 1);
+                    this.callbacks?.onDeferredApprovalStale?.(event);
+                    break;
+
                 case 'ask_user_question_request':
                     logger("AgentService: Received ask_user_question_request", event, 1);
                     // This event is handled by the UI via callback
@@ -839,9 +870,9 @@ export class AgentService {
                     }
                     const dataEvent = event as any;
                     logger(`AgentService: Received ${eventName}`, dataEvent, 1);
-                    const runRequest = () =>
+                    const runRequest = (): Promise<void> =>
                         entry.handle(dataEvent)
-                            .then(res => this.send(res))
+                            .then(res => { this.send(res); })
                             .catch(err => {
                                 logger(`AgentService: ${eventName} failed: ${err}`, 1);
                                 this.send(entry.errorResponse(dataEvent, err));
@@ -962,10 +993,13 @@ export class AgentService {
      * @param actionId The action ID from the approval request
      * @param approved Whether the user approved the action
      * @param userInstructions Optional additional instructions from the user
+     * @returns false if the socket was not open, so the decision never left the
+     *   client. The caller must recover the card rather than wait for a reply
+     *   that cannot come.
      */
-    sendApprovalResponse(actionId: string, approved: boolean, userInstructions?: string | null): void {
+    sendApprovalResponse(actionId: string, approved: boolean, userInstructions?: string | null): boolean {
         logger(`AgentService: Sending approval response for ${actionId}: ${approved}${userInstructions ? ' (with instructions)' : ''}`, 1);
-        this.send({
+        return this.send({
             type: 'deferred_approval_response',
             action_id: actionId,
             approved,

--- a/packages/agent-core/src/transport/connectionFailure.ts
+++ b/packages/agent-core/src/transport/connectionFailure.ts
@@ -32,6 +32,12 @@ export interface ConnectionFailureEvidence {
      * mid-stream cuts.
      */
     msSinceLastWsMessageMs?: number | null;
+    /**
+     * The run request was never handed to the socket, so the server cannot have
+     * started a run for it. Set when the write is refused outright — the one
+     * post-`ready` failure that is as safe to retry as a pre-`ready` one.
+     */
+    requestNeverSent?: boolean;
 }
 
 /** navigator.onLine when available; null in contexts without a navigator global. */
@@ -78,11 +84,19 @@ export function isAbruptTransportCloseCode(code: number | null): boolean {
 /**
  * Whether a failed connect attempt is worth retrying automatically.
  *
- * Only pre-`ready` transport failures qualify: an abrupt transport drop
- * (1005/1006) while opening, authenticating, or awaiting ready, or a connect
- * attempt that timed out after the socket started opening. These are the
- * failures that a cold-starting instance, a scale event, or a momentary
- * network block produce, and they routinely succeed on a quick retry.
+ * The rule is not really about timing but about whether the server can have
+ * started a run: retrying is safe exactly while the request has not reached it.
+ *
+ * Pre-`ready` transport failures qualify: an abrupt transport drop (1005/1006)
+ * while opening, authenticating, or awaiting ready, or a connect attempt that
+ * timed out after the socket started opening. These are the failures that a
+ * cold-starting instance, a scale event, or a momentary network block produce,
+ * and they routinely succeed on a quick retry.
+ *
+ * A refused write of the run request itself qualifies for the same reason,
+ * even though it happens after `ready` — the socket never took the message, so
+ * no run exists to duplicate, and the half-open channel behind it is usually
+ * transient.
  *
  * Auth-stage failures (the session lookup itself), policy rejections (1008),
  * and application-level errors are excluded — they will not fix themselves
@@ -91,6 +105,7 @@ export function isAbruptTransportCloseCode(code: number | null): boolean {
 export function isRetryablePreReadyConnectFailure(
     evidence: ConnectionFailureEvidence,
 ): boolean {
+    if (evidence.requestNeverSent) return true;
     if (
         evidence.stage !== 'opening' &&
         evidence.stage !== 'authenticating' &&

--- a/react/agents/agentActions.ts
+++ b/react/agents/agentActions.ts
@@ -618,83 +618,10 @@ export const hasPendingApprovalsAtom = atom(
     (get) => get(pendingApprovalsAtom).size > 0
 );
 
-/**
- * Build a PendingApproval from an AgentAction.
- * Fetches current field values for edit_metadata actions.
- */
-export async function buildPendingApprovalFromAction(action: AgentAction): Promise<PendingApproval | null> {
-    if (!action.toolcall_id) {
-        return null;
-    }
-
-    const actionType = action.action_type as AgentActionType;
-    const actionData = action.proposed_data ?? {};
-    let currentValue: Record<string, any> | undefined;
-
-    if (actionType === 'edit_metadata') {
-        const libraryId = typeof actionData.library_id === 'number'
-            ? actionData.library_id
-            : Number(actionData.library_id ?? 0);
-        const zoteroKey = typeof actionData.zotero_key === 'string'
-            ? actionData.zotero_key
-            : '';
-        const edits = Array.isArray(actionData.edits) ? actionData.edits : [];
-        const hasCreators = Array.isArray(actionData.creators) && actionData.creators.length > 0;
-
-        if (libraryId && zoteroKey && (edits.length > 0 || hasCreators)) {
-            const resolved = await resolveItemReference({
-                library_id: libraryId,
-                library_ref: typeof actionData.library_ref === 'string' ? actionData.library_ref : undefined,
-                zotero_key: zoteroKey,
-            });
-            if (resolved.status === 'found') {
-                const item = resolved.item;
-                const values: Record<string, any> = {};
-                for (const edit of edits) {
-                    const field = typeof edit?.field === 'string' ? edit.field : null;
-                    if (!field) continue;
-                    const value = item.getField(field);
-                    values[field] = value ? String(value) : null;
-                }
-                // Always include current creators for before/after tracking
-                values.current_creators = item.getCreatorsJSON();
-                currentValue = values;
-            }
-        }
-    } else if (actionType === 'create_collection') {
-        const libraryId = typeof actionData.library_id === 'number'
-            ? actionData.library_id
-            : Number(actionData.library_id ?? 0);
-
-        if (libraryId) {
-            const library = Zotero.Libraries.get(libraryId);
-            currentValue = {
-                library_id: libraryId,
-                library_name: library ? library.name : 'Unknown Library',
-                parent_key: actionData.parent_key ?? null,
-                item_count: actionData.item_ids?.length ?? 0,
-            };
-        }
-    } else if (actionType === 'organize_items') {
-        // For organize_items, current_state contains the current tags/collections for each item
-        // We can use it directly from the proposed data if available
-        currentValue = actionData.current_state ?? null;
-    } else if (actionType === 'confirm_extraction') {
-        // No Zotero data fetching needed — cost info is entirely in proposed_data
-        currentValue = undefined;
-    } else if (actionType === 'confirm_external_search') {
-        // No Zotero data fetching needed — cost info is entirely in proposed_data
-        currentValue = undefined;
-    } else if (actionType === 'edit_note' || actionType === 'edit_note_batch') {
-        // No extra Zotero data fetching needed — old_string/new_string are in proposed_data
-        currentValue = undefined;
-    }
-
-    return {
-        actionId: action.id,
-        toolcallId: action.toolcall_id,
-        actionType,
-        actionData,
-        currentValue,
-    };
-}
+// Note: `pendingApprovalsAtom` means "the backend is blocked waiting on this
+// decision". Do not rebuild entries from stored pending actions — an action left
+// pending by a timeout has no waiter, so a re-added entry would show an
+// "awaiting approval" card whose Approve button sends into the void. Such
+// actions are applied locally through the `status === 'pending'` controls
+// instead, and `staleApprovalActionIdsAtom` marks approvals whose channel has
+// closed.

--- a/react/atoms/agentRunAtoms.ts
+++ b/react/atoms/agentRunAtoms.ts
@@ -34,6 +34,7 @@ import {
     WSToolCallArgsStreamEvent,
     WSMissingZoteroDataEvent,
     WSDeferredApprovalRequest,
+    WSDeferredApprovalStale,
     WSAskUserQuestionRequest,
     AskUserQuestionAnswer,
     WSStreamingDoneEvent,
@@ -118,7 +119,6 @@ import {
     removePendingApprovalAtom,
     removePendingApprovalsAtom,
     pendingApprovalsAtom,
-    buildPendingApprovalFromAction,
     clearAllPendingApprovalsAtom,
 } from '../agents/agentActions';
 import {
@@ -1277,6 +1277,7 @@ export const prepareForNewRunAtom = atom(null, (_get, set) => {
     set(clearAllPendingApprovalsAtom);
     set(clearAllPendingQuestionsAtom);
     set(clearApprovalResponseIntentsAtom);
+    set(clearStaleApprovalsAtom);
     set(clearRunApprovalPolicyAtom);
 });
 
@@ -1974,6 +1975,19 @@ function createWSCallbacks(set: Setter): WSCallbacks {
 
             // Default: add to pending approvals map for UI rendering
             set(addPendingApprovalAtom, event);
+        },
+
+        onDeferredApprovalStale: (event: WSDeferredApprovalStale) => {
+            logger('WS onDeferredApprovalStale:', {
+                actionId: event.action_id,
+                reason: event.reason,
+            }, 1);
+            // The decision arrived after the backend stopped waiting, so the run
+            // never saw it. Retire the approval and let the card fall back to
+            // applying the (still valid) proposal locally.
+            set(markApprovalStaleAtom, event.action_id);
+            set(removePendingApprovalAtom, event.action_id);
+            set(removeApprovalResponseIntentAtom, event.action_id);
         },
 
         onAskUserQuestionRequest: (event: WSAskUserQuestionRequest) => {
@@ -3205,8 +3219,49 @@ export const clearApprovalResponseIntentsAtom = atom(
 );
 
 /**
+ * Deferred actions whose approval channel is closed: the user's decision either
+ * never left the client (socket down) or reached a backend that had already
+ * stopped waiting (`deferred_approval_stale`). The run cannot act on it.
+ *
+ * The proposal itself is untouched — still stored, still applicable — so views
+ * use this to drop the "awaiting approval" spinner and restore the local
+ * apply/reject controls. Without it a card waits forever on a reply that the
+ * backend will never send.
+ */
+export const staleApprovalActionIdsAtom = atom<Set<string>>(new Set<string>());
+
+export const markApprovalStaleAtom = atom(
+    null,
+    (_get, set, actionId: string) => {
+        set(staleApprovalActionIdsAtom, (prev) => {
+            if (prev.has(actionId)) return prev;
+            const next = new Set(prev);
+            next.add(actionId);
+            return next;
+        });
+    },
+);
+
+export const clearStaleApprovalsAtom = atom(
+    null,
+    (_get, set) => {
+        set(staleApprovalActionIdsAtom, new Set<string>());
+    },
+);
+
+// Note: clearing `pendingApprovalsAtom` when a run ends does not strand the
+// proposals it was carrying. Every deferred tool emits and persists its action
+// before it starts waiting, so each card falls back to the `status === 'pending'`
+// controls it already has and stays appliable. Recovering a card whose decision
+// was already sent is the view's job — see `useApprovalRecovery`.
+
+/**
  * Send approval response for a deferred action.
  * Called by the UI when user approves/rejects an action.
+ *
+ * A send that never left the client is recorded as stale immediately: the
+ * backend cannot answer a message it never received, so the card would
+ * otherwise sit on a spinner until the thread is reloaded.
  */
 export const sendApprovalResponseAtom = atom(
     null,
@@ -3217,7 +3272,11 @@ export const sendApprovalResponseAtom = atom(
             return next;
         });
         logger(`sendApprovalResponseAtom: Sending approval response for ${actionId}: ${approved}${userInstructions ? ' (with instructions)' : ''}`, 1);
-        agentService.sendApprovalResponse(actionId, approved, userInstructions);
+        const delivered = agentService.sendApprovalResponse(actionId, approved, userInstructions);
+        if (!delivered) {
+            logger(`sendApprovalResponseAtom: Approval response for ${actionId} was not sent; marking stale`, 1);
+            set(markApprovalStaleAtom, actionId);
+        }
     }
 );
 

--- a/react/host/zotero/components/AgentActionView.tsx
+++ b/react/host/zotero/components/AgentActionView.tsx
@@ -87,6 +87,7 @@ import {
     PreviewData,
 } from './agentActionViewHelpers';
 import { ActionPreview } from './ActionPreview';
+import { useApprovalRecovery } from './useApprovalRecovery';
 import { currentThreadIdAtom } from '../../../atoms/threads';
 import {
     getToolGroupRunApprovalLabel,
@@ -244,6 +245,19 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
         fetchTitle();
     }, [action, pendingApproval, itemTitle, itemTitleKey, hasAssociatedItem, setItemTitle]);
 
+    const handleApprovalRecovered = useCallback(() => {
+        setIsProcessingApproval(false);
+        setIsExternallyProcessing(false);
+        setClickedButton(null);
+    }, []);
+    const { setProcessingApproval } = useApprovalRecovery({
+        isAwaitingDecision: isProcessingApproval || isExternallyProcessing,
+        hasToolReturn,
+        actionStatus: action?.status,
+        onRecover: handleApprovalRecovered,
+        label: `AgentActionView(${toolName})`,
+    });
+
     useEffect(() => {
         const previousPendingApproval = prevPendingApprovalRef.current;
         const wasAwaiting = previousPendingApproval !== null;
@@ -256,6 +270,13 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
             if (!isProcessingApproval && isRunPending && !hasToolReturn) {
                 setIsExternallyProcessing(true);
                 setClickedButton(previousIntent === false ? 'reject' : 'approve');
+                // Record it for recovery too: a decision made from another
+                // surface (Approve All, the composer, the diff-preview banner)
+                // can miss its window exactly like one made here.
+                setProcessingApproval({
+                    actionId: previousActionId,
+                    kind: previousIntent === false ? 'reject' : 'approve',
+                });
             }
 
             if (previousIntent !== undefined) {
@@ -271,19 +292,22 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
         hasToolReturn,
         approvalResponseIntents,
         removeApprovalResponseIntent,
+        setProcessingApproval,
     ]);
 
     useEffect(() => {
         if ((isProcessingApproval || isExternallyProcessing) && action && action.status !== 'pending') {
             setIsProcessingApproval(false);
+            setProcessingApproval(null);
             setIsExternallyProcessing(false);
             setClickedButton(null);
         }
         if (isExternallyProcessing && (hasToolReturn || !isRunPending)) {
             setIsExternallyProcessing(false);
+            setProcessingApproval(null);
             setClickedButton(null);
         }
-    }, [isProcessingApproval, isExternallyProcessing, action?.status, hasToolReturn, isRunPending, action]);
+    }, [isProcessingApproval, isExternallyProcessing, action?.status, hasToolReturn, isRunPending, action, setProcessingApproval]);
 
     const isProcessing = isProcessingApproval || isProcessingAction || isExternallyProcessing;
     const actionDisplayStatus = action ? getCreateAnnotationsDisplayStatus(action) : null;
@@ -304,6 +328,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
     const handleApprove = useCallback(() => {
         if (!pendingApproval) return;
         setIsProcessingApproval(true);
+        setProcessingApproval({ actionId: pendingApproval.actionId, kind: 'approve' });
         setClickedButton('approve');
         sendApprovalResponse({ actionId: pendingApproval.actionId, approved: true });
         removePendingApproval(pendingApproval.actionId);
@@ -312,6 +337,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
     const handleReject = useCallback(() => {
         if (!pendingApproval) return;
         setIsProcessingApproval(true);
+        setProcessingApproval({ actionId: pendingApproval.actionId, kind: 'reject' });
         setClickedButton('reject');
         sendApprovalResponse({ actionId: pendingApproval.actionId, approved: false });
         removePendingApproval(pendingApproval.actionId);
@@ -320,6 +346,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
     const handleApproveForRun = useCallback(() => {
         if (!pendingApproval) return;
         setIsProcessingApproval(true);
+        setProcessingApproval({ actionId: pendingApproval.actionId, kind: 'approve' });
         setClickedButton('approve');
         approveToolGroupForRun({ runId, toolName });
     }, [pendingApproval, approveToolGroupForRun, runId, toolName]);

--- a/react/host/zotero/components/EditNoteGroupView.tsx
+++ b/react/host/zotero/components/EditNoteGroupView.tsx
@@ -16,6 +16,7 @@ import {
     approveToolGroupForRunAtom,
     isWSChatPendingAtom,
     sendApprovalResponseAtom,
+    staleApprovalActionIdsAtom,
 } from '../../../atoms/agentRunAtoms';
 import {
     agentActionItemTitlesAtom,
@@ -236,15 +237,22 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
             toolCallStatus: state.toolCallStatus,
         }));
     }, [partStates, isRunStreaming]);
+    // A child is still "processing" only while its tool call has not returned
+    // and its decision can still reach the run. Once the return is in, the call
+    // is settled whatever the action's status — an action left `pending` at that
+    // point had its approval window expire. A child whose approval was marked
+    // stale is settled for the same reason without waiting for a return.
+    // Counting either as unsettled would hold the group's spinner up for the
+    // rest of the run over a decision the backend can no longer act on.
+    const staleApprovalActionIds = useAtomValue(staleApprovalActionIdsAtom);
     const hasUnsettledProcessingChild = useMemo(() => (
         partStates.some((state) => (
             state.pendingApproval === null
-            && (
-                state.action?.status === 'pending'
-                || (!state.action && resultsMap.get(state.part.tool_call_id) === undefined)
-            )
+            && resultsMap.get(state.part.tool_call_id) === undefined
+            && (state.action?.status === 'pending' || !state.action)
+            && !(state.action && staleApprovalActionIds.has(state.action.id))
         ))
-    ), [partStates, resultsMap]);
+    ), [partStates, resultsMap, staleApprovalActionIds]);
 
     const aggregateStatus: ActionStatus | 'awaiting' = getOverallEditNoteDisplayStatus(rowStatuses);
 

--- a/react/host/zotero/components/useApprovalRecovery.ts
+++ b/react/host/zotero/components/useApprovalRecovery.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { logger } from '@beaver/agent-core/platform/logger';
+import {
+    isWSChatPendingAtom,
+    removeApprovalResponseIntentAtom,
+    staleApprovalActionIdsAtom,
+} from '../../../atoms/agentRunAtoms';
+import type { ActionStatus } from './agentActionViewHelpers';
+
+interface ApprovalRecoveryOptions {
+    /**
+     * Whether this view is waiting on a backend decision — whether it sent the
+     * decision itself or another surface did (Approve All, the composer, the
+     * diff-preview banner). Both leave the card on a spinner, so both need the
+     * same escape.
+     */
+    isAwaitingDecision: boolean;
+    /** True once the tool call this approval belongs to has returned. */
+    hasToolReturn: boolean;
+    /** Status of the stored action, if one exists yet. */
+    actionStatus: ActionStatus | undefined;
+    /** Drop the waiting state and restore the view's own apply/reject controls. */
+    onRecover: () => void;
+    /** Identifies the view in logs. */
+    label: string;
+}
+
+interface ApprovalRecovery {
+    /**
+     * Record the decision a click is waiting on. The decision is required, not
+     * defaulted: it is what keeps an approval from being abandoned mid-execution
+     * (see below), so a call site must say which one it made.
+     */
+    setProcessingApproval: (decision: { actionId: string; kind: 'approve' | 'reject' } | null) => void;
+}
+
+export interface ApprovalRecoverySignals {
+    /** The backend told us it is no longer waiting, or the send never went out. */
+    isStale: boolean;
+    /** The tool call this approval belongs to has returned. */
+    hasToolReturn: boolean;
+    /** Status of the stored action, if one exists yet. */
+    actionStatus: ActionStatus | undefined;
+    /** True when the pending decision was a rejection rather than an approval. */
+    decisionWasReject: boolean;
+    /** Whether a run is still in flight. */
+    isRunPending: boolean;
+}
+
+/**
+ * Whether a decision in flight can be declared lost. Pure so the invariant that
+ * matters most — an approval is never abandoned merely because the run
+ * stopped — is directly testable.
+ */
+export function shouldRecoverApproval({
+    isStale,
+    hasToolReturn,
+    actionStatus,
+    decisionWasReject,
+    isRunPending,
+}: ApprovalRecoverySignals): boolean {
+    if (isStale) return true;
+    if (hasToolReturn && actionStatus === 'pending') return true;
+    return decisionWasReject && !isRunPending;
+}
+
+/**
+ * Restore a view's local controls when a decision the user made never reached
+ * the run.
+ *
+ * Views stop showing apply/reject while an approval is in flight and rely on
+ * the action reaching a final status to bring them back. A decision that misses
+ * its window never changes that status, so without this the card would wait
+ * forever on a reply that cannot come — the user clicked Apply and, as far as
+ * the UI is concerned, nothing happened.
+ *
+ * Two signals prove the channel is closed for any decision:
+ *  - the action id was marked stale — the backend answered `deferred_approval_stale`,
+ *    or the response never left the client;
+ *  - the tool already returned while its action is still `pending`, which is
+ *    what a backend-side approval timeout looks like on the wire. Kept as an
+ *    independent check so recovery also works against a backend that does not
+ *    send the stale event.
+ *
+ * A third signal — the run no longer being in flight — is only used for a
+ * *rejection*. It cannot be trusted for an approval: the backend executes an
+ * approved action by asking this client to perform the mutation, and the action
+ * only turns `applied` locally when the follow-up `agent_actions` frame lands.
+ * Cancelling (or dropping the socket) mid-execution therefore looks exactly
+ * like a decision that never arrived, and restoring Apply there would offer to
+ * repeat a change that is already being made — duplicating a created
+ * collection, note, or item. A rejection executes nothing, so there is nothing
+ * to repeat.
+ *
+ * Recovery is safe because the proposal itself survives: the backend persists
+ * it before it starts waiting, so the view's own `status === 'pending'`
+ * controls can still apply it.
+ *
+ * Not covered: an approval whose response was sent and then lost with the
+ * connection. Whether it executed is genuinely unknown to this client, so the
+ * card keeps waiting rather than risk a duplicate.
+ *
+ * The rejection-only rule binds this hook, not the whole view. A card that was
+ * decided from another surface also has the older `isExternallyProcessing`
+ * clear, which releases on `!isRunPending` whatever the decision was — so the
+ * mid-execution ambiguity above is still reachable that way. Left as is
+ * deliberately: confirm-only approvals (extraction, external search) have no
+ * local apply path, so tightening that clear would strand them with nothing to
+ * gain, since they mutate nothing.
+ */
+export function useApprovalRecovery({
+    isAwaitingDecision,
+    hasToolReturn,
+    actionStatus,
+    onRecover,
+    label,
+}: ApprovalRecoveryOptions): ApprovalRecovery {
+    // Kept separately from the pending approval itself, which is cleared the
+    // moment the response is sent — the id is still needed to match against.
+    const [processing, setProcessing] = useState<{ actionId: string; kind: 'approve' | 'reject' } | null>(null);
+    const staleApprovalActionIds = useAtomValue(staleApprovalActionIdsAtom);
+    const isRunPending = useAtomValue(isWSChatPendingAtom);
+    const removeApprovalResponseIntent = useSetAtom(removeApprovalResponseIntentAtom);
+
+    const processingApprovalId = processing?.actionId ?? null;
+    const isStale = processingApprovalId !== null
+        && staleApprovalActionIds.has(processingApprovalId);
+    const decisionWasReject = processing?.kind === 'reject';
+
+    useEffect(() => {
+        if (!isAwaitingDecision) return;
+        const missedItsWindow = shouldRecoverApproval({
+            isStale,
+            hasToolReturn,
+            actionStatus,
+            decisionWasReject,
+            isRunPending,
+        });
+        if (!missedItsWindow) return;
+
+        logger(
+            `${label}: approval ${processingApprovalId ?? '(unknown)'} did not reach the run; restoring local controls`,
+            1,
+        );
+        if (processingApprovalId) removeApprovalResponseIntent(processingApprovalId);
+        setProcessing(null);
+        onRecover();
+    }, [
+        isAwaitingDecision,
+        isStale,
+        hasToolReturn,
+        actionStatus,
+        decisionWasReject,
+        isRunPending,
+        processingApprovalId,
+        removeApprovalResponseIntent,
+        onRecover,
+        label,
+    ]);
+
+    const setProcessingApproval = useCallback(
+        (decision: { actionId: string; kind: 'approve' | 'reject' } | null) => {
+            setProcessing(decision);
+        },
+        [],
+    );
+
+    return { setProcessingApproval };
+}

--- a/react/host/zotero/components/useEditNoteActions.ts
+++ b/react/host/zotero/components/useEditNoteActions.ts
@@ -37,6 +37,7 @@ import { diffPreviewNoteKeyAtom, isDiffPreviewLive } from '../../../utils/diffPr
 import { logger } from '@beaver/agent-core/platform/logger';
 import { store } from '../../../store';
 import { PreviewData, STATUS_CONFIGS, buildPreviewData } from './agentActionViewHelpers';
+import { useApprovalRecovery } from './useApprovalRecovery';
 import {
     EditNoteDisplayStatus,
     EditNoteResolvedTarget,
@@ -231,6 +232,19 @@ export function useEditNoteActions({
     const [clickedButton, setClickedButton] = useState<'approve' | 'reject' | 'undo' | 'retry' | null>(null);
     const prevPendingApprovalRef = useRef<PendingApproval | null>(pendingApproval);
 
+    const handleApprovalRecovered = useCallback(() => {
+        setIsProcessingApproval(false);
+        setIsExternallyProcessing(false);
+        setClickedButton(null);
+    }, []);
+    const { setProcessingApproval } = useApprovalRecovery({
+        isAwaitingDecision: isProcessingApproval || isExternallyProcessing,
+        hasToolReturn,
+        actionStatus: action?.status,
+        onRecover: handleApprovalRecovered,
+        label: 'useEditNoteActions',
+    });
+
     useEffect(() => {
         const previousPendingApproval = prevPendingApprovalRef.current;
         const wasAwaiting = previousPendingApproval !== null;
@@ -243,6 +257,13 @@ export function useEditNoteActions({
             if (!isProcessingApproval && isRunPending && !hasToolReturn) {
                 setIsExternallyProcessing(true);
                 setClickedButton(previousIntent === false ? 'reject' : 'approve');
+                // Record it for recovery too: a decision made from another
+                // surface (the group's Apply All, the diff-preview banner) can
+                // miss its window exactly like one made here.
+                setProcessingApproval({
+                    actionId: previousActionId,
+                    kind: previousIntent === false ? 'reject' : 'approve',
+                });
             }
 
             if (previousIntent !== undefined) {
@@ -258,19 +279,22 @@ export function useEditNoteActions({
         hasToolReturn,
         approvalResponseIntents,
         removeApprovalResponseIntent,
+        setProcessingApproval,
     ]);
 
     useEffect(() => {
         if ((isProcessingApproval || isExternallyProcessing) && action && action.status !== 'pending') {
             setIsProcessingApproval(false);
+            setProcessingApproval(null);
             setIsExternallyProcessing(false);
             setClickedButton(null);
         }
         if (isExternallyProcessing && (hasToolReturn || !isRunPending)) {
             setIsExternallyProcessing(false);
+            setProcessingApproval(null);
             setClickedButton(null);
         }
-    }, [isProcessingApproval, isExternallyProcessing, action?.status, hasToolReturn, isRunPending, action]);
+    }, [isProcessingApproval, isExternallyProcessing, action?.status, hasToolReturn, isRunPending, action, setProcessingApproval]);
 
     const isProcessing = isProcessingApproval || isProcessingAction || isExternallyProcessing;
     const effectiveStatus: EditNoteDisplayStatus = getEditNoteDisplayStatus({
@@ -339,18 +363,20 @@ export function useEditNoteActions({
     const handleApprove = useCallback(() => {
         if (!pendingApproval) return;
         setIsProcessingApproval(true);
+        setProcessingApproval({ actionId: pendingApproval.actionId, kind: 'approve' });
         setClickedButton('approve');
         sendApprovalResponse({ actionId: pendingApproval.actionId, approved: true });
         removePendingApproval(pendingApproval.actionId);
-    }, [pendingApproval, sendApprovalResponse, removePendingApproval]);
+    }, [pendingApproval, sendApprovalResponse, removePendingApproval, setProcessingApproval]);
 
     const handleReject = useCallback(() => {
         if (!pendingApproval) return;
         setIsProcessingApproval(true);
+        setProcessingApproval({ actionId: pendingApproval.actionId, kind: 'reject' });
         setClickedButton('reject');
         sendApprovalResponse({ actionId: pendingApproval.actionId, approved: false });
         removePendingApproval(pendingApproval.actionId);
-    }, [pendingApproval, sendApprovalResponse, removePendingApproval]);
+    }, [pendingApproval, sendApprovalResponse, removePendingApproval, setProcessingApproval]);
 
     const handleApplyPending = useCallback(async () => {
         await runApply('approve');

--- a/tests/unit/services/connectionFailure.test.ts
+++ b/tests/unit/services/connectionFailure.test.ts
@@ -467,6 +467,23 @@ describe('isRetryablePreReadyConnectFailure', () => {
             }),
         ).toBe(false);
     });
+
+    it('retries a run request the socket refused, despite the mid-run stage', () => {
+        // The stage says post-ready, but the socket never took the message, so
+        // no run exists to duplicate — the same property that makes the
+        // pre-ready failures safe. Failing here instead would turn a transient
+        // half-open socket into a failed run.
+        expect(
+            isRetryablePreReadyConnectFailure({
+                ...opening1006,
+                stage: 'mid_run',
+                closeCode: null,
+                socketOpened: true,
+                readyReceived: true,
+                requestNeverSent: true,
+            }),
+        ).toBe(true);
+    });
 });
 
 describe('connectRecoveryAuthFields', () => {

--- a/tests/unit/services/staleApproval.test.ts
+++ b/tests/unit/services/staleApproval.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Recovering an approval decision the run never acted on.
+ *
+ * A deferred tool waits a bounded time for the user; when that expires the tool
+ * returns `pending` and the run continues. A click that lands afterwards — or
+ * one made while the socket is down — cannot reach the agent. Both cases used
+ * to be indistinguishable from "still processing", which left the card spinning
+ * on a reply that would never arrive.
+ *
+ * These tests cover the two signals that close that gap: the transport
+ * reporting an undelivered send, and the backend's `deferred_approval_stale`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSupabase } = vi.hoisted(() => ({
+    mockSupabase: {
+        auth: {
+            getSession: vi.fn(),
+            refreshSession: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@beaver/agent-core/transport/supabaseClient', () => ({
+    supabase: mockSupabase,
+}));
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({
+    logger: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/zoteroUtils', () => ({
+    loadFullItemDataWithAllTypes: vi.fn(),
+    getZoteroUserIdentifier: vi.fn(() => ({ userID: undefined, localUserKey: 'test' })),
+}));
+
+vi.mock('../../../src/services/agentDataProvider', () => ({
+    handleZoteroDataRequest: vi.fn(),
+    handleExternalReferenceCheckRequest: vi.fn(),
+    handleZoteroDocumentRequest: vi.fn(),
+    handleZoteroAttachmentPageImagesRequest: vi.fn(),
+    handleZoteroAttachmentImageRequest: vi.fn(),
+    handleZoteroViewImagesRequest: vi.fn(),
+    handleZoteroAttachmentSearchRequest: vi.fn(),
+    handleItemSearchByMetadataRequest: vi.fn(),
+    handleItemSearchByTopicRequest: vi.fn(),
+    handleZoteroSearchRequest: vi.fn(),
+    handleListItemsRequest: vi.fn(),
+    handleListCollectionsRequest: vi.fn(),
+    handleListTagsRequest: vi.fn(),
+    handleListLibrariesRequest: vi.fn(),
+    handleGetMetadataRequest: vi.fn(),
+    handleGetAnnotationsRequest: vi.fn(),
+    handleFindAnnotationsRequest: vi.fn(),
+    handleAgentActionValidateRequest: vi.fn(),
+    handleAgentActionExecuteRequest: vi.fn(),
+    handleReadNoteRequest: vi.fn(),
+}));
+
+import { createStore } from 'jotai';
+import { AgentConnectionError, AgentService, agentService } from '@beaver/agent-core/transport/agentService';
+import { isRetryablePreReadyConnectFailure } from '@beaver/agent-core/transport/connectionFailure';
+import type {
+    AgentRunRequest,
+    WSCallbacks,
+    WSDeferredApprovalStale,
+} from '@beaver/agent-core/protocol/agentProtocol';
+import {
+    approvalResponseIntentsAtom,
+    clearStaleApprovalsAtom,
+    markApprovalStaleAtom,
+    sendApprovalResponseAtom,
+    staleApprovalActionIdsAtom,
+} from '../../../react/atoms/agentRunAtoms';
+import { shouldRecoverApproval } from '../../../react/host/zotero/components/useApprovalRecovery';
+
+class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    readonly url: string;
+    readyState = MockWebSocket.CONNECTING;
+    onopen: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: ((event: CloseEvent) => void) | null = null;
+    send = vi.fn();
+    close = vi.fn(() => {
+        this.readyState = MockWebSocket.CLOSING;
+    });
+
+    constructor(url: string) {
+        this.url = url;
+        MockWebSocket.instances.push(this);
+    }
+
+    emitOpen(): void {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.(new Event('open'));
+    }
+
+    emitMessage(data: unknown): void {
+        this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+    }
+}
+
+function createCallbacks(overrides: Partial<WSCallbacks> = {}): WSCallbacks {
+    return {
+        onReady: vi.fn(),
+        onRequestAck: vi.fn(),
+        onPart: vi.fn().mockResolvedValue(undefined),
+        onToolReturn: vi.fn().mockResolvedValue(undefined),
+        onToolCallProgress: vi.fn(),
+        onToolCallArgsStream: vi.fn(),
+        onRunComplete: vi.fn().mockResolvedValue(undefined),
+        onStreamingDone: vi.fn(),
+        onDone: vi.fn(),
+        onThread: vi.fn(),
+        onThreadName: vi.fn(),
+        onError: vi.fn(),
+        onWarning: vi.fn(),
+        onAgentActions: vi.fn().mockResolvedValue(undefined),
+        onRetry: vi.fn(),
+        onMissingZoteroData: vi.fn(),
+        onDeferredApprovalRequest: vi.fn(),
+        onOpen: vi.fn(),
+        onClose: vi.fn(),
+        ...overrides,
+    };
+}
+
+const request: AgentRunRequest = {
+    thread_id: 'thread-1',
+    user_prompt: { content: 'hello' },
+} as unknown as AgentRunRequest;
+
+async function completeConnect(
+    service: AgentService,
+    callbacks: WSCallbacks,
+): Promise<MockWebSocket> {
+    const initialCount = MockWebSocket.instances.length;
+    const connectPromise = service.connect(request, callbacks);
+
+    for (let i = 0; i < 20 && MockWebSocket.instances.length === initialCount; i++) {
+        await Promise.resolve();
+    }
+
+    const socket = MockWebSocket.instances[initialCount];
+    if (!socket) {
+        throw new Error('Expected AgentService.connect() to create a WebSocket');
+    }
+
+    socket.emitOpen();
+    await vi.advanceTimersByTimeAsync(50);
+    socket.emitMessage({
+        event: 'ready',
+        subscription_status: 'active',
+        processing_mode: 'fast',
+        indexing_complete: true,
+    });
+    await connectPromise;
+
+    return socket;
+}
+
+describe('approval response delivery', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        MockWebSocket.instances = [];
+        vi.stubGlobal('WebSocket', MockWebSocket);
+
+        mockSupabase.auth.getSession.mockReset();
+        mockSupabase.auth.refreshSession.mockReset();
+        mockSupabase.auth.getSession.mockResolvedValue({
+            data: {
+                session: {
+                    access_token: 'token',
+                    expires_at: Math.floor(Date.now() / 1000) + 3600,
+                },
+            },
+            error: null,
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('reports a delivered approval response', async () => {
+        const service = new AgentService('https://api.example.com');
+        const socket = await completeConnect(service, createCallbacks());
+
+        expect(service.sendApprovalResponse('action-1', true)).toBe(true);
+
+        const sent = JSON.parse(socket.send.mock.calls.at(-1)![0] as string);
+        expect(sent).toMatchObject({
+            type: 'deferred_approval_response',
+            action_id: 'action-1',
+            approved: true,
+        });
+    });
+
+    it('reports an approval response that never left the client', () => {
+        // No connection at all: the decision cannot reach the run, and the
+        // caller has to recover the card rather than wait for a reply.
+        const service = new AgentService('https://api.example.com');
+
+        expect(service.sendApprovalResponse('action-1', true)).toBe(false);
+    });
+
+    it('reports a send that throws on a socket that looks open', async () => {
+        const service = new AgentService('https://api.example.com');
+        const socket = await completeConnect(service, createCallbacks());
+        socket.send.mockImplementationOnce(() => {
+            throw new Error('InvalidStateError');
+        });
+
+        expect(service.sendApprovalResponse('action-1', true)).toBe(false);
+    });
+
+    it('fails the connect when the run request itself cannot be sent', async () => {
+        // A half-open socket reports OPEN but refuses the write. Swallowing
+        // that would leave the user waiting on a run the server never got.
+        const service = new AgentService('https://api.example.com');
+        const initialCount = MockWebSocket.instances.length;
+        const connectPromise = service.connect(request, createCallbacks());
+        for (let i = 0; i < 20 && MockWebSocket.instances.length === initialCount; i++) {
+            await Promise.resolve();
+        }
+        const socket = MockWebSocket.instances[initialCount];
+        socket.emitOpen();
+        await vi.advanceTimersByTimeAsync(50);
+        socket.send.mockImplementation(() => {
+            throw new Error('InvalidStateError');
+        });
+
+        socket.emitMessage({
+            event: 'ready',
+            subscription_status: 'active',
+            processing_mode: 'fast',
+            indexing_complete: true,
+        });
+
+        const error = await connectPromise.catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(AgentConnectionError);
+        expect((error as AgentConnectionError).message).toMatch(/before the request could be sent/);
+        // The socket must not be left live: `ready` already marked the
+        // connection up, so nothing downstream would reclaim it.
+        expect(socket.close).toHaveBeenCalled();
+        // Flagged so the retry orchestrator treats it as retryable: nothing
+        // reached the server, so a transient half-open socket must not cost
+        // the user their run.
+        expect((error as AgentConnectionError).evidence.requestNeverSent).toBe(true);
+        expect(isRetryablePreReadyConnectFailure((error as AgentConnectionError).evidence)).toBe(true);
+    });
+});
+
+describe('deferred_approval_stale transport', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        MockWebSocket.instances = [];
+        vi.stubGlobal('WebSocket', MockWebSocket);
+
+        mockSupabase.auth.getSession.mockReset();
+        mockSupabase.auth.refreshSession.mockReset();
+        mockSupabase.auth.getSession.mockResolvedValue({
+            data: {
+                session: {
+                    access_token: 'token',
+                    expires_at: Math.floor(Date.now() / 1000) + 3600,
+                },
+            },
+            error: null,
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('dispatches the event to the registered handler', async () => {
+        const service = new AgentService('https://api.example.com');
+        const onDeferredApprovalStale = vi.fn();
+        const socket = await completeConnect(
+            service,
+            createCallbacks({ onDeferredApprovalStale }),
+        );
+
+        const event: WSDeferredApprovalStale = {
+            event: 'deferred_approval_stale',
+            action_id: 'action-1',
+            reason: 'timed_out',
+        };
+        socket.emitMessage(event);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(onDeferredApprovalStale).toHaveBeenCalledWith(
+            expect.objectContaining({ action_id: 'action-1', reason: 'timed_out' }),
+        );
+    });
+
+    it('degrades quietly on a client that does not implement recovery', async () => {
+        // Not a test of the dispatch itself (an unhandled event is also a
+        // no-op) — it pins the contract that a client without the handler is
+        // left working rather than answering a notice that expects no reply.
+        const service = new AgentService('https://api.example.com');
+        const callbacks = createCallbacks();
+        delete (callbacks as Partial<WSCallbacks>).onDeferredApprovalStale;
+        const socket = await completeConnect(service, callbacks);
+        const sendCountBefore = socket.send.mock.calls.length;
+
+        socket.emitMessage({
+            event: 'deferred_approval_stale',
+            action_id: 'action-1',
+            reason: 'unknown',
+        });
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(socket.send.mock.calls.length).toBe(sendCountBefore);
+        expect(callbacks.onError).not.toHaveBeenCalled();
+    });
+});
+
+describe('shouldRecoverApproval', () => {
+    const live = {
+        isStale: false,
+        hasToolReturn: false,
+        actionStatus: 'pending' as const,
+        decisionWasReject: false,
+        isRunPending: true,
+    };
+
+    it('waits while the decision is still in play', () => {
+        expect(shouldRecoverApproval(live)).toBe(false);
+    });
+
+    it('recovers once the backend reports the channel closed', () => {
+        expect(shouldRecoverApproval({ ...live, isStale: true })).toBe(true);
+    });
+
+    it('recovers when the tool returned with the action still pending', () => {
+        // What a backend-side approval timeout looks like on the wire.
+        expect(shouldRecoverApproval({ ...live, hasToolReturn: true })).toBe(true);
+    });
+
+    it('does not recover when the tool returned having settled the action', () => {
+        expect(
+            shouldRecoverApproval({ ...live, hasToolReturn: true, actionStatus: 'applied' }),
+        ).toBe(false);
+    });
+
+    it('NEVER abandons an approval just because the run stopped', () => {
+        // The load-bearing invariant. An approved action is executed by this
+        // client on the backend's request, and only turns `applied` locally
+        // when the follow-up frame lands — so cancelling mid-execution looks
+        // identical to a decision that never arrived. Restoring Apply here
+        // would offer to repeat a change already being made.
+        expect(shouldRecoverApproval({ ...live, isRunPending: false })).toBe(false);
+    });
+
+    it('abandons a rejection when the run stops, which executes nothing', () => {
+        expect(
+            shouldRecoverApproval({ ...live, isRunPending: false, decisionWasReject: true }),
+        ).toBe(true);
+    });
+
+    it('still recovers an approval on a positive signal after the run stops', () => {
+        expect(
+            shouldRecoverApproval({ ...live, isRunPending: false, isStale: true }),
+        ).toBe(true);
+    });
+
+    it('recovers a decision made from another surface on the same signals', () => {
+        // Approve All, the composer and the diff-preview banner respond on a
+        // card's behalf; the card is left waiting just the same, so the
+        // predicate must not depend on who clicked.
+        expect(shouldRecoverApproval({ ...live, isStale: true })).toBe(true);
+        expect(shouldRecoverApproval({ ...live, hasToolReturn: true })).toBe(true);
+    });
+});
+
+describe('sendApprovalResponseAtom delivery handling', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('marks the approval stale when the decision never left the client', () => {
+        // The backend cannot answer a message it never received, so the card
+        // has to be told to recover rather than wait for a reply.
+        const store = createStore();
+        vi.spyOn(agentService, 'sendApprovalResponse').mockReturnValue(false);
+
+        store.set(sendApprovalResponseAtom, { actionId: 'action-1', approved: true });
+
+        expect(store.get(staleApprovalActionIdsAtom).has('action-1')).toBe(true);
+    });
+
+    it('leaves a delivered approval alone so the run can resolve it', () => {
+        const store = createStore();
+        vi.spyOn(agentService, 'sendApprovalResponse').mockReturnValue(true);
+
+        store.set(sendApprovalResponseAtom, { actionId: 'action-1', approved: true });
+
+        expect(store.get(staleApprovalActionIdsAtom).has('action-1')).toBe(false);
+        expect(store.get(approvalResponseIntentsAtom).get('action-1')).toBe(true);
+    });
+});
+
+describe('stale approval state', () => {
+    it('accumulates stale action ids', () => {
+        const store = createStore();
+
+        store.set(markApprovalStaleAtom, 'action-1');
+        store.set(markApprovalStaleAtom, 'action-2');
+
+        expect(store.get(staleApprovalActionIdsAtom)).toEqual(
+            new Set(['action-1', 'action-2']),
+        );
+    });
+
+    it('keeps the same set when re-marking an id, so views do not re-render', () => {
+        const store = createStore();
+        store.set(markApprovalStaleAtom, 'action-1');
+        const before = store.get(staleApprovalActionIdsAtom);
+
+        store.set(markApprovalStaleAtom, 'action-1');
+
+        expect(store.get(staleApprovalActionIdsAtom)).toBe(before);
+    });
+
+    it('clears the set when a new run starts', () => {
+        const store = createStore();
+        store.set(markApprovalStaleAtom, 'action-1');
+
+        store.set(clearStaleApprovalsAtom);
+
+        expect(store.get(staleApprovalActionIdsAtom).size).toBe(0);
+    });
+});


### PR DESCRIPTION
This commit introduces the `WSDeferredApprovalStale` interface to manage scenarios where an approval response arrives after the backend has stopped waiting for it. The new interface allows the client to recognize when a response is stale, enabling it to restore local apply/reject controls and prevent indefinite "awaiting approval" states. Additionally, the `AgentService` class is updated to handle the `deferred_approval_stale` event, ensuring proper logging and state management. Unit tests are added to verify the functionality of the new approval handling logic.