### PR TITLE
feat(agent-core): typed client for library reads outside a run

### DIFF
--- a/packages/agent-core/src/transport/clients/zoteroLibraryService.ts
+++ b/packages/agent-core/src/transport/clients/zoteroLibraryService.ts
@@ -1,0 +1,201 @@
+/**
+ * Reads library data from the signed-in user's running Zotero.
+ *
+ * Used by hosts without a local library (e.g. the Word add-in). The Zotero
+ * plugin reads its own library directly and should not use this. When Zotero
+ * is not running, the request fails with `zotero_offline` — branch on
+ * `isZoteroOffline` rather than treating that as a generic error.
+ */
+
+import { ApiService, type RequestOptions } from '../apiService';
+import { ApiError } from '../../types/apiErrors';
+import type {
+    CollectionInfo,
+    ItemSearchFrontendResultItem,
+    LibrarySummary,
+    TagInfo,
+} from '../../protocol/agentProtocol';
+
+const ZOTERO_REQUEST_ENDPOINT = '/api/v1/zotero/request';
+
+/**
+ * Default deadline for one library request.
+ *
+ * Must sit above the backend's stacked budgets (up to ~8s to wake an idle
+ * provider, then 15–25s for the op) plus round-trip and a 401 retry. Callers
+ * that block interactive UI can pass a shorter `timeoutMs`.
+ */
+export const ZOTERO_REQUEST_TIMEOUT_MS = 45_000;
+
+// =============================================================================
+// Op payloads
+// =============================================================================
+
+/** Params for `item_search_by_metadata` */
+export interface ItemSearchByMetadataParams {
+    /** Matched against title-like fields */
+    title_query?: string;
+    /** Matched against creator names */
+    author_query?: string;
+    /** Matched against publication / container titles */
+    publication_query?: string;
+    /** Earliest publication year, inclusive */
+    year_min?: number;
+    /** Latest publication year, inclusive */
+    year_max?: number;
+    item_type_filter?: string;
+    /** Library names or refs; OR'd */
+    libraries_filter?: string[];
+    /** Tag names; OR'd */
+    tags_filter?: string[];
+    /** Collection names or keys; OR'd */
+    collections_filter?: string[];
+    /** 1–50, default 25. Hits include full metadata plus attachments. */
+    limit?: number;
+    offset?: number;
+}
+
+/** Result of `item_search_by_metadata` */
+export interface ItemSearchByMetadataData {
+    items: ItemSearchFrontendResultItem[];
+}
+
+/** `list_libraries` takes no parameters. */
+export type ListLibrariesParams = Record<string, never>;
+
+/** Result of `list_libraries` */
+export interface ListLibrariesData {
+    libraries: LibrarySummary[];
+    total_count: number;
+}
+
+/** Params for `list_collections` */
+export interface ListCollectionsParams {
+    /** Library ref, name or numeric id; the user's personal library when absent */
+    library_id?: number | string;
+    /** Children of this collection; omit for the library root */
+    parent_collection_key?: string;
+    include_item_counts?: boolean;
+    /** 1–200, default 100 */
+    limit?: number;
+    offset?: number;
+}
+
+/** Result of `list_collections` */
+export interface ListCollectionsData {
+    collections: CollectionInfo[];
+    /** Matching collections, which may exceed the page returned */
+    total_count: number;
+    library_id?: number | null;
+    library_ref?: string | null;
+    library_name?: string | null;
+}
+
+/** Params for `list_tags` */
+export interface ListTagsParams {
+    /** Library ref, name or numeric id; the user's personal library when absent */
+    library_id?: number | string;
+    /** Restrict to tags used inside this collection */
+    collection_key?: string;
+    /** Drop tags used by fewer items than this; default 1 */
+    min_item_count?: number;
+    /** 1–200, default 100 */
+    limit?: number;
+    offset?: number;
+}
+
+/** Result of `list_tags` */
+export interface ListTagsData {
+    tags: TagInfo[];
+    /** Matching tags, which may exceed the page returned */
+    total_count: number;
+    library_id?: number | null;
+    library_ref?: string | null;
+    library_name?: string | null;
+}
+
+/**
+ * Library ops a client may request, with params and result typed together.
+ * The backend keeps a matching allowlist.
+ */
+export interface ZoteroLibraryOpMap {
+    /** Search the user's library by metadata */
+    item_search_by_metadata: {
+        params: ItemSearchByMetadataParams;
+        data: ItemSearchByMetadataData;
+    };
+    /** List the libraries this user's Zotero can see */
+    list_libraries: {
+        params: ListLibrariesParams;
+        data: ListLibrariesData;
+    };
+    /** List collections in one library */
+    list_collections: {
+        params: ListCollectionsParams;
+        data: ListCollectionsData;
+    };
+    /** List tags in one library */
+    list_tags: {
+        params: ListTagsParams;
+        data: ListTagsData;
+    };
+}
+
+/** Identifier of a library op */
+export type ZoteroLibraryOp = keyof ZoteroLibraryOpMap;
+
+/** Params accepted by a single op */
+export type ZoteroLibraryOpParams<Op extends ZoteroLibraryOp> = ZoteroLibraryOpMap[Op]['params'];
+
+/** Data returned by a single op */
+export type ZoteroLibraryOpData<Op extends ZoteroLibraryOp> = ZoteroLibraryOpMap[Op]['data'];
+
+/** Successful response envelope, narrowed to one op */
+interface ZoteroLibraryResponse<Op extends ZoteroLibraryOp> {
+    /** Echo of the requested op */
+    op: Op;
+    data: ZoteroLibraryOpData<Op>;
+}
+
+// =============================================================================
+// Degraded states
+// =============================================================================
+
+/** Backend code for "the user's Zotero is not reachable". */
+export const ZOTERO_OFFLINE_CODE = 'zotero_offline';
+
+/** True when the request failed because the user's Zotero is not running. */
+export function isZoteroOffline(error: unknown): boolean {
+    return error instanceof ApiError && error.code === ZOTERO_OFFLINE_CODE;
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+/**
+ * Reads library data from the signed-in user's running Zotero.
+ */
+export class ZoteroLibraryService extends ApiService {
+    /**
+     * Runs one library op and returns its data.
+     *
+     * @throws ApiError with `code === 'zotero_offline'` when Zotero is
+     * unreachable (see `isZoteroOffline`). Other failures arrive as an
+     * `ApiError` with a user-facing `message`.
+     */
+    async runOp<Op extends ZoteroLibraryOp>(
+        op: Op,
+        params: ZoteroLibraryOpParams<Op>,
+        options?: RequestOptions,
+    ): Promise<ZoteroLibraryOpData<Op>> {
+        const response = await this.post<ZoteroLibraryResponse<Op>>(
+            ZOTERO_REQUEST_ENDPOINT,
+            { op, params },
+            { timeoutMs: ZOTERO_REQUEST_TIMEOUT_MS, ...options },
+        );
+        return response.data;
+    }
+}
+
+export const zoteroLibraryService = new ZoteroLibraryService();

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -94,6 +94,7 @@
     "./src/transport/clients/embeddingsService.ts",
     "./src/transport/clients/searchService.ts",
     "./src/transport/clients/diagnosticsService.ts",
+    "./src/transport/clients/zoteroLibraryService.ts",
     "./src/platform/runtime.ts",
     "./src/platform/logger.ts",
     "./src/types/models.ts",

--- a/packages/agent-core/verify-program.mjs
+++ b/packages/agent-core/verify-program.mjs
@@ -175,6 +175,7 @@ const entryPaths = [
   "src/transport/clients/embeddingsService.ts",
   "src/transport/clients/searchService.ts",
   "src/transport/clients/diagnosticsService.ts",
+  "src/transport/clients/zoteroLibraryService.ts",
   "src/run-state/toolResultViews.ts",
   "src/run-state/toolResultTypes.ts",
   "src/run-state/toolCallRequest.ts",

--- a/tests/unit/services/zoteroLibraryService.test.ts
+++ b/tests/unit/services/zoteroLibraryService.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Pins the request envelope and the offline vs. other-failure branch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSupabase } = vi.hoisted(() => ({
+    mockSupabase: {
+        auth: {
+            getSession: vi.fn(),
+            refreshSession: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@beaver/agent-core/transport/supabaseClient', () => ({ supabase: mockSupabase }));
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+
+import {
+    isZoteroOffline,
+    zoteroLibraryService,
+} from '@beaver/agent-core/transport/clients/zoteroLibraryService';
+import { ApiError } from '@beaver/agent-core/types/apiErrors';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Response body the backend returns for a failed library request. */
+function providerFailure(code: string, message: string): Response {
+    return new Response(JSON.stringify({ detail: { code, message } }), {
+        status: 424,
+        statusText: 'Failed Dependency',
+    });
+}
+
+describe('zoteroLibraryService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        mockSupabase.auth.getSession.mockResolvedValue({
+            data: {
+                session: {
+                    access_token: 'token',
+                    expires_at: Math.floor(Date.now() / 1000) + 3600,
+                },
+            },
+            error: null,
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('sends the op envelope and returns that op\'s data', async () => {
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    op: 'list_tags',
+                    data: {
+                        tags: [{ name: 'methods', item_count: 4, color: '#FF6666' }],
+                        total_count: 1,
+                        library_id: 1,
+                        library_ref: 'u',
+                        library_name: 'My Library',
+                    },
+                }),
+                { status: 200, statusText: 'OK' },
+            ),
+        );
+
+        const data = await zoteroLibraryService.runOp('list_tags', {
+            library_id: 'u',
+            min_item_count: 2,
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain('/api/v1/zotero/request');
+        expect(JSON.parse(init.body)).toEqual({
+            op: 'list_tags',
+            params: { library_id: 'u', min_item_count: 2 },
+        });
+        expect(data.total_count).toBe(1);
+        expect(data.tags[0].name).toBe('methods');
+        expect(data.library_ref).toBe('u');
+    });
+
+    it('surfaces a closed Zotero as the offline signal, not a generic failure', async () => {
+        fetchMock.mockResolvedValue(
+            providerFailure('zotero_offline', 'Zotero is not reachable. Open Zotero and try again.'),
+        );
+
+        const error = await zoteroLibraryService
+            .runOp('list_libraries', {})
+            .then(() => null, (e: unknown) => e);
+
+        expect(isZoteroOffline(error)).toBe(true);
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).message).toContain('Open Zotero');
+    });
+
+    it('does not report other provider failures as offline', async () => {
+        fetchMock.mockResolvedValue(
+            providerFailure('library_not_found', 'No library named "Shared" on this device.'),
+        );
+
+        const error = await zoteroLibraryService
+            .runOp('list_collections', { library_id: 'Shared' })
+            .then(() => null, (e: unknown) => e);
+
+        expect(error).toBeInstanceOf(ApiError);
+        expect(isZoteroOffline(error)).toBe(false);
+        expect((error as ApiError).code).toBe('library_not_found');
+    });
+});


### PR DESCRIPTION
Hosts without a library of their own (the Word add-in) can now ask the backend for one allowlisted read from the user's running Zotero. One op map types params and result together, and isZoteroOffline gives callers the two-way branch the degraded state needs.