### PR TITLE
feat(agent-core): add run status visibility logic and tests

### DIFF
--- a/packages/agent-core/src/agents/messageVisibility.ts
+++ b/packages/agent-core/src/agents/messageVisibility.ts
@@ -1,11 +1,22 @@
 /**
+ * What of a run's model messages reaches the reader.
+ *
  * Model requests contain assembled model input, not user-authored transcript
  * text. Render the user's prompt separately and only show responses as-is.
  */
 
-import type { ModelMessage, ModelResponse } from './types';
+import type { ModelMessage, ModelResponse, ToolCallPart } from './types';
 
 /** True for messages that may be rendered to the user as-is. */
 export function isRenderableMessage(message: ModelMessage): message is ModelResponse {
     return message.kind === 'response';
+}
+
+/**
+ * Backend-injected plumbing (load_capacity / read-tool auto_load injection).
+ * Only `auto_load_*` IDs are suppressed — `tool_kind` is also set on normal
+ * agent-initiated search/capability calls and must not drive visibility here.
+ */
+export function isAutoLoadingToolCall(part: ToolCallPart): boolean {
+    return part.tool_call_id.startsWith('auto_load_');
 }

--- a/packages/agent-core/src/run-state/runStatusVisibility.ts
+++ b/packages/agent-core/src/run-state/runStatusVisibility.ts
@@ -1,0 +1,110 @@
+/**
+ * When a run has nothing to show for itself yet.
+ *
+ * The companion to `runStatusCopy`: that module decides what a waiting run says,
+ * this one decides whether there is anything to say it about. Shared across
+ * clients because it is the rule that keeps a status line honest, and getting it
+ * wrong is invisible in a screenshot — a spinner left up beside an answer reads
+ * as a hang, and one missing during the wait before the first token reads as a
+ * message that was never sent.
+ *
+ * Presentation-neutral: no markup, styling, or host APIs. Where the indicator is
+ * drawn, and what it looks like, stays each client's own.
+ */
+
+import { isAutoLoadingToolCall } from "../agents/messageVisibility";
+import type {
+    AgentRun,
+    ModelResponse,
+    RetryPromptPart,
+    ToolReturnPart,
+} from "../agents/types";
+import { getToolCallStatus } from "./atoms";
+
+/**
+ * Whether anything the reader can see has arrived in the run's newest message.
+ *
+ * Only the newest: everything before it is already on screen, and the question
+ * this answers is whether the run is currently producing something visible or
+ * leaving a gap. Auto-loading tool calls do not count — they are plumbing the
+ * backend injected, and a client that hides them would be pointing at a blank
+ * space if they suppressed the status line.
+ */
+function hasVisibleContent(run: AgentRun): boolean {
+    const lastMessage = run.model_messages[run.model_messages.length - 1];
+    if (!lastMessage || lastMessage.kind !== "response") return false;
+
+    return (lastMessage as ModelResponse).parts.some(
+        (part) =>
+            (part.part_kind === "text" && part.content.trim() !== "") ||
+            (part.part_kind === "thinking" && part.content.trim() !== "") ||
+            (part.part_kind === "tool-call" && !isAutoLoadingToolCall(part)),
+    );
+}
+
+/**
+ * Whether a tool call anywhere in the run is still waiting on its result.
+ *
+ * The whole run rather than its newest message, because a call and its result
+ * land in different messages: the parallel calls a model makes in one turn are
+ * only finished when the last of them comes back, and the card the reader is
+ * watching is wherever that call was made.
+ *
+ * Auto-loading calls are counted here even though `hasVisibleContent` ignores
+ * them, and the asymmetry is deliberate rather than an oversight. The two halves
+ * answer different questions: whether there is something on screen, and whether
+ * the run is between steps. A client that hides an auto-loading call has neither
+ * a card nor this line for as long as one is outstanding — which is the whole
+ * of its execution, measured in single-digit milliseconds — while a client that
+ * draws one would get this line beside a card already saying the same thing.
+ * Excluding them here buys the first client a gap no reader can perceive and
+ * costs the second a visibly doubled claim, so it is not worth making until
+ * both clients agree on whether such a call is drawn at all.
+ */
+function hasInProgressToolCall(
+    run: AgentRun,
+    toolResults: Map<string, ToolReturnPart | RetryPromptPart>,
+): boolean {
+    for (const message of run.model_messages) {
+        if (message.kind !== "response") continue;
+        for (const part of message.parts) {
+            if (
+                part.part_kind === "tool-call" &&
+                getToolCallStatus(
+                    part.tool_call_id,
+                    toolResults,
+                    run.status,
+                ) === "in_progress"
+            ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Whether a run is working with nothing on screen to show for it.
+ *
+ * True exactly in the gaps: after the prompt is sent and before the first part
+ * arrives, and between a tool result and whatever the model does next. A tool
+ * call still running is not a gap — its own card says so, and a second spinner
+ * beside it would be the pane claiming two things are happening.
+ *
+ * `in_progress` and not `isRunActive`: a run holding for a deferred approval is
+ * live, but it is waiting on the reader rather than working, and its card is
+ * what should be drawing the eye.
+ *
+ * Which run is worth showing this for is the caller's to decide — in a thread,
+ * only the newest.
+ */
+export function shouldShowRunStatus(
+    run: AgentRun,
+    toolResults: Map<string, ToolReturnPart | RetryPromptPart>,
+): boolean {
+    return (
+        run.status === "in_progress" &&
+        !hasVisibleContent(run) &&
+        !hasInProgressToolCall(run, toolResults)
+    );
+}

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -116,6 +116,7 @@
     "./src/run-state/pendingBatchApprovals.ts",
     "./src/run-state/toolLabels.ts",
     "./src/run-state/runErrorCopy.ts",
-    "./src/run-state/runStatusCopy.ts"
+    "./src/run-state/runStatusCopy.ts",
+    "./src/run-state/runStatusVisibility.ts"
   ]
 }

--- a/packages/agent-core/verify-program.mjs
+++ b/packages/agent-core/verify-program.mjs
@@ -190,6 +190,7 @@ const entryPaths = [
   "src/run-state/pendingBatchApprovals.ts",
   "src/run-state/runErrorCopy.ts",
   "src/run-state/runStatusCopy.ts",
+  "src/run-state/runStatusVisibility.ts",
   "src/citations/atoms.ts",
   "src/citations/externalReferences.ts",
 ].map((p) => path.join(pkgDir, p));

--- a/react/components/agentRuns/AgentRunView.tsx
+++ b/react/components/agentRuns/AgentRunView.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useMemo, useState, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
-import { AgentRun, ModelResponse, ToolCallPart } from '@beaver/agent-core/agents/types';
-import { isAutoLoadingToolCall } from './ModelResponseView';
+import { AgentRun, ToolCallPart } from '@beaver/agent-core/agents/types';
+import { shouldShowRunStatus } from '@beaver/agent-core/run-state/runStatusVisibility';
 import { UserRequestView } from './UserRequestView';
 import { ModelMessagesView } from './ModelMessagesView';
 import { AgentRunFooter } from './AgentRunFooter';
@@ -10,7 +10,7 @@ import { RunErrorDisplay } from './RunErrorDisplay';
 import { RunWarningDisplay } from './RunWarningDisplay';
 import { RunResumeDisplay } from './RunResumeDisplay';
 import { threadWarningsAtom } from '../../atoms/warnings';
-import { getToolCallStatus, toolResultsMapAtom, resumedRunIdsAtom } from '@beaver/agent-core/run-state/atoms';
+import { toolResultsMapAtom, resumedRunIdsAtom } from '@beaver/agent-core/run-state/atoms';
 import { streamingDoneRunIdsAtom } from '../../atoms/agentRunAtoms';
 import { getHost } from '@beaver/agent-ui/host';
 
@@ -18,22 +18,6 @@ interface AgentRunViewProps {
     run: AgentRun;
     isLastRun: boolean;
 }
-
-/** Check if there's any visible content in the run's model messages */
-const hasVisibleContent = (run: AgentRun): boolean => {
-    if (run.model_messages.length === 0) return false;
-    
-    // Check the last message for visible content
-    const lastMessage = run.model_messages[run.model_messages.length - 1];
-    if (lastMessage.kind !== 'response') return false;
-    
-    const response = lastMessage as ModelResponse;
-    return response.parts.some(part =>
-        (part.part_kind === 'text' && part.content.trim() !== '') ||
-        (part.part_kind === 'thinking' && part.content.trim() !== '') ||
-        (part.part_kind === 'tool-call' && !isAutoLoadingToolCall(part))
-    );
-};
 
 /**
  * Container component for a single agent run.
@@ -49,30 +33,20 @@ export const AgentRunView = React.memo(forwardRef<HTMLDivElement, AgentRunViewPr
     const streamingDoneRunIds = useAtomValue(streamingDoneRunIdsAtom);
     const isPostProcessing = streamingDoneRunIds.has(run.id);
 
-    // Check if any tool calls are currently in progress
-    const hasInprogressToolcalls = useMemo(() => {
-        for (const message of run.model_messages) {
-            if (message.kind === 'response') {
-                for (const part of message.parts) {
-                    if (part.part_kind === 'tool-call') {
-                        if (getToolCallStatus(part.tool_call_id, resultsMap, run.status) === 'in_progress') {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }, [run.model_messages, resultsMap]);
-
     // Check if this error run was resumed (to hide error display)
     const wasResumed = hasError && resumedRunIds.has(run.id);
 
     // Don't show user message for resume runs (empty content)
     const showUserMessage = !run.user_prompt.is_resume || run.user_prompt.content.length > 0;
     
-    // Only show spinner when streaming AND no visible content yet AND no tool calls in progress
-    const showStatusIndicator = isLastRun && isStreaming && !hasVisibleContent(run) && !hasInprogressToolcalls;
+    // Only the newest run: further up the thread a run that is still working is
+    // one the conversation has moved past, and its gap is not what the reader is
+    // waiting on.
+    const runHasNothingToShow = useMemo(
+        () => shouldShowRunStatus(run, resultsMap),
+        [run, resultsMap],
+    );
+    const showStatusIndicator = isLastRun && runHasNothingToShow;
 
     // Show agent run footer
     const showAgentRunFooter =

--- a/react/components/agentRuns/ModelResponseView.tsx
+++ b/react/components/agentRuns/ModelResponseView.tsx
@@ -4,20 +4,12 @@ import { TextPartView } from './TextPartView';
 import { ThinkingPartView } from './ThinkingPartView';
 import { ToolCallPartView } from './ToolCallPartView';
 import { isAnnotationToolResult } from '@beaver/agent-core/run-state/toolResultTypes';
+import { isAutoLoadingToolCall } from '@beaver/agent-core/agents/messageVisibility';
 import ContextMenu from '@beaver/agent-ui/primitives/ContextMenu';
 import useSelectionContextMenu from '../../hooks/useSelectionContextMenu';
 import { buildEditNoteRenderItems, getEditNoteGroupInstanceId } from './editNoteShared';
 import { getHost } from '@beaver/agent-ui/host';
 import { GenericAgentActionView } from './GenericAgentActionView';
-
-/**
- * Backend-injected plumbing (load_capacity / read-tool auto_load injection).
- * Only `auto_load_*` IDs are suppressed — `tool_kind` is also set on normal
- * agent-initiated search/capability calls and must not drive visibility here.
- */
-export function isAutoLoadingToolCall(part: ToolCallPart): boolean {
-    return part.tool_call_id.startsWith('auto_load_');
-}
 
 interface ModelResponseViewProps {
     /** The model response */

--- a/tests/unit/agents/runStatusVisibility.test.ts
+++ b/tests/unit/agents/runStatusVisibility.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for `@beaver/agent-core/run-state/runStatusVisibility`.
+ *
+ * The rule is worth pinning because both of its mistakes are silent. Left up
+ * beside an answer, a status line reads as a hang; missing during the wait
+ * before the first token, it reads as a message that was never sent. Both are
+ * one boolean away from each other, and neither shows up in a type check.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+    AgentRun,
+    ModelMessage,
+    ModelResponse,
+    RetryPromptPart,
+    ToolReturnPart,
+} from '@beaver/agent-core/agents/types';
+
+type ResponsePart = ModelResponse['parts'][number];
+
+import { shouldShowRunStatus } from '@beaver/agent-core/run-state/runStatusVisibility';
+
+function run(
+    messages: ModelMessage[],
+    status: AgentRun['status'] = 'in_progress',
+): AgentRun {
+    return {
+        id: 'run-1',
+        user_id: 'user-1',
+        thread_id: 'thread-1',
+        agent_name: 'beaver',
+        user_prompt: { content: 'hello', attachments: [] },
+        status,
+        model_messages: messages,
+        model_name: 'model',
+        created_at: '2026-01-01T00:00:00.000Z',
+        consent_to_share: false,
+    };
+}
+
+function response(...parts: ResponsePart[]): ModelMessage {
+    return { kind: 'response', run_id: 'run-1', parts };
+}
+
+/** The shape a tool result arrives in: a request message, not a response. */
+function toolResultMessage(): ModelMessage {
+    return {
+        kind: 'request',
+        run_id: 'run-1',
+        parts: [],
+    } as unknown as ModelMessage;
+}
+
+const toolCall = (toolCallId: string): ResponsePart => ({
+    part_kind: 'tool-call',
+    tool_name: 'search',
+    args: null,
+    tool_call_id: toolCallId,
+});
+
+const results = (
+    ...parts: (ToolReturnPart | RetryPromptPart)[]
+): Map<string, ToolReturnPart | RetryPromptPart> =>
+    new Map(parts.map((part) => [part.tool_call_id, part]));
+
+const toolReturn = (toolCallId: string): ToolReturnPart => ({
+    part_kind: 'tool-return',
+    tool_name: 'search',
+    content: 'ok',
+    tool_call_id: toolCallId,
+});
+
+const noResults = new Map<string, ToolReturnPart | RetryPromptPart>();
+
+describe('shouldShowRunStatus', () => {
+    it('shows for a run that has been sent and has produced nothing', () => {
+        expect(shouldShowRunStatus(run([]), noResults)).toBe(true);
+    });
+
+    it('stops as soon as the first text arrives', () => {
+        expect(
+            shouldShowRunStatus(
+                run([response({ part_kind: 'text', content: 'A' })]),
+                noResults,
+            ),
+        ).toBe(false);
+    });
+
+    it('treats an empty part as nothing, because that is what it looks like', () => {
+        // A text part exists before its first token streams into it, so the run
+        // has a part and the reader still has a blank space under the prompt.
+        expect(
+            shouldShowRunStatus(
+                run([response({ part_kind: 'text', content: '' })]),
+                noResults,
+            ),
+        ).toBe(true);
+    });
+
+    it('counts thinking as something to look at', () => {
+        expect(
+            shouldShowRunStatus(
+                run([response({ part_kind: 'thinking', content: 'hmm' })]),
+                noResults,
+            ),
+        ).toBe(false);
+    });
+
+    it('counts a tool call as something to look at, back or not', () => {
+        // A call the reader can see is content in its own right: its card is on
+        // screen from the moment the call is made, and it is the card — not this
+        // line — that says whether it has come back.
+        expect(
+            shouldShowRunStatus(run([response(toolCall('call-1'))]), noResults),
+        ).toBe(false);
+        expect(
+            shouldShowRunStatus(
+                run([response(toolCall('call-1'))]),
+                results(toolReturn('call-1')),
+            ),
+        ).toBe(false);
+    });
+
+    it('comes back in the gap between a tool result and whatever follows it', () => {
+        expect(
+            shouldShowRunStatus(
+                run([response(toolCall('call-1')), toolResultMessage()]),
+                results(toolReturn('call-1')),
+            ),
+        ).toBe(true);
+    });
+
+    it('waits for the last of several parallel calls', () => {
+        // The calls share a message and their results arrive separately, so one
+        // of them landing is not the run coming back — the other card is still
+        // spinning, and this line beside it would be a second claim.
+        expect(
+            shouldShowRunStatus(
+                run([
+                    response(toolCall('call-1'), toolCall('call-2')),
+                    toolResultMessage(),
+                ]),
+                results(toolReturn('call-1')),
+            ),
+        ).toBe(false);
+    });
+
+    it('looks past the newest message for a call still outstanding', () => {
+        // A call made in an earlier message is still the thing being waited on;
+        // only the visible-content half of the rule is about the newest one.
+        expect(
+            shouldShowRunStatus(
+                run([
+                    response(toolCall('call-1')),
+                    toolResultMessage(),
+                    response(),
+                ]),
+                noResults,
+            ),
+        ).toBe(false);
+    });
+
+    it('ignores an auto-loading call, which no client draws', () => {
+        // Backend plumbing: treating it as content would leave the reader
+        // looking at a blank space with nothing to explain it. Given a result,
+        // so the call is back and only the visible-content half is under test.
+        expect(
+            shouldShowRunStatus(
+                run([response(toolCall('auto_load_1'))]),
+                results(toolReturn('auto_load_1')),
+            ),
+        ).toBe(true);
+    });
+
+    it('stays quiet while an auto-loading call is outstanding', () => {
+        // The deliberate asymmetry, pinned so that removing it is a decision
+        // rather than an accident: the call is not content, but it is a step
+        // the run is between, and a client that draws such a call would
+        // otherwise get this line beside a card already saying so. What it
+        // costs a client that hides them is the call's own duration, which is
+        // single-digit milliseconds.
+        expect(
+            shouldShowRunStatus(
+                run([response(toolCall('auto_load_1'))]),
+                noResults,
+            ),
+        ).toBe(false);
+    });
+
+    it('says nothing for a run that is no longer working', () => {
+        for (const status of [
+            'completed',
+            'error',
+            'canceled',
+            'awaiting_deferred',
+        ] as const) {
+            expect(shouldShowRunStatus(run([], status), noResults)).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
Introduced a new module `runStatusVisibility.ts` to determine when a run has no visible content to display, enhancing the user experience by preventing misleading status indicators. This includes functions to check for visible content and in-progress tool calls. Updated the `AgentRunView` component to utilize this new logic, ensuring accurate status representation. Additionally, comprehensive unit tests have been added to validate the new functionality, addressing potential silent errors in status reporting.