### PR TITLE
feat(agent-core): update population request structure for collections…

### DIFF
--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -1417,12 +1417,15 @@ export interface WSResolvePopulationRequest extends WSBaseEvent {
     request_id: string;
     /** Library id or name. Null/absent = the user's default library. */
     library_id?: number | string | null;
-    /** Bare collection key (never library-qualified); the backend down-converts. */
-    collection_key?: string | null;
-    /** Include items from subcollections when scoped to a collection. */
+    /**
+     * Bare collection keys (never library-qualified); the backend
+     * down-converts. ORed: an item matches when it is in ANY of them.
+     */
+    collection_keys?: string[] | null;
+    /** Include items from subcollections of every scoped collection. */
     recursive: boolean;
-    /** Exact tag the items must carry. */
-    tag?: string | null;
+    /** Exact tag names. ORed: an item matches when it carries ANY of them. */
+    tags?: string[] | null;
     /** Only items that belong to no collection. */
     unfiled: boolean;
     /** Only items that carry no tags. */
@@ -1455,13 +1458,18 @@ export interface WSResolvePopulationResponse {
     /** True when total_count exceeded max_items and item_ids was cut short. */
     truncated: boolean;
     /**
-     * Display names of the library and collection the filters resolved
+     * Display names of the library and collections the filters resolved
      * against. The approval card names the population's location from these
      * and says nothing about it when they are absent, so omitting them costs
      * the user the WHERE half of what they are approving.
+     *
+     * `collection_names` is in the order `collection_keys` named them, and is
+     * answered in full or not at all — the card cannot state the place from a
+     * partial list, because the collections it skipped are part of the
+     * population too.
      */
     library_name?: string | null;
-    collection_name?: string | null;
+    collection_names?: string[] | null;
     error?: string | null;
     error_code?: string | null;
     /** Available libraries (only included when error_code is 'library_not_found') */

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -661,9 +661,9 @@ async function handleResolvePopulationHttpRequest(request: any) {
         event: 'resolve_population_request',
         request_id: generateRequestId(),
         library_id: request.library_id,
-        collection_key: request.collection_key ?? null,
+        collection_keys: request.collection_keys ?? [],
         recursive: request.recursive ?? true,
-        tag: request.tag ?? null,
+        tags: request.tags ?? [],
         unfiled: request.unfiled ?? false,
         untagged: request.untagged ?? false,
         conditions: request.conditions || [],
@@ -678,6 +678,11 @@ async function handleResolvePopulationHttpRequest(request: any) {
         item_ids: response.item_ids,
         total_count: response.total_count,
         truncated: response.truncated,
+        // The place the population lives, which the approval card states from
+        // these alone — the WebSocket transport forwards them, so this one has
+        // to as well or a localhost run loses the WHERE half of the card.
+        library_name: response.library_name,
+        collection_names: response.collection_names,
         // A dropped condition widens the population; the caller must not act on
         // ids that came back with a warning.
         warnings: response.warnings,

--- a/src/services/agentDataProvider/handleResolvePopulationRequest.ts
+++ b/src/services/agentDataProvider/handleResolvePopulationRequest.ts
@@ -7,6 +7,14 @@
  * handler must never load or serialize items (that is what made the old
  * `list_items` paging loop cost O(library)), and the order it returns must be
  * deterministic.
+ *
+ * Filters are ANDed, except that `collection_keys` and `tags` are each an
+ * OR-group inside that AND: the population is the items in ANY of the
+ * collections that also carry ANY of the tags. An OR-group is expressed as a
+ * scope search (see `orGroupScope`) rather than as conditions on the main
+ * search, because Zotero's join mode is per-search — flipping the main search
+ * to 'any' would turn its item-type guards into always-true disjuncts and
+ * select the whole library.
  */
 
 import { logger } from '@beaver/agent-core/platform/logger';
@@ -137,8 +145,39 @@ function errorResponse(
 }
 
 /**
+ * A search matching the union of `values` under one condition name.
+ *
+ * `joinMode any` is safe here and nowhere else in this handler: the scope
+ * search carries nothing but this one group, so there is no ANDed guard for
+ * the OR to swallow. The caller intersects it into the population with
+ * `setScope`, which is what keeps the group ANDed with everything else.
+ *
+ * Returns null for an empty group — an unscoped search matches the whole
+ * library, so attaching one would widen the population instead of narrowing
+ * it.
+ */
+function orGroupScope(
+    libraryID: number,
+    condition: 'collection' | 'tag',
+    values: string[],
+): Zotero.Search | null {
+    if (values.length === 0) return null;
+
+    // Returned as `Zotero.Search`, not `ZoteroSearchWritable`: `setScope`
+    // takes the former, and checking the interface against it trips TS2589
+    // ("type instantiation is excessively deep") at the call site.
+    const scope = new Zotero.Search() as unknown as ZoteroSearchWritable;
+    scope.libraryID = libraryID;
+    scope.addCondition('joinMode', 'any', '');
+    for (const value of values) {
+        scope.addCondition(condition, 'is', value);
+    }
+    return scope as unknown as Zotero.Search;
+}
+
+/**
  * Handle resolve_population request from backend.
- * Runs one native Zotero search with every filter ANDed and returns ids only.
+ * Runs one native Zotero search with every filter group ANDed and returns ids only.
  */
 export async function handleResolvePopulationRequest(
     request: WSResolvePopulationRequest
@@ -173,67 +212,71 @@ export async function handleResolvePopulationRequest(
                 'invalid_request',
             );
         }
-        if (request.tag === '') {
+        const requestedTags = request.tags ?? [];
+        const requestedCollectionKeys = request.collection_keys ?? [];
+        if (requestedTags.some((tag) => !tag)) {
             return errorResponse(
                 request.request_id,
-                'tag was empty. Pass an exact tag name, or use untagged=true to select items with no tags.',
+                'tags contained an empty entry. Pass exact tag names, or use untagged=true to select items with no tags.',
                 'invalid_request',
             );
         }
-        if (request.collection_key === '') {
+        if (requestedCollectionKeys.some((key) => !key)) {
             return errorResponse(
                 request.request_id,
-                'collection_key was empty. Pass a collection key from list_collections, or omit it.',
+                'collection_keys contained an empty entry. Pass collection keys from list_collections, or omit the filter.',
                 'invalid_request',
             );
         }
 
-        // Resolve the collection scope. The wire always carries a BARE key;
-        // the backend has already down-converted a library-qualified one.
-        // The name is kept alongside the id: it is the only thing that turns
-        // the key back into something the approval card can show the user.
-        let collectionId: number | null = null;
-        let collectionName: string | null = null;
-        if (request.collection_key) {
-            const collection = Zotero.Collections.getByLibraryAndKey(library.libraryID, request.collection_key);
+        // Resolve the collection scope. The wire always carries BARE keys; the
+        // backend has already down-converted library-qualified ones. The names
+        // are kept alongside: they are the only thing that turns the keys back
+        // into something the approval card can show the user, and they are
+        // returned in the order the request named them.
+        //
+        // A key the library does not have fails the whole request. Zotero's
+        // own answer for an unknown collection is to match nothing, which the
+        // backend would read as "these filters select no items" and hand the
+        // model as a reason to change the filters rather than fix the key.
+        const collectionNames: string[] = [];
+        for (const key of requestedCollectionKeys) {
+            const collection = Zotero.Collections.getByLibraryAndKey(library.libraryID, key);
             if (!collection) {
                 return errorResponse(
                     request.request_id,
-                    `Collection not found: "${request.collection_key}" in library "${library.name}". `
+                    `Collection not found: "${key}" in library "${library.name}". `
                         + 'Use list_collections to get the collection key.',
                     'collection_not_found',
                 );
             }
-            collectionId = collection.id;
-            collectionName = collection.name;
+            collectionNames.push(collection.name);
         }
 
         // Warnings are surfaced to the backend so the agent can correct bad
         // conditions rather than mutate a silently-widened population.
         const warnings: string[] = [];
 
-        // One search, join mode 'all' — never add a `joinMode` condition. With
-        // 'any', the itemType conditions below become an always-true disjunct
-        // and the population becomes the whole library.
+        // Resolve every tag to the casing the library stores; unknown tags
+        // error instead of matching nothing, for the same reason as an unknown
+        // collection key.
+        const resolvedTags: string[] = [];
+        for (const tag of requestedTags) {
+            const resolved = await resolveStoredTagName(library.libraryID, library.name, tag);
+            if (!resolved.found) {
+                return errorResponse(request.request_id, resolved.error, 'tag_not_found');
+            }
+            resolvedTags.push(resolved.name);
+        }
+
+        // The main search, join mode 'all' — never add a `joinMode` condition
+        // here. With 'any', the itemType conditions below become an
+        // always-true disjunct and the population becomes the whole library.
+        // The OR-groups live in their own scope searches instead.
         const search = new Zotero.Search() as unknown as ZoteroSearchWritable;
         search.libraryID = library.libraryID;
 
-        if (collectionId !== null) {
-            search.addCondition('collectionID', 'is', String(collectionId));
-            // `recursive` only affects collection conditions.
-            if (request.recursive !== false) {
-                search.addCondition('recursive', 'true', '');
-            }
-        }
-
-        if (request.tag) {
-            // Resolve to stored casing; unknown tags error instead of matching nothing.
-            const resolvedTag = await resolveStoredTagName(library.libraryID, library.name, request.tag);
-            if (!resolvedTag.found) {
-                return errorResponse(request.request_id, resolvedTag.error, 'tag_not_found');
-            }
-            search.addCondition('tag', 'is', resolvedTag.name);
-        }
+        const recursive = request.recursive !== false;
 
         // Both predicates are native Zotero conditions; emulating them in the
         // backend is what this request exists to avoid.
@@ -246,6 +289,33 @@ export async function handleResolvePopulationRequest(
 
         for (const condition of request.conditions ?? []) {
             addSearchCondition(search, condition, warnings, 'handleResolvePopulationRequest');
+        }
+
+        // `recursive` only affects collection conditions, so this is a no-op
+        // unless one was given as a condition — and it must be added for those
+        // too, or a `collection` condition would match direct membership only
+        // while `collection_keys` recursed. Mirrors handleZoteroSearchRequest.
+        if (recursive) {
+            search.addCondition('recursive', 'true', '');
+        }
+
+        // The two OR-groups. A search carries ONE scope, and scopes must not be
+        // nested: Zotero 7 materializes an outer scope from `getSQL()`, which
+        // ignores that scope's own `_scope`, so the inner group is silently
+        // dropped — and a dropped group WIDENS the population to every item the
+        // outer group matched. (Zotero 10 added a branch that runs a nested
+        // scope properly, which is exactly why the bug is invisible there.) So
+        // one group becomes the scope and the other is intersected below.
+        const collectionScope = orGroupScope(library.libraryID, 'collection', requestedCollectionKeys);
+        if (collectionScope && recursive) {
+            // `recursive` is special, not a disjunct, so it stays ANDed even
+            // under joinMode 'any' — it applies to every collection in the group.
+            collectionScope.addCondition('recursive', 'true', '');
+        }
+        const tagScope = orGroupScope(library.libraryID, 'tag', resolvedTags);
+        const scope = collectionScope ?? tagScope;
+        if (scope) {
+            search.setScope(scope, true);
         }
 
         // Every filter above describes a bibliographic item, so the search
@@ -261,6 +331,16 @@ export async function handleResolvePopulationRequest(
         search.addCondition('noChildren', 'true', '');
 
         let itemIds = await search.search();
+
+        // The group that did not become the scope, intersected here. Running it
+        // as its own search costs one ids-only query and is what makes the two
+        // groups independent of how a given Zotero version materializes a
+        // nested scope. Intersecting can only narrow, which is the safe
+        // direction for a population about to be mutated.
+        if (collectionScope && tagScope && itemIds.length > 0) {
+            const tagged = new Set(await tagScope.search());
+            itemIds = itemIds.filter(id => tagged.has(id));
+        }
 
         // has_attachments, in SQL. This is the only filter that could
         // reintroduce an O(population) item load, so it must never become a
@@ -304,7 +384,7 @@ export async function handleResolvePopulationRequest(
                 total_count: totalCount,
                 truncated: totalCount > 0,
                 library_name: library.name,
-                collection_name: collectionName,
+                collection_names: collectionNames,
                 warnings: warnings.length ? warnings : undefined,
             };
         }
@@ -338,7 +418,7 @@ export async function handleResolvePopulationRequest(
             // Where the population lives, in the names the user gave those
             // places. The approval card states the location from these alone.
             library_name: library.name,
-            collection_name: collectionName,
+            collection_names: collectionNames,
             warnings: warnings.length ? warnings : undefined,
         };
     } catch (error) {

--- a/tests/unit/handlers/resolvePopulation.test.ts
+++ b/tests/unit/handlers/resolvePopulation.test.ts
@@ -25,6 +25,9 @@ type MockSearchInstance = {
     libraryID: number;
     addCondition: ReturnType<typeof vi.fn>;
     search: ReturnType<typeof vi.fn>;
+    setScope: ReturnType<typeof vi.fn>;
+    /** The search this one was scoped to, if any. */
+    scope: MockSearchInstance | null;
 };
 
 const LIBRARY_ID = 1;
@@ -36,6 +39,12 @@ describe('handleResolvePopulationRequest', () => {
     const attachmentsByParent = new Map<number, number[]>();
     /** What the native search resolves to. */
     let searchResultIds: number[] = [];
+    /**
+     * What a SCOPE search resolves to, when the handler runs one itself. Null
+     * means "same as the main search", which is what every test that does not
+     * care about the second OR-group wants.
+     */
+    let scopeSearchResultIds: number[] | null = null;
     /** Tags that exist in the library; an unknown tag is reported, not silently empty. */
     let libraryTags: string[] = [];
     /** Every Zotero.Search the handler constructed, in construction order. */
@@ -48,6 +57,43 @@ describe('handleResolvePopulationRequest', () => {
     /** Conditions handed to the primary search, as [field, operator, value]. */
     const addedConditions = () =>
         (mainSearch()?.addCondition.mock.calls ?? []).map(call => call.slice(0, 3));
+
+    /** Conditions on one search, as [field, operator, value]. */
+    const conditionsOn = (search: MockSearchInstance | null) =>
+        (search?.addCondition.mock.calls ?? []).map(call => call.slice(0, 3));
+
+    /**
+     * The OR-group scope searches the main search was given, outermost first.
+     * The handler chains them, so this walks the chain rather than assuming a
+     * construction order.
+     */
+    const scopeChain = (): MockSearchInstance[] => {
+        const chain: MockSearchInstance[] = [];
+        let current = mainSearch()?.scope ?? null;
+        while (current) {
+            chain.push(current);
+            current = current.scope;
+        }
+        return chain;
+    };
+
+    /**
+     * Every OR-group search the handler built. Not the same as `scopeChain()`:
+     * only one group is ever attached as a scope, and the other is run on its
+     * own and intersected.
+     */
+    const orGroupSearches = () => searches.slice(1);
+
+    /** The OR-group search over `field`, if one exists. */
+    const scopeFor = (field: 'collection' | 'tag') =>
+        orGroupSearches().find(search =>
+            conditionsOn(search).some(([name]) => name === field)) ?? null;
+
+    /** The values of the `field is <value>` disjuncts in that group. */
+    const orGroupValues = (field: 'collection' | 'tag') =>
+        conditionsOn(scopeFor(field))
+            .filter(([name, operator]) => name === field && operator === 'is')
+            .map(([, , value]) => value);
 
     /** All Zotero.DB.queryAsync calls as [sql, params] pairs. */
     const dbCalls = (): [string, any[]][] =>
@@ -96,6 +142,7 @@ describe('handleResolvePopulationRequest', () => {
         attachmentsByParent.clear();
         collections.clear();
         searchResultIds = [];
+        scopeSearchResultIds = null;
         searches = [];
         libraryTags = ['to-read', 'reviewed'];
 
@@ -117,7 +164,16 @@ describe('handleResolvePopulationRequest', () => {
         (globalThis as any).Zotero.Search = class MockSearch {
             libraryID = 0;
             addCondition = vi.fn();
-            search = vi.fn(async () => searchResultIds);
+            // searches[0] is the main search; anything later is a scope
+            // search the handler built and may run on its own.
+            search = vi.fn(async () =>
+                (searches[0] as unknown) === this || scopeSearchResultIds === null
+                    ? searchResultIds
+                    : scopeSearchResultIds);
+            scope: MockSearchInstance | null = null;
+            setScope = vi.fn((scope: MockSearchInstance) => {
+                this.scope = scope;
+            });
             constructor() {
                 searches.push(this as unknown as MockSearchInstance);
             }
@@ -198,31 +254,30 @@ describe('handleResolvePopulationRequest', () => {
             expect(addedConditions()).toContainEqual(['tag', 'doesNotContain', '']);
         });
 
-        it('adds an exact tag condition and a recursive collection scope', async () => {
+        it('scopes the population to a tag and to a recursive collection', async () => {
             searchResultIds = [1];
             seedItem(1);
             collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
 
             await handleResolvePopulationRequest(makeRequest({
-                tag: 'to-read',
-                collection_key: 'ABCD2345',
+                tags: ['to-read'],
+                collection_keys: ['ABCD2345'],
                 recursive: true,
             }));
 
-            expect(addedConditions()).toContainEqual(['tag', 'is', 'to-read']);
-            expect(addedConditions()).toContainEqual(['collectionID', 'is', '77']);
-            expect(addedConditions()).toContainEqual(['recursive', 'true', '']);
+            expect(orGroupValues('tag')).toEqual(['to-read']);
+            expect(orGroupValues('collection')).toEqual(['ABCD2345']);
+            expect(conditionsOn(scopeFor('collection'))).toContainEqual(['recursive', 'true', '']);
         });
 
         it('searches the casing the library stores, not the one the caller sent', async () => {
             searchResultIds = [1];
             seedItem(1);
 
-            const response = await handleResolvePopulationRequest(makeRequest({ tag: 'TO-READ' }));
+            const response = await handleResolvePopulationRequest(makeRequest({ tags: ['TO-READ'] }));
 
             expect(response.error).toBeUndefined();
-            expect(addedConditions()).toContainEqual(['tag', 'is', 'to-read']);
-            expect(addedConditions()).not.toContainEqual(['tag', 'is', 'TO-READ']);
+            expect(orGroupValues('tag')).toEqual(['to-read']);
         });
 
         it('omits the recursive condition when recursive is false', async () => {
@@ -231,22 +286,37 @@ describe('handleResolvePopulationRequest', () => {
             collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
 
             await handleResolvePopulationRequest(makeRequest({
-                collection_key: 'ABCD2345',
+                collection_keys: ['ABCD2345'],
                 recursive: false,
             }));
 
-            expect(addedConditions()).toContainEqual(['collectionID', 'is', '77']);
+            expect(orGroupValues('collection')).toEqual(['ABCD2345']);
+            expect(conditionsOn(scopeFor('collection')).some(([field]) => field === 'recursive')).toBe(false);
             expect(addedConditions().some(([field]) => field === 'recursive')).toBe(false);
         });
 
-        it('never sets a join mode, so every filter stays ANDed', async () => {
+        it('recurses a collection condition given through the condition grammar', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+
+            await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'collection', operator: 'is', value: 'ABCD2345' }],
+                recursive: true,
+            }));
+
+            // Without this the condition form would match direct membership
+            // only while `collection_keys` recursed.
+            expect(addedConditions()).toContainEqual(['recursive', 'true', '']);
+        });
+
+        it('never sets a join mode on the main search, so every filter group stays ANDed', async () => {
             searchResultIds = [1];
             seedItem(1);
 
             await handleResolvePopulationRequest(makeRequest({
                 unfiled: true,
                 untagged: true,
-                tag: 'to-read',
+                tags: ['to-read'],
                 conditions: [{ field: 'DOI', operator: 'is', value: '' }],
             }));
 
@@ -254,28 +324,158 @@ describe('handleResolvePopulationRequest', () => {
         });
     });
 
+    describe('OR-groups', () => {
+        it('ORs several collections in a scope search rather than ANDing them', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+            collections.set(`${LIBRARY_ID}/EFGH6789`, { id: 78, name: 'Theory' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['ABCD2345', 'EFGH6789'],
+            }));
+
+            expect(response.error).toBeUndefined();
+            // ANDed collection conditions select their intersection, which for
+            // two collections is almost always nothing.
+            expect(addedConditions().some(([field]) => field === 'collection')).toBe(false);
+            expect(orGroupValues('collection')).toEqual(['ABCD2345', 'EFGH6789']);
+            expect(conditionsOn(scopeFor('collection'))).toContainEqual(['joinMode', 'any', '']);
+        });
+
+        it('ORs several tags in a scope search rather than ANDing them', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+            libraryTags = ['ml', 'machine-learning'];
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                tags: ['ml', 'machine-learning'],
+            }));
+
+            expect(response.error).toBeUndefined();
+            expect(orGroupValues('tag')).toEqual(['ml', 'machine-learning']);
+            expect(conditionsOn(scopeFor('tag'))).toContainEqual(['joinMode', 'any', '']);
+        });
+
+        it('never nests one group inside the other', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+            collections.set(`${LIBRARY_ID}/EFGH6789`, { id: 78, name: 'Theory' });
+
+            await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['ABCD2345', 'EFGH6789'],
+                tags: ['to-read', 'reviewed'],
+            }));
+
+            // Zotero 7 materializes an outer scope from getSQL(), which ignores
+            // that scope's own scope — a nested group is silently dropped, and
+            // a dropped group widens the population to everything the outer one
+            // matched. Only Zotero 10 runs a nested scope properly, so nesting
+            // would make the population depend on the Zotero version.
+            expect(scopeChain()).toHaveLength(1);
+        });
+
+        it('intersects the group that did not become the scope', async () => {
+            searchResultIds = [1, 2, 3];
+            scopeSearchResultIds = [2, 3, 4];
+            seedItem(1);
+            seedItem(2);
+            seedItem(3);
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+            collections.set(`${LIBRARY_ID}/EFGH6789`, { id: 78, name: 'Theory' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['ABCD2345', 'EFGH6789'],
+                tags: ['to-read', 'reviewed'],
+            }));
+
+            const tagScope = scopeFor('tag');
+            expect(orGroupValues('collection')).toEqual(['ABCD2345', 'EFGH6789']);
+            expect(orGroupValues('tag')).toEqual(['to-read', 'reviewed']);
+            // The tag group is the one run separately, and its ids narrow the
+            // scoped result rather than replacing it.
+            expect(tagScope?.search).toHaveBeenCalled();
+            expect(response.total_count).toBe(2);
+            expect(response.item_ids).toEqual(['u-KEY2', 'u-KEY3']);
+        });
+
+        it('keeps a lone tag group as the scope, with nothing to intersect', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+
+            await handleResolvePopulationRequest(makeRequest({ tags: ['to-read'] }));
+
+            expect(scopeChain()).toHaveLength(1);
+            expect(orGroupValues('tag')).toEqual(['to-read']);
+            expect(scopeFor('tag')?.search).not.toHaveBeenCalled();
+        });
+
+        it('attaches no scope at all when neither group is given', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+
+            await handleResolvePopulationRequest(makeRequest({ unfiled: true }));
+
+            // An empty scope search matches the whole library, so attaching one
+            // would widen the population instead of narrowing it.
+            expect(mainSearch()?.setScope).not.toHaveBeenCalled();
+        });
+
+        it('scopes every group to the library the population resolves in', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+
+            await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['ABCD2345'],
+                tags: ['to-read'],
+            }));
+
+            expect(orGroupSearches()).toHaveLength(2);
+            for (const scope of orGroupSearches()) {
+                expect(scope.libraryID).toBe(LIBRARY_ID);
+            }
+        });
+    });
+
     describe('display names', () => {
-        it('names the library and the collection the filters resolved against', async () => {
+        it('names the library and the collections the filters resolved against', async () => {
             searchResultIds = [1];
             seedItem(1);
             collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
 
             const response = await handleResolvePopulationRequest(makeRequest({
-                collection_key: 'ABCD2345',
+                collection_keys: ['ABCD2345'],
             }));
 
             expect(response.library_name).toBe('My Library');
-            expect(response.collection_name).toBe('Methods');
+            expect(response.collection_names).toEqual(['Methods']);
+        });
+
+        it('names every collection, in the order the request asked for them', async () => {
+            searchResultIds = [1];
+            seedItem(1);
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+            collections.set(`${LIBRARY_ID}/EFGH6789`, { id: 78, name: 'Theory' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['EFGH6789', 'ABCD2345'],
+            }));
+
+            // The card pairs names with keys positionally; a reordered answer
+            // would name a place the population does not cover.
+            expect(response.collection_names).toEqual(['Theory', 'Methods']);
         });
 
         it('names the library alone when the population is not scoped to a collection', async () => {
             searchResultIds = [1];
             seedItem(1);
 
-            const response = await handleResolvePopulationRequest(makeRequest({ tag: 'to-read' }));
+            const response = await handleResolvePopulationRequest(makeRequest({ tags: ['to-read'] }));
 
             expect(response.library_name).toBe('My Library');
-            expect(response.collection_name).toBeNull();
+            expect(response.collection_names).toEqual([]);
         });
 
         it('names both on a count-only request, which returns no ids to name them from', async () => {
@@ -285,14 +485,14 @@ describe('handleResolvePopulationRequest', () => {
             collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
 
             const response = await handleResolvePopulationRequest(makeRequest({
-                collection_key: 'ABCD2345',
+                collection_keys: ['ABCD2345'],
                 max_items: 0,
             }));
 
             expect(response.item_ids).toEqual([]);
             expect(response.total_count).toBe(2);
             expect(response.library_name).toBe('My Library');
-            expect(response.collection_name).toBe('Methods');
+            expect(response.collection_names).toEqual(['Methods']);
         });
     });
 
@@ -656,7 +856,7 @@ describe('handleResolvePopulationRequest', () => {
 
     describe('invalid filters', () => {
         it('reports collection_not_found for a key the library does not have', async () => {
-            const response = await handleResolvePopulationRequest(makeRequest({ collection_key: 'ZZZZ9999' }));
+            const response = await handleResolvePopulationRequest(makeRequest({ collection_keys: ['ZZZZ9999'] }));
 
             expect(response.error_code).toBe('collection_not_found');
             expect(response.error).toContain('ZZZZ9999');
@@ -665,13 +865,40 @@ describe('handleResolvePopulationRequest', () => {
             expect(searches).toHaveLength(0);
         });
 
+        it('names the one bad key when the rest of the group resolves', async () => {
+            collections.set(`${LIBRARY_ID}/ABCD2345`, { id: 77, name: 'Methods' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                collection_keys: ['ABCD2345', 'ZZZZ9999'],
+            }));
+
+            // Resolving the rest would drop a disjunct, and a dropped disjunct
+            // NARROWS an OR-group — the batch would silently skip a collection
+            // the user was told it covers.
+            expect(response.error_code).toBe('collection_not_found');
+            expect(response.error).toContain('ZZZZ9999');
+            expect(response.error).not.toContain('ABCD2345');
+            expect(searches).toHaveLength(0);
+        });
+
         it('reports tag_not_found for a tag the library does not have', async () => {
-            const response = await handleResolvePopulationRequest(makeRequest({ tag: 'To Read' }));
+            const response = await handleResolvePopulationRequest(makeRequest({ tags: ['To Read'] }));
 
             expect(response.error_code).toBe('tag_not_found');
             expect(response.error).toContain('To Read');
             expect(response.item_ids).toEqual([]);
-            expect(searches[0].addCondition).not.toHaveBeenCalledWith('tag', 'is', 'To Read');
+            expect(searches.every(search =>
+                !search.addCondition.mock.calls.some(
+                    (call: any[]) => call[0] === 'tag' && call[2] === 'To Read'))).toBe(true);
+        });
+
+        it('reports tag_not_found for one bad tag among several', async () => {
+            const response = await handleResolvePopulationRequest(makeRequest({
+                tags: ['to-read', 'nonexistent'],
+            }));
+
+            expect(response.error_code).toBe('tag_not_found');
+            expect(response.error).toContain('nonexistent');
         });
 
         it('refuses a joinMode condition instead of letting it flip the search to OR', async () => {
@@ -728,19 +955,19 @@ describe('handleResolvePopulationRequest', () => {
             expect(response.warnings).toBeUndefined();
         });
 
-        it('rejects an empty tag and points at untagged', async () => {
-            const response = await handleResolvePopulationRequest(makeRequest({ tag: '' }));
+        it('rejects an empty tag entry and points at untagged', async () => {
+            const response = await handleResolvePopulationRequest(makeRequest({ tags: ['to-read', ''] }));
 
             expect(response.error_code).toBe('invalid_request');
             expect(response.error).toContain('untagged');
             expect(searches).toHaveLength(0);
         });
 
-        it('rejects an empty collection_key', async () => {
-            const response = await handleResolvePopulationRequest(makeRequest({ collection_key: '' }));
+        it('rejects an empty collection key entry', async () => {
+            const response = await handleResolvePopulationRequest(makeRequest({ collection_keys: [''] }));
 
             expect(response.error_code).toBe('invalid_request');
-            expect(response.error).toContain('collection_key');
+            expect(response.error).toContain('collection_keys');
             expect(searches).toHaveLength(0);
         });
 
@@ -749,6 +976,7 @@ describe('handleResolvePopulationRequest', () => {
                 libraryID = 0;
                 addCondition = vi.fn();
                 search = vi.fn(async () => { throw new Error('search blew up'); });
+                setScope = vi.fn();
                 constructor() {
                     searches.push(this as unknown as MockSearchInstance);
                 }


### PR DESCRIPTION
… and tags

Refactored the `WSResolvePopulationRequest` and `WSResolvePopulationResponse` interfaces to support multiple collection keys and tags. Changed `collection_key` to `collection_keys` and `tag` to `tags`, allowing for more flexible filtering. Updated the handling logic in `handleResolvePopulationHttpRequest` and `handleResolvePopulationRequest` to accommodate these changes, ensuring that the population request can now handle multiple collections and tags effectively. Enhanced unit tests to verify the new functionality and maintain existing behavior.