### PR TITLE
feat(agent-core): introduce max attachment file size preference and u…

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -141,3 +141,9 @@ pref("librarySuggestionsGeneratedAt", "");
 
 // Account-scoped first-run assignment map, keyed by Beaver user id.
 pref("firstRunAssignments", "{}");
+
+// Largest attachment file, in MB, that Beaver will read
+// for document extraction, page and image rendering, in-file search, and
+// attaching an external file. It also decides which attachments count as
+// readable at all, so raising it un-blocks oversized ones in the sidebar.
+pref("maxAttachmentFileSizeMB", 100);

--- a/packages/agent-core/src/platform/runtime.ts
+++ b/packages/agent-core/src/platform/runtime.ts
@@ -25,6 +25,17 @@ export interface RuntimeAdapter {
     /** Clear a fully-qualified preference key. */
     clearPref(key: string): void;
     /**
+     * Read a Beaver preference by its *unqualified* key, letting the host apply
+     * its own preference namespace. Lets shared code carry a user-configurable
+     * setting without knowing how the host namespaces preferences.
+     *
+     * Optional: a host with no preference store omits it. Callers must treat a
+     * missing implementation, and any value they cannot use, the same as
+     * "unset" and fall back to their own default — so this seam is only for
+     * settings that have one.
+     */
+    getPluginPref?(key: string): unknown;
+    /**
      * The host application's own version (e.g. the Zotero version), or an empty
      * string when the host has none to report.
      */
@@ -45,8 +56,8 @@ export interface RuntimeAdapter {
  * caller reaching these without a registered host would otherwise read back
  * `undefined` and have writes silently discarded, which is a worse failure
  * mode (a wrong default, or a lost user preference) than an immediate error at
- * the source. `hostVersion`/`getVersionHeaders` are left off entirely, since
- * both are optional.
+ * the source. `getPluginPref`/`hostVersion`/`getVersionHeaders` are left off
+ * entirely, since all three are optional.
  */
 const unregisteredAdapter: RuntimeAdapter = {
     debug() {},

--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -280,7 +280,10 @@ export interface WSZoteroDocumentRequest extends WSBaseEvent {
     mode: BeaverExtractResult['mode'];
     /** Reject threshold for total document page count; not a page clamp. */
     max_pages?: number | null;
-    /** Backend-requested file size cap; frontend also applies its hard cap. */
+    /**
+     * Requested file size cap. Accepted for wire compatibility and ignored:
+     * the frontend's file-size ceiling is a client-side preference.
+     */
     max_file_size_mb?: number | null;
     /** Frontend-side extraction deadline in seconds. */
     timeout_seconds?: number;

--- a/packages/agent-core/src/transport/attachmentLimits.ts
+++ b/packages/agent-core/src/transport/attachmentLimits.ts
@@ -1,23 +1,48 @@
+/**
+ * Attachment size and page-count ceilings applied before a file is read.
+ *
+ * The file-size ceiling protects local resources — memory, and the time spent
+ * moving bytes — so it belongs to the client and is user-configurable through a
+ * host preference (advanced, no UI) rather than compiled in. A caller-requested
+ * cap is not consulted for it. The page-count ceiling is the opposite: it is a
+ * hard cap, and a caller may only ask for a stricter one.
+ */
+
+import { getRuntimeAdapter } from '../platform/runtime';
+
+/**
+ * Unqualified preference key for the file-size ceiling, in MB. The host adds
+ * its own preference namespace (see `RuntimeAdapter.getPluginPref`).
+ */
+const MAX_FILE_SIZE_MB_PREF = 'maxAttachmentFileSizeMB';
+
+/**
+ * File-size ceiling used when the host exposes no preference store or the
+ * stored value is unusable (absent, non-numeric, or not positive).
+ */
+export const DEFAULT_MAX_FILE_SIZE_MB = 100;
+
 export const HARD_ATTACHMENT_LIMITS = {
-    maxFileSizeMB: 100,
     // Whole-document transfers are additionally bounded by the backend's
     // serialized-payload budget (max_payload_bytes on the document request);
     // oversized extractions fail cleanly with document_too_large.
     maxPageCount: 1500,
 } as const;
 
-function positiveFiniteNumber(value: number | null | undefined): number | null {
+function positiveFiniteNumber(value: unknown): number | null {
     return typeof value === 'number' && Number.isFinite(value) && value > 0
         ? value
         : null;
 }
 
 /**
- * Return the effective file-size ceiling after applying Beaver's hard cap.
+ * Return the file-size ceiling in MB: the host preference when it holds a
+ * positive number, otherwise `DEFAULT_MAX_FILE_SIZE_MB`. Read at the point of
+ * use so a preference change takes effect without a reload.
  */
-export function effectiveMaxFileSizeMB(requested?: number | null): number {
-    const requestedLimit = positiveFiniteNumber(requested);
-    return Math.min(requestedLimit ?? HARD_ATTACHMENT_LIMITS.maxFileSizeMB, HARD_ATTACHMENT_LIMITS.maxFileSizeMB);
+export function effectiveMaxFileSizeMB(): number {
+    const configured = getRuntimeAdapter().getPluginPref?.(MAX_FILE_SIZE_MB_PREF);
+    return positiveFiniteNumber(configured) ?? DEFAULT_MAX_FILE_SIZE_MB;
 }
 
 /**
@@ -28,12 +53,16 @@ export function effectiveMaxPageCount(requested?: number | null): number {
     return Math.min(requestedLimit ?? HARD_ATTACHMENT_LIMITS.maxPageCount, HARD_ATTACHMENT_LIMITS.maxPageCount);
 }
 
-// Snapshots are parsed twice in memory, so use a tighter cap than other files.
+/**
+ * Snapshots are parsed twice in memory, so they carry their own hard ceiling.
+ * The file-size preference can lower it but not raise it: this cap guards the
+ * host's memory, not the transfer budget.
+ */
 export const SNAPSHOT_HARD_MAX_FILE_SIZE_MB = 50;
 
 /**
- * Return the effective snapshot file-size ceiling after both hard caps.
+ * Return the effective snapshot file-size ceiling after both caps.
  */
-export function effectiveMaxSnapshotFileSizeMB(requested?: number | null): number {
-    return Math.min(effectiveMaxFileSizeMB(requested), SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
+export function effectiveMaxSnapshotFileSizeMB(): number {
+    return Math.min(effectiveMaxFileSizeMB(), SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
 }

--- a/react/atoms/profile.ts
+++ b/react/atoms/profile.ts
@@ -4,7 +4,7 @@ import { ExcludedLibrary, SafeProfileWithPlan, PlanFeatures, ProfileBalance, Pro
 import { ZoteroLibrary } from "@beaver/agent-core/types/zotero";
 import { fileStatusAtom } from "./files";
 import { compareVersions } from "../utils/compareVersions";
-import { effectiveMaxFileSizeMB, effectiveMaxPageCount } from "@beaver/agent-core/transport/attachmentLimits";
+import { effectiveMaxPageCount } from "@beaver/agent-core/transport/attachmentLimits";
 
 // Profile and plan state
 export const isProfileLoadedAtom = atom<boolean>(false);
@@ -171,11 +171,15 @@ export const processingModeAtom = atom<ProcessingMode>(() => ProcessingMode.FRON
 // Plan features
 export const planFeaturesAtom = atom<PlanFeatures>((get) => {
     const profile = get(profileWithPlanAtom);
+    // The plan's own upload ceiling, which the backend enforces — unrelated to
+    // the local read ceiling in `attachmentLimits`. A plan row carries whatever
+    // the API returned, so treat anything but a positive number as unset.
+    const planFileSizeLimit = profile?.plan.max_file_size_mb;
     return {
         databaseSync: profile?.plan.sync_database || false,
         uploadFiles: profile?.plan.upload_files || false,
         maxUserAttachments: profile?.plan.max_user_attachments || 2,
-        uploadFileSizeLimit: effectiveMaxFileSizeMB(profile?.plan.max_file_size_mb ?? 10),
+        uploadFileSizeLimit: planFileSizeLimit && planFileSizeLimit > 0 ? planFileSizeLimit : 10,
         maxPageCount: effectiveMaxPageCount(profile?.plan.max_page_count ?? 100),
     } as PlanFeatures;
 });

--- a/react/hooks/httpHandlers/testCacheHandlers.ts
+++ b/react/hooks/httpHandlers/testCacheHandlers.ts
@@ -796,7 +796,6 @@ export async function handleTestDocumentSerializedHttpRequest(request: any) {
         external_file_key: request?.external_file_key ?? undefined,
         mode: request?.mode ?? 'structured',
         max_pages: request?.max_pages ?? undefined,
-        max_file_size_mb: request?.max_file_size_mb ?? undefined,
         max_payload_bytes: request?.max_payload_bytes ?? undefined,
         timeout_seconds: request?.timeout_seconds ?? undefined,
     };

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -522,7 +522,6 @@ async function handleAttachmentDocumentHttpRequest(request: any) {
         external_file_key: request.external_file_key,
         mode: request.mode ?? 'structured',
         max_pages: request.max_pages,
-        max_file_size_mb: request.max_file_size_mb,
         timeout_seconds: request.timeout_seconds,
     };
 

--- a/src/platform/zoteroRuntime.ts
+++ b/src/platform/zoteroRuntime.ts
@@ -10,6 +10,9 @@
  */
 
 import { setRuntimeAdapterIfUnset, type RuntimeAdapter } from '@beaver/agent-core/platform/runtime';
+import config from '../../package.json';
+
+const PREFS_PREFIX = config.config.prefsPrefix;
 
 /** The running Zotero's version, or an empty string when it reports none. */
 function zoteroVersion(): string {
@@ -33,6 +36,9 @@ const zoteroAdapter: RuntimeAdapter = {
     },
     clearPref(key) {
         Zotero.Prefs.clear(key, true);
+    },
+    getPluginPref(key) {
+        return Zotero.Prefs.get(`${PREFS_PREFIX}.${key}`, true);
     },
     hostVersion() {
         return zoteroVersion();

--- a/src/services/agentDataProvider/handleZoteroAttachmentImageRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroAttachmentImageRequest.ts
@@ -181,7 +181,7 @@ export async function handleZoteroAttachmentImageRequest(
             );
         }
         if (isRemoteOnly) {
-            const exceeded = checkRemotePdfSize(imageBytes, false, maxFileSizeMB);
+            const exceeded = checkRemotePdfSize(imageBytes, false);
             if (exceeded) {
                 return errorResponse(
                     `The image file for ${imageKey} has a file size of ${exceeded.sizeMB.toFixed(1)}MB, which exceeds the ${exceeded.maxMB}MB limit.`,

--- a/src/services/agentDataProvider/handleZoteroAttachmentPageImagesRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroAttachmentPageImagesRequest.ts
@@ -250,7 +250,7 @@ export async function handleZoteroAttachmentPageImagesRequest(
                     );
                 }
                 if (isRemoteOnly) {
-                    const exceeded = checkRemotePdfSize(pdfData, false, maxFileSizeMB);
+                    const exceeded = checkRemotePdfSize(pdfData, false);
                     if (exceeded) {
                         throwIfTimedOut('remote_file_too_large_response');
                         return errorResponse(
@@ -342,7 +342,7 @@ export async function handleZoteroAttachmentPageImagesRequest(
                 );
             }
             if (isRemoteOnly) {
-                const exceeded = checkRemotePdfSize(pdfData, false, maxFileSizeMB);
+                const exceeded = checkRemotePdfSize(pdfData, false);
                 if (exceeded) {
                     throwIfTimedOut('remote_file_too_large_response');
                     return errorResponse(

--- a/src/services/agentDataProvider/handleZoteroAttachmentSearchRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroAttachmentSearchRequest.ts
@@ -231,7 +231,7 @@ export async function handleZoteroAttachmentSearchRequest(
             );
         }
         if (isRemoteOnly) {
-            const exceeded = checkRemotePdfSize(pdfData, false, maxFileSizeMB);
+            const exceeded = checkRemotePdfSize(pdfData, false);
             if (exceeded) {
                 throwIfTimedOut('remote_file_too_large_response');
                 return errorResponse(

--- a/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
@@ -44,6 +44,7 @@ import {
     validateZoteroItemReference,
 } from './utils';
 import { EXTERNAL_LIBRARY_ID, resolveExternalFile } from '../externalFiles';
+import { effectiveMaxFileSizeMB } from '@beaver/agent-core/transport/attachmentLimits';
 import { withWorkerDiagnostics } from './workerDiagnostics';
 import type { ExternalFileRecord } from '../database';
 import { serializeAttachmentStub, serializeItemStub } from '../../utils/zoteroSerializers';
@@ -230,7 +231,9 @@ export async function handleZoteroDocumentRequest(
     request: WSZoteroDocumentRequest,
     options: ZoteroDocumentRequestOptions = {},
 ): Promise<WSZoteroDocumentResponse | PreparedJsonMessage> {
-    const { attachment, external_file_key, mode, max_pages, max_file_size_mb, request_id, timeout_seconds } = request;
+    // `max_file_size_mb` on the request is deliberately ignored: the file-size
+    // ceiling is a client-side preference (see attachmentLimits.ts).
+    const { attachment, external_file_key, mode, max_pages, request_id, timeout_seconds } = request;
 
     // Populated once the attachment resolves so post-resolution error responses
     // carry the same view-row metadata as success responses (best-effort:
@@ -337,7 +340,6 @@ export async function handleZoteroDocumentRequest(
         if (contentKind === 'text') {
             const source = await resolveAttachmentFileSource({
                 item: resolvedItem,
-                maxFileSizeMB: max_file_size_mb ?? 0,
                 localSizeStrategy: 'stat',
                 signal: timeout.signal,
                 throwIfTimedOut: timeout.throwIfTimedOut,
@@ -365,7 +367,6 @@ export async function handleZoteroDocumentRequest(
             const data = await loadAttachmentData({
                 item: resolvedItem,
                 source: source.source,
-                maxFileSizeMB: max_file_size_mb ?? 0,
                 onRemoteDownloadFailure: notifyRemoteDownloadFailure,
                 signal: timeout.signal,
                 throwIfTimedOut: timeout.throwIfTimedOut,
@@ -423,7 +424,6 @@ export async function handleZoteroDocumentRequest(
                     resolvedKey,
                     contentType,
                     maxPages: max_pages ?? null,
-                    maxFileSizeMB: max_file_size_mb ?? 0,
                     externalAbortSignal: timeout.signal,
                     onFileNotSyncedLocally: notifyRemoteFileNotSynced,
                 }),
@@ -461,7 +461,6 @@ export async function handleZoteroDocumentRequest(
                     resolvedKey,
                     contentType,
                     maxPages: max_pages ?? null,
-                    maxFileSizeMB: max_file_size_mb ?? 0,
                     externalAbortSignal: timeout.signal,
                     onFileNotSyncedLocally: notifyRemoteFileNotSynced,
                 }),
@@ -508,7 +507,6 @@ export async function handleZoteroDocumentRequest(
             contentType,
             mode,
             maxPages: max_pages ?? null,
-            maxFileSizeMB: max_file_size_mb ?? 0,
             timeoutSeconds: timeout_seconds ?? 0,
             workerName: 'hot',
             externalAbortSignal: timeout.signal,
@@ -581,7 +579,6 @@ export async function handleZoteroDocumentRequest(
                         payload: {
                             content_kind: 'pdf',
                             maxPages: max_pages ?? null,
-                            maxFileSizeMB: max_file_size_mb ?? 0,
                             timeoutSeconds: MAX_PDF_TIMEOUT_SECONDS,
                         },
                         now: Date.now(),
@@ -663,7 +660,7 @@ async function handleExternalFileDocumentRequest(
     ) => WSZoteroDocumentResponse,
     options: ZoteroDocumentRequestOptions = {},
 ): Promise<WSZoteroDocumentResponse | PreparedJsonMessage> {
-    const { mode, max_pages, max_file_size_mb, request_id, timeout_seconds } = request;
+    const { mode, max_pages, request_id, timeout_seconds } = request;
     const requestKey = `ext-${extKey}`;
 
     // Attach the served-file stub to post-resolution error responses too (it is
@@ -723,8 +720,8 @@ async function handleExternalFileDocumentRequest(
                 if (error instanceof TimeoutError) throw error;
                 return errorResponse(externalFileMissingMessage(extKey, record), 'file_missing', null, 'text');
             }
-            const maxMB = max_file_size_mb ?? 0;
-            if (maxMB > 0 && data.byteLength > maxMB * 1024 * 1024) {
+            const maxMB = effectiveMaxFileSizeMB();
+            if (data.byteLength > maxMB * 1024 * 1024) {
                 return errorResponse(
                     `External file '${requestKey}' is too large (${(data.byteLength / 1024 / 1024).toFixed(1)}MB > ${maxMB}MB).`,
                     'file_too_large',
@@ -754,7 +751,6 @@ async function handleExternalFileDocumentRequest(
                     resolvedKey: requestKey,
                     contentType: record.mimeType,
                     maxPages: max_pages ?? null,
-                    maxFileSizeMB: max_file_size_mb ?? 0,
                     externalAbortSignal: timeout.signal,
                 }),
                 timeout.signal,
@@ -788,7 +784,6 @@ async function handleExternalFileDocumentRequest(
             contentType: record.mimeType,
             mode,
             maxPages: max_pages ?? null,
-            maxFileSizeMB: max_file_size_mb ?? 0,
             timeoutSeconds: timeout_seconds ?? 0,
             workerName: 'hot',
             externalAbortSignal: timeout.signal,

--- a/src/services/backgroundExtractor.ts
+++ b/src/services/backgroundExtractor.ts
@@ -613,7 +613,6 @@ export class BackgroundExtractor {
                 zoteroKey: record.zoteroKey,
                 mode: record.payloadKind,
                 maxPages: payload.maxPages,
-                maxFileSizeMB: payload.maxFileSizeMB,
                 timeoutSeconds: payload.timeoutSeconds,
                 workerName: 'background',
                 externalAbortSignal,

--- a/src/services/documentExtraction/attachmentInfo.ts
+++ b/src/services/documentExtraction/attachmentInfo.ts
@@ -520,7 +520,6 @@ async function loadRemoteData(attachment: Zotero.Item, filePath: string): Promis
     const result = await loadAttachmentData({
         item: attachment,
         source: { kind: 'remote', filePath, isRemoteOnly: true },
-        maxFileSizeMB: effectiveMaxFileSizeMB(),
     });
     if (result.kind === 'ok') {
         return result.data;

--- a/src/services/documentExtraction/attachmentSource.ts
+++ b/src/services/documentExtraction/attachmentSource.ts
@@ -99,13 +99,12 @@ async function getLocalSizeBytes(
 /** Resolve a Zotero attachment to a local path or supported remote source. */
 export async function resolveAttachmentFileSource(args: {
     item: Zotero.Item;
-    maxFileSizeMB: number;
     localSizeStrategy: LocalSizeStrategy;
     signal?: AbortSignal;
     throwIfTimedOut?: (phase: string) => void;
 }): Promise<AttachmentSourceResult> {
     const { item, localSizeStrategy, signal, throwIfTimedOut } = args;
-    const maxFileSizeMB = effectiveMaxFileSizeMB(args.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxFileSizeMB();
 
     throwIfTimedOut?.('file_path_lookup');
     const rawFilePath = await withDeadline(
@@ -180,6 +179,46 @@ const remoteDataCache = new Map<string, { data: Uint8Array; ts: number }>();
 const remoteInflight = new Map<string, Promise<Uint8Array>>();
 const REMOTE_CACHE_TTL_MS = 120_000;
 const REMOTE_CACHE_MAX = 10;
+// Resident-bytes budget for the cache above. Bounding total bytes rather than
+// per-entry size keeps the two properties that matter independent of the
+// configured file-size ceiling: memory stays capped however high a user raises
+// it, and a file large enough to read is still small enough to cache, so
+// successive handlers in one agent turn do not each re-download it.
+const REMOTE_CACHE_MAX_TOTAL_BYTES = 1000 * 1024 * 1024;
+
+/**
+ * Store a downloaded attachment, evicting expired then oldest entries until it
+ * fits both the entry count and the byte budget. A download the caller cannot
+ * use, or one larger than the whole budget, is returned but never cached.
+ */
+function admitToRemoteCache(cacheKey: string, data: Uint8Array): void {
+    // Every caller rejects bytes over the configured ceiling — some through
+    // `checkAttachmentDataSize` here, the `skipSizeCheck` ones by checking at
+    // the call site — so retaining them only holds memory for a re-read that
+    // will fail the same way.
+    if (data.length > effectiveMaxFileSizeMB() * 1024 * 1024) return;
+    if (data.length > REMOTE_CACHE_MAX_TOTAL_BYTES) return;
+
+    const now = Date.now();
+    for (const [key, value] of remoteDataCache) {
+        if (now - value.ts > REMOTE_CACHE_TTL_MS) remoteDataCache.delete(key);
+    }
+
+    let residentBytes = data.length;
+    for (const value of remoteDataCache.values()) residentBytes += value.data.length;
+
+    // Map iteration is insertion-ordered, and a cache hit refreshes `ts`
+    // without reinserting, so this evicts least-recently-*added* first.
+    for (const [key, value] of remoteDataCache) {
+        if (remoteDataCache.size < REMOTE_CACHE_MAX && residentBytes <= REMOTE_CACHE_MAX_TOTAL_BYTES) {
+            break;
+        }
+        remoteDataCache.delete(key);
+        residentBytes -= value.data.length;
+    }
+
+    remoteDataCache.set(cacheKey, { data, ts: now });
+}
 
 async function readRemoteAttachmentData(
     item: Zotero.Item,
@@ -217,32 +256,18 @@ async function readRemoteAttachmentData(
         remoteInflight.delete(cacheKey);
     }
 
-    const defaultMaxMB = effectiveMaxFileSizeMB();
-    if ((data.length / 1024 / 1024) <= defaultMaxMB) {
-        if (remoteDataCache.size >= REMOTE_CACHE_MAX) {
-            const now = Date.now();
-            for (const [key, value] of remoteDataCache) {
-                if (now - value.ts > REMOTE_CACHE_TTL_MS) remoteDataCache.delete(key);
-            }
-        }
-        if (remoteDataCache.size >= REMOTE_CACHE_MAX) {
-            const oldest = remoteDataCache.keys().next().value;
-            if (oldest !== undefined) remoteDataCache.delete(oldest);
-        }
-        remoteDataCache.set(cacheKey, { data, ts: Date.now() });
-    }
+    admitToRemoteCache(cacheKey, data);
 
     return data;
 }
 
-/** Check whether in-memory attachment data exceeds a caller's size limit. */
+/** Check whether in-memory attachment data exceeds the file-size ceiling. */
 export function checkAttachmentDataSize(
     data: Uint8Array,
     skipLimits?: boolean,
-    maxFileSizeMB?: number,
 ): { sizeMB: number; maxMB: number } | null {
     if (skipLimits) return null;
-    const maxMB = effectiveMaxFileSizeMB(maxFileSizeMB);
+    const maxMB = effectiveMaxFileSizeMB();
     const sizeMB = data.length / 1024 / 1024;
     return sizeMB > maxMB ? { sizeMB, maxMB } : null;
 }
@@ -255,7 +280,6 @@ export function checkAttachmentDataSize(
 export async function loadAttachmentData(args: {
     item?: Zotero.Item | null;
     source: AttachmentFileSource;
-    maxFileSizeMB: number;
     skipSizeCheck?: boolean;
     onRemoteDownloadFailure?: (error: unknown) => void;
     signal?: AbortSignal;
@@ -302,7 +326,7 @@ export async function loadAttachmentData(args: {
             return { kind: 'error', code: 'download_failed', error };
         }
 
-        const exceeded = checkAttachmentDataSize(data, args.skipSizeCheck, args.maxFileSizeMB);
+        const exceeded = checkAttachmentDataSize(data, args.skipSizeCheck);
         if (exceeded) {
             return {
                 kind: 'error',

--- a/src/services/documentExtraction/epub/EpubExtractor.ts
+++ b/src/services/documentExtraction/epub/EpubExtractor.ts
@@ -51,7 +51,6 @@ interface ZoteroEpubModule {
 }
 
 export interface ExtractEpubDocumentOptions {
-    maxFileSizeMB?: number | null;
     onFileNotSyncedLocally?: () => void;
 }
 
@@ -365,7 +364,7 @@ export async function preflightEpubFile(
         return preflightResponseError("file_missing", "The EPUB file is not available locally.");
     }
 
-    const maxFileSizeMB = effectiveMaxFileSizeMB(options?.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxFileSizeMB();
     try {
         const stat = await IOUtils.stat(filePath);
         const sizeMB = typeof stat.size === "number" ? stat.size / 1024 / 1024 : null;

--- a/src/services/documentExtraction/pdfData.ts
+++ b/src/services/documentExtraction/pdfData.ts
@@ -23,7 +23,6 @@ export async function loadPdfData(
     const result = await loadAttachmentData({
         item,
         source,
-        maxFileSizeMB: 0,
         skipSizeCheck: true,
         onRemoteDownloadFailure: onRemoteFailure,
     });
@@ -37,7 +36,6 @@ export async function loadPdfData(
 export function checkRemotePdfSize(
     data: Uint8Array,
     skipLimits?: boolean,
-    maxFileSizeMB?: number,
 ): { sizeMB: number; maxMB: number } | null {
-    return checkAttachmentDataSize(data, skipLimits, maxFileSizeMB);
+    return checkAttachmentDataSize(data, skipLimits);
 }

--- a/src/services/documentExtraction/shared/backgroundJobPayloads.ts
+++ b/src/services/documentExtraction/shared/backgroundJobPayloads.ts
@@ -6,7 +6,6 @@ import {
 export interface PdfBackgroundJobPayload {
   content_kind: "pdf";
   maxPages: number | null;
-  maxFileSizeMB: number;
   timeoutSeconds: number;
 }
 
@@ -64,11 +63,7 @@ export function parseBackgroundJobPayload(
       const payload = parsed as Partial<PdfBackgroundJobPayload>;
       const maxPagesValid =
         payload.maxPages === null || typeof payload.maxPages === "number";
-      if (
-        !maxPagesValid ||
-        typeof payload.maxFileSizeMB !== "number" ||
-        typeof payload.timeoutSeconds !== "number"
-      ) {
+      if (!maxPagesValid || typeof payload.timeoutSeconds !== "number") {
         return null;
       }
       return payload as PdfBackgroundJobPayload;

--- a/src/services/documentExtraction/snapshot/SnapshotExtractor.ts
+++ b/src/services/documentExtraction/snapshot/SnapshotExtractor.ts
@@ -38,7 +38,6 @@ const LOW_COVERAGE_WARN_THRESHOLD = 0.85;
 const SYNTHETIC_PAGE_CHAR_INTERVAL = 1800;
 
 export interface ExtractSnapshotDocumentOptions {
-    maxFileSizeMB?: number | null;
     onFileNotSyncedLocally?: () => void;
 }
 
@@ -318,7 +317,7 @@ export async function preflightSnapshotFile(
         return preflightResponseError("file_missing", "The snapshot file is not available locally.");
     }
 
-    const maxFileSizeMB = effectiveMaxSnapshotFileSizeMB(options?.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxSnapshotFileSizeMB();
     try {
         const stat = await IOUtils.stat(filePath);
         const sizeMB = typeof stat.size === "number" ? stat.size / 1024 / 1024 : null;

--- a/src/services/documentExtractionCore.ts
+++ b/src/services/documentExtractionCore.ts
@@ -96,15 +96,18 @@ export type ExtractionSource =
     | { kind: 'zotero'; item: Zotero.Item }
     | { kind: 'external'; filePath: string; itemRef: DocumentCacheItemRef };
 
-/** Inline local-file source check for external files (no Zotero item). */
+/**
+ * Inline local-file source check for external files (no Zotero item).
+ * `maxMB` is the already-resolved ceiling, so snapshot callers can pass their
+ * tighter one.
+ */
 async function resolveExternalFileSource(
     filePath: string,
-    maxFileSizeMBInput: number,
+    maxMB: number,
 ): Promise<
     | { kind: 'ok'; filePath: string }
     | { kind: 'error'; code: 'file_missing' | 'file_too_large'; sizeMB?: number; maxMB?: number }
 > {
-    const maxMB = effectiveMaxFileSizeMB(maxFileSizeMBInput);
     let stat: { size?: number | null };
     try {
         stat = await IOUtils.stat(filePath);
@@ -164,7 +167,6 @@ export interface ExtractAndCacheArgs {
      * pages.
      */
     maxPages: number | null;
-    maxFileSizeMB: number;
     /** Extraction deadline in seconds. */
     timeoutSeconds: number;
     /** Default `"hot"`. Background processor sets `"background"`. */
@@ -204,7 +206,6 @@ export interface ExtractAndCacheEpubArgs {
      * markers, otherwise synthetic ~character-interval pages).
      */
     maxPages: number | null;
-    maxFileSizeMB: number;
     externalAbortSignal?: AbortSignal;
     onFileNotSyncedLocally?: () => void;
 }
@@ -219,7 +220,6 @@ export interface ExtractAndCacheSnapshotArgs {
      * synthetic `pageNumber` coordinate (~character-interval pages).
      */
     maxPages: number | null;
-    maxFileSizeMB: number;
     externalAbortSignal?: AbortSignal;
     onFileNotSyncedLocally?: () => void;
 }
@@ -511,7 +511,6 @@ export async function extractAndCacheEpubDocument(
     let filePath: string;
     if (args.source.kind === 'zotero') {
         const preflight = await preflightEpubFile(args.source.item, {
-            maxFileSizeMB: args.maxFileSizeMB,
             onFileNotSyncedLocally: args.onFileNotSyncedLocally,
         });
         if (preflight.kind === 'response_error') {
@@ -527,7 +526,7 @@ export async function extractAndCacheEpubDocument(
     } else {
         // External files skip the Zotero preflight (kind already validated at
         // attach time; the managed copy is local-only).
-        const externalSource = await resolveExternalFileSource(args.source.filePath, args.maxFileSizeMB);
+        const externalSource = await resolveExternalFileSource(args.source.filePath, effectiveMaxFileSizeMB());
         if (externalSource.kind === 'error') {
             return {
                 kind: 'response_error',
@@ -542,7 +541,7 @@ export async function extractAndCacheEpubDocument(
         filePath = externalSource.filePath;
     }
 
-    const maxFileSizeMB = effectiveMaxFileSizeMB(args.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxFileSizeMB();
     const maxSourceSizeBytes = maxFileSizeMB * 1024 * 1024;
     const maxPages = effectiveMaxPageCount(args.maxPages);
 
@@ -688,7 +687,6 @@ export async function extractAndCacheSnapshotDocument(
     let filePath: string;
     if (args.source.kind === 'zotero') {
         const preflight = await preflightSnapshotFile(args.source.item, {
-            maxFileSizeMB: args.maxFileSizeMB,
             onFileNotSyncedLocally: args.onFileNotSyncedLocally,
         });
         if (preflight.kind === 'response_error') {
@@ -705,7 +703,7 @@ export async function extractAndCacheSnapshotDocument(
         // Match the tighter Zotero snapshot preflight limit for external files.
         const externalSource = await resolveExternalFileSource(
             args.source.filePath,
-            effectiveMaxSnapshotFileSizeMB(args.maxFileSizeMB),
+            effectiveMaxSnapshotFileSizeMB(),
         );
         if (externalSource.kind === 'error') {
             return {
@@ -728,7 +726,7 @@ export async function extractAndCacheSnapshotDocument(
         : {};
 
     // Keep cache and fallback errors aligned with snapshot preflight.
-    const maxFileSizeMB = effectiveMaxSnapshotFileSizeMB(args.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxSnapshotFileSizeMB();
     const maxSourceSizeBytes = maxFileSizeMB * 1024 * 1024;
     const maxPages = effectiveMaxPageCount(args.maxPages);
 
@@ -864,7 +862,7 @@ export async function extractAndCacheResolvedPdfDocument(
     const workerName: PDFWorkerSlotName = args.workerName ?? 'hot';
     const requestKey = args.resolvedKey;
 
-    const maxFileSizeMB = effectiveMaxFileSizeMB(args.maxFileSizeMB);
+    const maxFileSizeMB = effectiveMaxFileSizeMB();
     const maxPages = effectiveMaxPageCount(args.maxPages);
 
     const ownsTimeout = !args.timeoutContext;
@@ -924,7 +922,7 @@ export async function extractAndCacheResolvedPdfDocument(
         if (args.source.kind === 'external') {
             // External files: the managed copy is the only source — no remote
             // fallback, plain stat-based existence/size check.
-            const externalSource = await resolveExternalFileSource(args.source.filePath, args.maxFileSizeMB);
+            const externalSource = await resolveExternalFileSource(args.source.filePath, maxFileSizeMB);
             throwIfTimedOut('file_missing_response');
             if (externalSource.kind === 'error') {
                 if (externalSource.code === 'file_too_large') {
@@ -948,7 +946,6 @@ export async function extractAndCacheResolvedPdfDocument(
         } else {
             const source = await resolveAttachmentFileSource({
                 item: args.source.item,
-                maxFileSizeMB: args.maxFileSizeMB,
                 localSizeStrategy: 'zotero-total',
                 signal,
                 throwIfTimedOut,
@@ -1090,7 +1087,6 @@ export async function extractAndCacheResolvedPdfDocument(
             const loaded = await loadAttachmentData({
                 item: zoteroItem,
                 source: attachmentSource,
-                maxFileSizeMB,
                 onRemoteDownloadFailure: args.onRemoteDownloadFailure,
                 signal,
                 throwIfTimedOut,
@@ -1156,7 +1152,6 @@ export async function extractAndCacheResolvedPdfDocument(
             const loaded = await loadAttachmentData({
                 item: zoteroItem,
                 source: attachmentSource,
-                maxFileSizeMB,
                 onRemoteDownloadFailure: args.onRemoteDownloadFailure,
                 signal,
                 throwIfTimedOut,

--- a/tests/helpers/cacheInspector.ts
+++ b/tests/helpers/cacheInspector.ts
@@ -934,7 +934,6 @@ export type BackgroundJobPayloadKind = 'structured' | 'markdown';
 export interface PdfBackgroundJobPayload {
     content_kind: 'pdf';
     maxPages: number | null;
-    maxFileSizeMB: number;
     timeoutSeconds: number;
 }
 

--- a/tests/helpers/zoteroHttpClient.ts
+++ b/tests/helpers/zoteroHttpClient.ts
@@ -159,7 +159,6 @@ export function fetchDocument(
     extra?: {
         mode?: 'markdown' | 'structured';
         max_pages?: number | null;
-        max_file_size_mb?: number | null;
         timeout_seconds?: number;
     },
     opts?: RequestOptions,
@@ -182,7 +181,6 @@ export function fetchExternalFileDocument(
     extra?: {
         mode?: 'markdown' | 'structured';
         max_pages?: number | null;
-        max_file_size_mb?: number | null;
         timeout_seconds?: number;
     },
     opts?: RequestOptions,
@@ -250,7 +248,6 @@ export function fetchDocumentSerialized(
     extra?: {
         mode?: 'markdown' | 'structured';
         max_pages?: number | null;
-        max_file_size_mb?: number | null;
         max_payload_bytes?: number | null;
         timeout_seconds?: number;
     },
@@ -271,7 +268,6 @@ export function fetchExternalFileDocumentSerialized(
     extra?: {
         mode?: 'markdown' | 'structured';
         max_pages?: number | null;
-        max_file_size_mb?: number | null;
         max_payload_bytes?: number | null;
         timeout_seconds?: number;
     },

--- a/tests/live/backgroundContentKind.live.test.ts
+++ b/tests/live/backgroundContentKind.live.test.ts
@@ -64,7 +64,6 @@ function pdfPayload(maxPages: number | null): BackgroundJobPayload {
     return {
         content_kind: 'pdf',
         maxPages,
-        maxFileSizeMB: 25,
         timeoutSeconds: 120,
     };
 }
@@ -93,7 +92,6 @@ describe('background queue — payload parsing on read', () => {
         expect(job.payload).toEqual({
             content_kind: 'pdf',
             maxPages: 7,
-            maxFileSizeMB: 25,
             timeoutSeconds: 120,
         });
     });
@@ -111,7 +109,6 @@ describe('background queue — payload parsing on read', () => {
         expect(peek.jobs![0].payload).toEqual({
             content_kind: 'pdf',
             maxPages: null,
-            maxFileSizeMB: 25,
             timeoutSeconds: 120,
         });
     });
@@ -139,7 +136,7 @@ describe('background queue — payload parsing on read', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            // Missing maxFileSizeMB and timeoutSeconds.
+            // Missing timeoutSeconds.
             payload: { content_kind: 'pdf', maxPages: null } as unknown as BackgroundJobPayload,
         });
         const peek = await backgroundPeek();
@@ -156,7 +153,6 @@ describe('background queue — payload parsing on read', () => {
             payload: {
                 content_kind: 'pdf',
                 maxPages: 'all',
-                maxFileSizeMB: 25,
                 timeoutSeconds: 120,
             } as unknown as BackgroundJobPayload,
         });

--- a/tests/live/backgroundExtractor.live.test.ts
+++ b/tests/live/backgroundExtractor.live.test.ts
@@ -91,7 +91,6 @@ describe('background queue — enqueue endpoint', () => {
             payload: {
                 content_kind: 'pdf',
                 maxPages: null,
-                maxFileSizeMB: 0,
                 timeoutSeconds: 180,
             },
         });
@@ -117,7 +116,7 @@ describe('background queue — enqueue endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 100,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         expect(first.enqueued).toBe(true);
 
@@ -128,7 +127,7 @@ describe('background queue — enqueue endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 100,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         expect(second.enqueued).toBe(false);
         expect(second.id).toBe(first.id);
@@ -141,7 +140,7 @@ describe('background queue — enqueue endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const markdown = await backgroundEnqueue({
             library_id: SMALL_PDF.library_id,
@@ -149,7 +148,7 @@ describe('background queue — enqueue endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'markdown',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         expect(structured.enqueued).toBe(true);
         expect(markdown.enqueued).toBe(true);
@@ -179,7 +178,6 @@ describe('background queue — peek endpoint', () => {
             payload: {
                 content_kind: 'pdf',
                 maxPages: 50,
-                maxFileSizeMB: 25,
                 timeoutSeconds: 180,
             },
         });
@@ -200,7 +198,6 @@ describe('background queue — peek endpoint', () => {
         expect(job.payload).toEqual({
             content_kind: 'pdf',
             maxPages: 50,
-            maxFileSizeMB: 25,
             timeoutSeconds: 180,
         });
         expect(typeof job.enqueuedAt).toBe('number');
@@ -214,7 +211,7 @@ describe('background queue — peek endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
             library_id: NORMAL_PDF.library_id,
@@ -222,7 +219,7 @@ describe('background queue — peek endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const limited = await backgroundPeek({ limit: 1 });
@@ -241,7 +238,7 @@ describe('background queue — peek endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 200,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const high = await backgroundEnqueue({
             library_id: NORMAL_PDF.library_id,
@@ -250,7 +247,7 @@ describe('background queue — peek endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 10,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const peek = await backgroundPeek();
@@ -286,7 +283,7 @@ describe('background queue — stats endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const res = await backgroundStats();
         expect(res.queue!.pending).toBe(1);
@@ -327,7 +324,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
@@ -352,7 +349,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
@@ -372,7 +369,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
@@ -392,7 +389,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const res = await backgroundProcessOnce();
@@ -411,7 +408,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
             library_id: SMALL_PDF.library_id,
@@ -420,7 +417,7 @@ describe('background queue — processOnce endpoint', () => {
             payload_kind: 'markdown',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const first = await backgroundProcessOnce();
@@ -449,7 +446,7 @@ describe('background queue — enqueue defaults', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const peek = await backgroundPeek();
         expect(peek.jobs?.length).toBe(1);
@@ -463,7 +460,7 @@ describe('background queue — enqueue defaults', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const peekNull = await backgroundPeek();
         expect(peekNull.jobs![0].itemId).toBeNull();
@@ -477,7 +474,7 @@ describe('background queue — enqueue defaults', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             item_id: 42,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const peek = await backgroundPeek();
         expect(peek.jobs![0].itemId).toBe(42);
@@ -517,7 +514,7 @@ describe('background queue — clear endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
             library_id: SMALL_PDF.library_id,
@@ -525,7 +522,7 @@ describe('background queue — clear endpoint', () => {
             content_kind: 'pdf',
             payload_kind: 'markdown',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const before = await backgroundStats();
@@ -558,7 +555,7 @@ describe('background queue — terminal response_error completes without retry',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
             notify: true,
         });
 
@@ -593,7 +590,7 @@ describe('background queue — group library extraction', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
             notify: true,
         });
 
@@ -627,7 +624,7 @@ describe('background queue — worker slot isolation', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: DRAIN_PRIORITY,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
             notify: true,
         });
 
@@ -666,7 +663,7 @@ describe('background queue — stats.byJobType across payload kinds', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
             library_id: SMALL_PDF.library_id,
@@ -674,7 +671,7 @@ describe('background queue — stats.byJobType across payload kinds', () => {
             content_kind: 'pdf',
             payload_kind: 'markdown',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const stats = await backgroundStats();
@@ -697,7 +694,7 @@ describe('background queue — peek edge cases', () => {
             content_kind: 'pdf',
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const peek = await backgroundPeek({ limit: 0 });
         expect(peek.ok).toBe(true);
@@ -712,7 +709,7 @@ describe('background queue — peek edge cases', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 5,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         const mid = await backgroundEnqueue({
             library_id: NORMAL_PDF.library_id,
@@ -721,7 +718,7 @@ describe('background queue — peek edge cases', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 50,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
         await backgroundEnqueue({
             library_id: NO_TEXT_PDF.library_id,
@@ -730,7 +727,7 @@ describe('background queue — peek edge cases', () => {
             payload_kind: 'structured',
             job_type: 'document_timeout_retry',
             priority: 500,
-            payload: { content_kind: 'pdf', maxPages: null, maxFileSizeMB: 0, timeoutSeconds: 180 },
+            payload: { content_kind: 'pdf', maxPages: null, timeoutSeconds: 180 },
         });
 
         const peek = await backgroundPeek({ limit: 2 });

--- a/tests/unit/platform/zoteroRuntime.test.ts
+++ b/tests/unit/platform/zoteroRuntime.test.ts
@@ -43,6 +43,18 @@ describe('the Zotero runtime adapter', () => {
         });
     });
 
+    describe('getPluginPref', () => {
+        it('qualifies an unprefixed key with the plugin preference namespace', () => {
+            vi.mocked(Zotero.Prefs.get).mockReturnValue(250);
+
+            expect(zoteroAdapter.getPluginPref?.('maxAttachmentFileSizeMB')).toBe(250);
+            expect(Zotero.Prefs.get).toHaveBeenCalledWith(
+                'extensions.zotero.beaver.maxAttachmentFileSizeMB',
+                true,
+            );
+        });
+    });
+
     describe('hostVersion', () => {
         it('reports the Zotero version', () => {
             vi.stubGlobal('Zotero', { version: '7.0.99' });

--- a/tests/unit/services/attachmentLimits.test.ts
+++ b/tests/unit/services/attachmentLimits.test.ts
@@ -1,37 +1,80 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+    DEFAULT_MAX_FILE_SIZE_MB,
     HARD_ATTACHMENT_LIMITS,
+    SNAPSHOT_HARD_MAX_FILE_SIZE_MB,
     effectiveMaxFileSizeMB,
     effectiveMaxPageCount,
+    effectiveMaxSnapshotFileSizeMB,
 } from '@beaver/agent-core/transport/attachmentLimits';
+import {
+    getRuntimeAdapter,
+    setRuntimeAdapter,
+    type RuntimeAdapter,
+} from '@beaver/agent-core/platform/runtime';
 
-const { maxFileSizeMB, maxPageCount } = HARD_ATTACHMENT_LIMITS;
+const { maxPageCount } = HARD_ATTACHMENT_LIMITS;
+const pristineAdapter = getRuntimeAdapter();
+
+/** Install an adapter whose only job is to answer the file-size preference. */
+function withPrefValue(value: unknown): void {
+    setRuntimeAdapter({
+        ...pristineAdapter,
+        getPluginPref: () => value,
+    } as RuntimeAdapter);
+}
 
 describe('attachmentLimits', () => {
-    it('exposes positive hard attachment caps', () => {
-        expect(maxFileSizeMB).toBeGreaterThan(0);
+    afterEach(() => {
+        setRuntimeAdapter(pristineAdapter);
+    });
+
+    it('exposes positive defaults and caps', () => {
+        expect(DEFAULT_MAX_FILE_SIZE_MB).toBeGreaterThan(0);
         expect(maxPageCount).toBeGreaterThan(0);
     });
 
-    it('uses hard caps when no caller-specific limit is provided', () => {
-        expect(effectiveMaxFileSizeMB()).toBe(maxFileSizeMB);
+    it('falls back to the default file size when the host exposes no preference', () => {
+        expect(effectiveMaxFileSizeMB()).toBe(DEFAULT_MAX_FILE_SIZE_MB);
+    });
+
+    it('uses the preference value, above or below the default', () => {
+        withPrefValue(25);
+        expect(effectiveMaxFileSizeMB()).toBe(25);
+
+        withPrefValue(DEFAULT_MAX_FILE_SIZE_MB + 150);
+        expect(effectiveMaxFileSizeMB()).toBe(DEFAULT_MAX_FILE_SIZE_MB + 150);
+    });
+
+    it('falls back to the default for unusable preference values', () => {
+        for (const value of [0, -1, Number.NaN, null, undefined, '50', {}]) {
+            withPrefValue(value);
+            expect(effectiveMaxFileSizeMB()).toBe(DEFAULT_MAX_FILE_SIZE_MB);
+        }
+    });
+
+    it('bounds the snapshot ceiling by the snapshot hard cap', () => {
+        withPrefValue(500);
+        expect(effectiveMaxSnapshotFileSizeMB()).toBe(SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
+
+        withPrefValue(20);
+        expect(effectiveMaxSnapshotFileSizeMB()).toBe(20);
+    });
+
+    it('uses the hard page-count cap when no caller-specific limit is provided', () => {
         expect(effectiveMaxPageCount()).toBe(maxPageCount);
     });
 
-    it('keeps stricter caller-specific limits', () => {
-        expect(effectiveMaxFileSizeMB(25)).toBe(25);
+    it('keeps stricter caller-specific page-count limits', () => {
         expect(effectiveMaxPageCount(300)).toBe(300);
     });
 
-    it('clamps caller-specific limits to the hard caps', () => {
-        expect(effectiveMaxFileSizeMB(maxFileSizeMB + 150)).toBe(maxFileSizeMB);
+    it('clamps caller-specific page-count limits to the hard cap', () => {
         expect(effectiveMaxPageCount(maxPageCount + 2000)).toBe(maxPageCount);
     });
 
-    it('ignores invalid caller-specific limits', () => {
-        expect(effectiveMaxFileSizeMB(0)).toBe(maxFileSizeMB);
-        expect(effectiveMaxFileSizeMB(Number.NaN)).toBe(maxFileSizeMB);
+    it('ignores invalid caller-specific page-count limits', () => {
         expect(effectiveMaxPageCount(-1)).toBe(maxPageCount);
         expect(effectiveMaxPageCount(null)).toBe(maxPageCount);
     });

--- a/tests/unit/services/attachmentLimitsPrefDeclaration.test.ts
+++ b/tests/unit/services/attachmentLimitsPrefDeclaration.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Lock the file-size ceiling to its preference declaration.
+ *
+ * `attachmentLimits` reads `maxAttachmentFileSizeMB` through the runtime
+ * adapter, which takes an untyped key string. Renaming, dropping, or commenting
+ * out the `pref(...)` line in `addon/prefs.js` therefore type-checks and lints
+ * cleanly: the read just returns `undefined` and every ceiling silently reverts
+ * to the built-in default, so the user's setting stops working with no signal.
+ * The same goes for the declared default drifting away from the built-in one,
+ * which would make the value shown in `about:config` not the value in force.
+ *
+ * Asserting against the source is the only option here — `prefs.js` is loaded
+ * by Zotero, not importable.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MAX_FILE_SIZE_MB } from '@beaver/agent-core/transport/attachmentLimits';
+
+const prefsSource = readFileSync(
+    fileURLToPath(new URL('../../../addon/prefs.js', import.meta.url)),
+    'utf8',
+);
+
+/**
+ * Declarations of one key, ignoring commented-out ones. Block comments are
+ * stripped (a `pref(...)` inside one can start its own line); line comments
+ * need no stripping, because the match is anchored to the start of a line and
+ * only tolerates indentation before `pref`.
+ */
+function declarationsOf(key: string): string[] {
+    const live = prefsSource.replace(/\/\*[\s\S]*?\*\//g, '');
+    const pattern = new RegExp(String.raw`^[ \t]*pref\("${key}",\s*([^)]+)\)`, 'gm');
+    return [...live.matchAll(pattern)].map((match) => match[1].trim());
+}
+
+describe('the attachment file-size preference declaration', () => {
+    it('declares the key attachmentLimits reads, with the same default', () => {
+        const declarations = declarationsOf('maxAttachmentFileSizeMB');
+
+        // Exactly one: a duplicate line would make the last call win, so the
+        // default asserted below would not be the one in force.
+        expect(
+            declarations,
+            'addon/prefs.js must declare maxAttachmentFileSizeMB exactly once',
+        ).toHaveLength(1);
+        expect(
+            Number(declarations[0]),
+            'the default declared in addon/prefs.js must equal DEFAULT_MAX_FILE_SIZE_MB',
+        ).toBe(DEFAULT_MAX_FILE_SIZE_MB);
+    });
+});

--- a/tests/unit/services/attachmentSource.test.ts
+++ b/tests/unit/services/attachmentSource.test.ts
@@ -45,9 +45,16 @@ function makeAttachment(overrides: Partial<Zotero.Item> = {}): Zotero.Item {
 }
 
 describe('attachmentSource', () => {
+    // The file-size ceiling is read from the preference on every check, so
+    // tests set it here instead of passing a per-call limit.
+    let maxFileSizeMBPref = 10;
+
     beforeEach(() => {
         vi.clearAllMocks();
-        Zotero.Prefs.get = vi.fn().mockReturnValue(true);
+        maxFileSizeMBPref = 10;
+        Zotero.Prefs.get = vi.fn((key: string) =>
+            key.endsWith('.maxAttachmentFileSizeMB') ? maxFileSizeMBPref : true,
+        ) as any;
         Zotero.Attachments.getTotalFileSize = vi.fn().mockResolvedValue(1024);
         (globalThis as any).IOUtils.stat.mockResolvedValue({ lastModified: 0, size: 1024 });
         (globalThis as any).IOUtils.read.mockResolvedValue(new Uint8Array([1, 2, 3]));
@@ -60,7 +67,6 @@ describe('attachmentSource', () => {
 
         const result = await resolveAttachmentFileSource({
             item,
-            maxFileSizeMB: 10,
             localSizeStrategy: 'zotero-total',
         });
 
@@ -74,7 +80,6 @@ describe('attachmentSource', () => {
 
         const result = await resolveAttachmentFileSource({
             item,
-            maxFileSizeMB: 10,
             localSizeStrategy: 'stat',
         });
 
@@ -92,7 +97,6 @@ describe('attachmentSource', () => {
 
         const result = await resolveAttachmentFileSource({
             item,
-            maxFileSizeMB: 10,
             localSizeStrategy: 'stat',
         });
 
@@ -113,7 +117,6 @@ describe('attachmentSource', () => {
 
         const source = await resolveAttachmentFileSource({
             item,
-            maxFileSizeMB: 10,
             localSizeStrategy: 'stat',
         });
         expect(source.kind).toBe('ok');
@@ -122,7 +125,6 @@ describe('attachmentSource', () => {
         const data = await loadAttachmentData({
             item,
             source: source.source,
-            maxFileSizeMB: 10,
         });
 
         expect(data).toEqual({ kind: 'ok', data: new Uint8Array([4, 5, 6]) });
@@ -136,7 +138,6 @@ describe('attachmentSource', () => {
         Zotero.Attachments.getTotalFileSize = vi.fn().mockResolvedValue(11 * 1024 * 1024);
         const local = await resolveAttachmentFileSource({
             item: makeAttachment(),
-            maxFileSizeMB: 10,
             localSizeStrategy: 'zotero-total',
         });
         expect(local).toMatchObject({ kind: 'error', code: 'file_too_large' });
@@ -149,15 +150,14 @@ describe('attachmentSource', () => {
         mockGetAttachmentDataInMemory.mockResolvedValue(new Uint8Array(2 * 1024 * 1024));
         const remoteSource = await resolveAttachmentFileSource({
             item: remoteItem,
-            maxFileSizeMB: 10,
             localSizeStrategy: 'stat',
         });
         if (remoteSource.kind !== 'ok') throw new Error('remote source should resolve');
 
+        maxFileSizeMBPref = 1;
         const remote = await loadAttachmentData({
             item: remoteItem,
             source: remoteSource.source,
-            maxFileSizeMB: 1,
         });
         expect(remote).toMatchObject({ kind: 'error', code: 'file_too_large' });
     });
@@ -170,10 +170,63 @@ describe('attachmentSource', () => {
         const loaded = await loadPdfData(item, 'remote:k:1-REMOTE05-v1', true);
 
         expect(loaded).toBe(bytes);
-        expect(checkRemotePdfSize(loaded, false, 1)).toMatchObject({
+        maxFileSizeMBPref = 1;
+        expect(checkRemotePdfSize(loaded, false)).toMatchObject({
             sizeMB: 2,
             maxMB: 1,
         });
+    });
+
+    // Only `.length` is read on the downloaded bytes, so stub the size rather
+    // than allocating hundreds of megabytes per case.
+    function fakeBytes(sizeMB: number): Uint8Array {
+        return { length: sizeMB * 1024 * 1024 } as unknown as Uint8Array;
+    }
+
+    async function remoteSourceFor(key: string) {
+        const item = makeAttachment({ key, getFilePathAsync: vi.fn().mockResolvedValue(null) });
+        mockIsAttachmentAvailableRemotely.mockReturnValue(true);
+        const source = await resolveAttachmentFileSource({ item, localSizeStrategy: 'stat' });
+        if (source.kind !== 'ok') throw new Error('remote source should resolve');
+        return { item, source: source.source };
+    }
+
+    it('caches a remote download too large for the default ceiling', async () => {
+        maxFileSizeMBPref = 300;
+        mockGetAttachmentDataInMemory.mockResolvedValue(fakeBytes(150));
+        const { item, source } = await remoteSourceFor('REMOTE06');
+
+        expect(await loadAttachmentData({ item, source })).toMatchObject({ kind: 'ok' });
+        expect(await loadAttachmentData({ item, source })).toMatchObject({ kind: 'ok' });
+
+        expect(mockGetAttachmentDataInMemory).toHaveBeenCalledTimes(1);
+    });
+
+    it('declines to cache a remote download the ceiling rejects', async () => {
+        mockGetAttachmentDataInMemory.mockResolvedValue(fakeBytes(150));
+        const { item, source } = await remoteSourceFor('REMOTE08');
+
+        expect(await loadAttachmentData({ item, source })).toMatchObject({
+            kind: 'error',
+            code: 'file_too_large',
+        });
+        expect(await loadAttachmentData({ item, source })).toMatchObject({
+            kind: 'error',
+            code: 'file_too_large',
+        });
+
+        expect(mockGetAttachmentDataInMemory).toHaveBeenCalledTimes(2);
+    });
+
+    it('declines to cache a remote download larger than the whole cache budget', async () => {
+        maxFileSizeMBPref = 4000;
+        mockGetAttachmentDataInMemory.mockResolvedValue(fakeBytes(1200));
+        const { item, source } = await remoteSourceFor('REMOTE07');
+
+        expect(await loadAttachmentData({ item, source })).toMatchObject({ kind: 'ok' });
+        expect(await loadAttachmentData({ item, source })).toMatchObject({ kind: 'ok' });
+
+        expect(mockGetAttachmentDataInMemory).toHaveBeenCalledTimes(2);
     });
 
     it('returns read_failed and download_failed for expected read failures', async () => {
@@ -181,7 +234,6 @@ describe('attachmentSource', () => {
         const local = await loadAttachmentData({
             item: makeAttachment(),
             source: { kind: 'local', filePath: '/storage/test.txt', isRemoteOnly: false },
-            maxFileSizeMB: 10,
         });
         expect(local).toMatchObject({ kind: 'error', code: 'read_failed' });
 
@@ -189,7 +241,6 @@ describe('attachmentSource', () => {
         const remote = await loadAttachmentData({
             item: makeAttachment({ key: 'REMOTE03' }),
             source: { kind: 'remote', filePath: 'remote:k:1-REMOTE03-v1', isRemoteOnly: true },
-            maxFileSizeMB: 10,
         });
         expect(remote).toMatchObject({ kind: 'error', code: 'download_failed' });
     });
@@ -200,7 +251,6 @@ describe('attachmentSource', () => {
             const pathTimeout = createTimeoutController(1, 10);
             const pathPromise = resolveAttachmentFileSource({
                 item: makeAttachment({ getFilePathAsync: vi.fn(() => new Promise(() => {})) }),
-                maxFileSizeMB: 10,
                 localSizeStrategy: 'stat',
                 signal: pathTimeout.signal,
                 throwIfTimedOut: pathTimeout.throwIfTimedOut,
@@ -214,7 +264,6 @@ describe('attachmentSource', () => {
             (globalThis as any).IOUtils.stat.mockImplementation(() => new Promise(() => {}));
             const sizePromise = resolveAttachmentFileSource({
                 item: makeAttachment({ getFilePathAsync: vi.fn().mockResolvedValue('/storage/test.txt') }),
-                maxFileSizeMB: 10,
                 localSizeStrategy: 'stat',
                 signal: sizeTimeout.signal,
                 throwIfTimedOut: sizeTimeout.throwIfTimedOut,
@@ -229,7 +278,6 @@ describe('attachmentSource', () => {
             const readPromise = loadAttachmentData({
                 item: makeAttachment(),
                 source: { kind: 'local', filePath: '/storage/test.txt', isRemoteOnly: false },
-                maxFileSizeMB: 10,
                 signal: readTimeout.signal,
                 throwIfTimedOut: readTimeout.throwIfTimedOut,
             });
@@ -243,7 +291,6 @@ describe('attachmentSource', () => {
             const remotePromise = loadAttachmentData({
                 item: makeAttachment({ key: 'REMOTE04' }),
                 source: { kind: 'remote', filePath: 'remote:k:1-REMOTE04-v1', isRemoteOnly: true },
-                maxFileSizeMB: 10,
                 signal: remoteTimeout.signal,
                 throwIfTimedOut: remoteTimeout.throwIfTimedOut,
             });

--- a/tests/unit/services/backgroundExtractor.test.ts
+++ b/tests/unit/services/backgroundExtractor.test.ts
@@ -60,7 +60,6 @@ function payload(overrides: Partial<BackgroundJobPayload> = {}): BackgroundJobPa
     return {
         content_kind: 'pdf',
         maxPages: 200,
-        maxFileSizeMB: 50,
         timeoutSeconds: 120,
         ...overrides,
     };

--- a/tests/unit/services/backgroundJobPayloads.test.ts
+++ b/tests/unit/services/backgroundJobPayloads.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBackgroundJobPayload } from '../../../src/services/documentExtraction/shared/backgroundJobPayloads';
+
+describe('parseBackgroundJobPayload', () => {
+    it('accepts a PDF payload', () => {
+        expect(
+            parseBackgroundJobPayload(
+                'pdf',
+                JSON.stringify({ content_kind: 'pdf', maxPages: 7, timeoutSeconds: 180 }),
+            ),
+        ).toEqual({ content_kind: 'pdf', maxPages: 7, timeoutSeconds: 180 });
+    });
+
+    it('accepts a queued PDF payload that still carries a file-size limit', () => {
+        // The file-size ceiling is now read from a preference, so it is no
+        // longer part of the payload — but rows enqueued before that must keep
+        // draining rather than being rejected as malformed.
+        const legacy = {
+            content_kind: 'pdf',
+            maxPages: null,
+            maxFileSizeMB: 25,
+            timeoutSeconds: 180,
+        };
+
+        expect(parseBackgroundJobPayload('pdf', JSON.stringify(legacy))).toMatchObject({
+            content_kind: 'pdf',
+            maxPages: null,
+            timeoutSeconds: 180,
+        });
+    });
+
+    it('rejects a PDF payload whose remaining bounds are missing or wrongly typed', () => {
+        expect(
+            parseBackgroundJobPayload('pdf', JSON.stringify({ content_kind: 'pdf', maxPages: null })),
+        ).toBeNull();
+        expect(
+            parseBackgroundJobPayload(
+                'pdf',
+                JSON.stringify({ content_kind: 'pdf', maxPages: 'all', timeoutSeconds: 180 }),
+            ),
+        ).toBeNull();
+    });
+
+    it('rejects a payload whose discriminator disagrees with the column kind', () => {
+        expect(parseBackgroundJobPayload('pdf', JSON.stringify({ content_kind: 'epub' }))).toBeNull();
+    });
+
+    it('rejects an absent, unknown, or unparseable payload', () => {
+        expect(parseBackgroundJobPayload('pdf', null)).toBeNull();
+        expect(parseBackgroundJobPayload(null, JSON.stringify({ content_kind: 'pdf' }))).toBeNull();
+        expect(parseBackgroundJobPayload('mystery', JSON.stringify({ content_kind: 'mystery' }))).toBeNull();
+        expect(parseBackgroundJobPayload('pdf', 'not json')).toBeNull();
+    });
+
+    it('passes through the payload kinds that carry no bounds', () => {
+        expect(parseBackgroundJobPayload('epub', JSON.stringify({ content_kind: 'epub' }))).toEqual({
+            content_kind: 'epub',
+        });
+        expect(parseBackgroundJobPayload('snapshot', JSON.stringify({ content_kind: 'snapshot' }))).toEqual({
+            content_kind: 'snapshot',
+        });
+        expect(parseBackgroundJobPayload('text', JSON.stringify({ content_kind: 'text' }))).toEqual({
+            content_kind: 'text',
+        });
+    });
+});

--- a/tests/unit/services/backgroundQueue.test.ts
+++ b/tests/unit/services/backgroundQueue.test.ts
@@ -24,7 +24,6 @@ function makePayload(overrides: Partial<BackgroundJobPayload> = {}): BackgroundJ
     return {
         content_kind: 'pdf',
         maxPages: 200,
-        maxFileSizeMB: 50,
         timeoutSeconds: 120,
         ...overrides,
     };

--- a/tests/unit/services/documentExtractionCore.sharedBudget.test.ts
+++ b/tests/unit/services/documentExtractionCore.sharedBudget.test.ts
@@ -93,7 +93,6 @@ const runPdf = (overrides: Partial<ExtractAndCacheResolvedPdfArgs> = {}) =>
         contentType: 'application/pdf',
         mode: 'structured',
         maxPages: null,
-        maxFileSizeMB: 0,
         timeoutSeconds: 60,
         workerName: 'hot',
         ...overrides,

--- a/tests/unit/services/documentExtractionCore.timeout.test.ts
+++ b/tests/unit/services/documentExtractionCore.timeout.test.ts
@@ -69,7 +69,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             zoteroKey: 'ABCD1234',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 0,
             timeoutSeconds: 0.01,
             workerName: 'background',
         });
@@ -100,7 +99,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             zoteroKey: 'ABCD1234',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 0,
             timeoutSeconds: 60,
             workerName: 'background',
             externalAbortSignal: external.signal,
@@ -136,7 +134,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 10,
             timeoutSeconds: 40,
             workerName: 'hot',
         });
@@ -179,7 +176,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 10,
             timeoutSeconds: 40,
             workerName: 'hot',
             externalAbortSignal: external.signal,
@@ -219,7 +215,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 10,
             timeoutSeconds: 40,
             workerName: 'hot',
             externalAbortSignal: external.signal,
@@ -272,7 +267,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 10,
             timeoutSeconds: 1,
             workerName: 'hot',
         });
@@ -326,7 +320,6 @@ describe('extractAndCacheDocument timeout handling', () => {
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 10,
             timeoutSeconds: 1,
             workerName: 'hot',
         });

--- a/tests/unit/services/documentExtractionCore.workerUnavailable.test.ts
+++ b/tests/unit/services/documentExtractionCore.workerUnavailable.test.ts
@@ -107,7 +107,6 @@ describe('extractAndCacheResolvedPdfDocument worker-lifecycle classification', (
             contentType: 'application/pdf',
             mode: 'structured',
             maxPages: null,
-            maxFileSizeMB: 0,
             timeoutSeconds: 60,
             workerName: 'hot',
         });

--- a/tests/unit/services/epubExtractor.test.ts
+++ b/tests/unit/services/epubExtractor.test.ts
@@ -15,6 +15,13 @@ import {
     extractEpubDocumentFromFile,
     extractEpubDocumentSafe,
 } from "../../../src/services/documentExtraction/epub";
+// The file-size ceiling is read through the platform runtime adapter, which the
+// running plugin installs at bundle load. This suite mocks away
+// `attachmentSource`, the module that would otherwise pull it in, so install it
+// here to make `Zotero.Prefs` the source of the ceiling.
+import { registerZoteroRuntime } from "../../../src/platform/zoteroRuntime";
+
+registerZoteroRuntime();
 
 function parseXhtml(markup: string): Document {
     return new DOMParser().parseFromString(
@@ -314,6 +321,7 @@ describe("extractEpubDocumentSafe", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         (globalThis as any).Zotero.Promise = { delay: vi.fn().mockResolvedValue(undefined) };
+        (globalThis as any).Zotero.Prefs.get = vi.fn().mockReturnValue(undefined);
         isRemoteAccessAvailableMock.mockReturnValue(false);
         (globalThis as any).IOUtils.stat.mockResolvedValue({ lastModified: 0, size: 1024 });
     });
@@ -416,11 +424,15 @@ describe("extractEpubDocumentSafe", () => {
             lastModified: 0,
             size: 2 * 1024 * 1024,
         });
+        // The ceiling comes from the preference, not a per-call argument.
+        Zotero.Prefs.get = vi.fn((key: string) =>
+            key.endsWith(".maxAttachmentFileSizeMB") ? 1 : undefined,
+        ) as any;
 
         const result = await extractEpubDocumentSafe({
             isEPUBAttachment: () => true,
             getFilePathAsync: vi.fn().mockResolvedValue("/tmp/book.epub"),
-        } as any, { maxFileSizeMB: 1 });
+        } as any);
 
         expect(result).toMatchObject({
             kind: "response_error",

--- a/tests/unit/services/snapshotMemory.test.ts
+++ b/tests/unit/services/snapshotMemory.test.ts
@@ -3,10 +3,6 @@
 import { describe, expect, it } from "vitest";
 import { measureSectionSourceText } from "../../../src/services/documentExtraction/dom/diagnostics";
 import { visibleTextContent } from "../../../src/services/documentExtraction/dom/domWalk";
-import {
-    SNAPSHOT_HARD_MAX_FILE_SIZE_MB,
-    effectiveMaxSnapshotFileSizeMB,
-} from "@beaver/agent-core/transport/attachmentLimits";
 
 function docWith(bodyHtml: string): Document {
     const doc = globalThis.document.implementation.createHTMLDocument("");
@@ -33,16 +29,5 @@ describe("measureSectionSourceText — non-cloning coverage measurement", () => 
     it("excludes script/style text from the count", () => {
         const doc = docWith("<p>ab</p><script>ignored_script_text()</script>");
         expect(measureSectionSourceText(doc)).toBe(2); // only "ab"
-    });
-});
-
-describe("effectiveMaxSnapshotFileSizeMB", () => {
-    it("bounds the general cap by the snapshot-specific hard limit", () => {
-        // Unset / zero / over-cap requests fall back to the snapshot hard limit.
-        expect(effectiveMaxSnapshotFileSizeMB(null)).toBe(SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
-        expect(effectiveMaxSnapshotFileSizeMB(0)).toBe(SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
-        expect(effectiveMaxSnapshotFileSizeMB(100)).toBe(SNAPSHOT_HARD_MAX_FILE_SIZE_MB);
-        // A smaller request is honored.
-        expect(effectiveMaxSnapshotFileSizeMB(20)).toBe(20);
     });
 });

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -79,6 +79,7 @@ declare namespace _ZoteroTypes {
       "librarySuggestions": string;
       "librarySuggestionsGeneratedAt": string;
       "firstRunAssignments": string;
+      "maxAttachmentFileSizeMB": number;
     };
   }
 }


### PR DESCRIPTION
…pdate related logic

Added a new preference for the maximum attachment file size (in MB) that Beaver will read for various operations, including document extraction and rendering. Updated the RuntimeAdapter to support retrieving this preference, and modified relevant functions across the codebase to utilize the new preference instead of hardcoded values. Removed deprecated parameters and ensured consistent handling of file size limits in document processing and extraction functions.