### PR TITLE
feat(preferences): implement Beaver preferences pane functionality

### DIFF
--- a/addon/content/beaverZoteroPrefs.js
+++ b/addon/content/beaverZoteroPrefs.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef, no-restricted-globals */
+/**
+ * Script for the Beaver pane in Zotero's Preferences window.
+ *
+ * Registered via the `scripts` option of `Zotero.PreferencePanes.register()`
+ * (see `src/hooks.ts`), which loads it into a sandbox scoped to the
+ * preferences window before the pane markup is inserted.
+ *
+ * The handler lives here rather than in an `oncommand` attribute on the button
+ * because Firefox 153 (Zotero 11) applies a baseline `script-src` CSP to every
+ * chrome: document, which blocks inline event handlers. Zotero disables that
+ * CSP for now but intends to remove the override.
+ *
+ * Because the script runs *before* the pane fragment is inserted, the button
+ * does not exist yet — so this listens for the `command` event as it bubbles
+ * up to the document instead of binding to the element directly.
+ */
+document.addEventListener("command", (event) => {
+    const target = event.target;
+    if (!target || target.id !== "beaver-open-prefs-btn") {
+        return;
+    }
+
+    const mainWin = Zotero.getMainWindow();
+    if (!mainWin) {
+        return;
+    }
+    mainWin.focus();
+
+    const eventBus = mainWin.__beaverEventBus;
+    if (!eventBus) {
+        return;
+    }
+    eventBus.dispatchEvent(
+        new mainWin.CustomEvent("toggleChat", {
+            detail: { forceOpen: true },
+        }),
+    );
+});

--- a/addon/content/beaverZoteroPrefs.xhtml
+++ b/addon/content/beaverZoteroPrefs.xhtml
@@ -6,20 +6,11 @@
             Beaver preferences are available from within the sidebar.
         </html:p>
         <hbox>
-        <button id="beaver-open-prefs-btn"
-                label="Open Beaver"
-                oncommand="
-                    var mainWin = Zotero.getMainWindow();
-                    mainWin.focus();
-                    var eventBus = mainWin.__beaverEventBus;
-                    if (eventBus) {
-                        eventBus.dispatchEvent(
-                            new mainWin.CustomEvent('toggleChat', {
-                                detail: { forceOpen: true }
-                            })
-                        );
-                    }
-                " />
+        <!-- The command handler lives in beaverZoteroPrefs.js, registered via
+             the `scripts` option of Zotero.PreferencePanes.register(). Inline
+             event handlers are blocked by the baseline chrome CSP that
+             Firefox 153 (Zotero 11) introduced. -->
+        <button id="beaver-open-prefs-btn" label="Open Beaver" />
         </hbox>
     </groupbox>
 </vbox>

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -87,11 +87,11 @@
 }
 
 #zotero-beaver-tb-chat-toggle:active,
-#zotero-beaver-tb-chat-toggle[selected="true"] {
+#zotero-beaver-tb-chat-toggle[selected] {
     background-color: var(--fill-quarternary);
 }
 
-#zotero-beaver-tb-chat-toggle[disabled="true"] {
+#zotero-beaver-tb-chat-toggle[disabled] {
     opacity: .5;
 }
 

--- a/react/hooks/useObservePaneCollapse.ts
+++ b/react/hooks/useObservePaneCollapse.ts
@@ -27,7 +27,13 @@ export function useObservePaneCollapse(location: SidebarLocation) {
                     const selectedType = win.Zotero_Tabs.selectedType;
                     const currentLocation = selectedType === 'library' ? 'library' : 'reader';
                     if(currentLocation !== location) return;
-                    const isCollapsed = itemPane.getAttribute("collapsed") === "true";
+                    // Read Zotero's own `collapsed` getter rather than the raw
+                    // attribute. Zotero 10 writes `collapsed="true"`/`"false"`,
+                    // Zotero 11 (Firefox 153) made it a boolean XUL attribute
+                    // written with toggleAttribute(), so it is `collapsed=""`
+                    // there and any `=== "true"` comparison is dead.
+                    // @ts-ignore: `collapsed` is not typed on the Zotero panes
+                    const isCollapsed = Boolean(itemPane.collapsed);
                     if (isCollapsed && sidebar.style.display !== 'none') {
                         // Dismiss any active diff preview in the note editor
                         dismissDiffPreview();

--- a/react/hooks/useSidebarDOMEffects.ts
+++ b/react/hooks/useSidebarDOMEffects.ts
@@ -80,11 +80,9 @@ export function useSidebarDOMEffects() {
         }
 
         // Update toolbar button
-        if (isSidebarVisible) {
-            chatToggleBtn?.setAttribute("selected", "true");
-        } else {
-            chatToggleBtn?.removeAttribute("selected");
-        }
+        // `selected` is a boolean XUL attribute as of Zotero 11 (Firefox 153):
+        // presence alone selects, so toggle it rather than writing "true".
+        chatToggleBtn?.toggleAttribute("selected", isSidebarVisible);
 
         // Cleanup function
         return () => {

--- a/react/ui/UIManager.ts
+++ b/react/ui/UIManager.ts
@@ -217,11 +217,9 @@ class UIManager {
     }
 
     public updateToolbarButton(isVisible: boolean): void {
-        if (isVisible) {
-            this.elements.chatToggleButton?.setAttribute("selected", "true");
-        } else {
-            this.elements.chatToggleButton?.removeAttribute("selected");
-        }
+        // `selected` is a boolean XUL attribute as of Zotero 11 (Firefox 153):
+        // presence alone selects, so toggle it rather than writing "true".
+        this.elements.chatToggleButton?.toggleAttribute("selected", isVisible);
         // Expose the open/closed state to screen readers as a toggle button.
         this.elements.chatToggleButton?.setAttribute("aria-pressed", isVisible ? "true" : "false");
     }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -300,6 +300,7 @@ async function onStartup() {
         await Zotero.PreferencePanes.register({
             pluginID: addon.data.config.addonID,
             src: rootURI + 'content/beaverZoteroPrefs.xhtml',
+            scripts: [rootURI + 'content/beaverZoteroPrefs.js'],
             id: 'beaver-prefpane',
             label: 'Beaver',
             image: rootURI + 'content/icons/beaver@0.5x.png',

--- a/src/modules/readerToolbarMenu.ts
+++ b/src/modules/readerToolbarMenu.ts
@@ -219,6 +219,10 @@ function openBeaverMenu(reader: any, anchorButton: HTMLElement): void {
             // Disabled header
             const header = xulDoc.createXULElement('menuitem');
             header.setAttribute('label', 'Actions');
+            // Keep the literal 'true': Gecko 115 (Zotero 7-10) disables a
+            // menuitem only on disabled="true", while Zotero 11 (Firefox 153)
+            // treats the attribute as boolean and accepts any value. Writing
+            // "true" is the one form that disables under both.
             header.setAttribute('disabled', 'true');
             popup.appendChild(header);
 


### PR DESCRIPTION
Added a new script `beaverZoteroPrefs.js` to handle the command event for opening the Beaver preferences pane in Zotero. This change moves the event handling logic from inline attributes in `beaverZoteroPrefs.xhtml` to the new script, ensuring compatibility with Firefox's CSP restrictions. Updated the button's behavior to focus the main window and dispatch a custom event for toggling the chat. Additionally, adjusted CSS selectors for better attribute handling in the Beaver toolbar button.