### PR TITLE
refactor(agent-retry): enhance chat navigation handling and retry logic

### DIFF
--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -190,15 +190,6 @@ export interface WSErrorEvent extends WSBaseEvent {
     try_auto_resume?: boolean;
     /** show the beaver credits button */
     has_beaver_fallback?: boolean;
-    /**
-     * Whether the run had high input token usage (backend-assessed).
-     *
-     * On this frame rather than `run_complete` since CLIENT_FEATURES.CITATIONS_EVENT:
-     * a run that failed still has this to say about the conversation, and it is the
-     * only source for a failed run — the composer's own fallback reads
-     * `lastRun.total_usage`, which a failed run does not have.
-     */
-    high_token_usage?: boolean;
 }
 
 /** Warning event for non-fatal issues */

--- a/react/atoms/agentRunAtoms.ts
+++ b/react/atoms/agentRunAtoms.ts
@@ -167,7 +167,7 @@ import { isToolResultView } from '@beaver/agent-core/run-state/toolResultViews';
 import { selectLiveBatchProgress } from '@beaver/agent-core/run-state/batchProgress';
 import { addWarningAtom, clearWarningsAtom } from './warnings';
 import { backendHighTokenUsageRunsAtom } from './messageUIState';
-import { currentThreadNameAtom, loadThreadAtom } from './threads';
+import { currentThreadNameAtom, loadThreadAtom, threadNavigationSeqAtom } from './threads';
 import { loadItemDataForAgentActions, autoApplyAnnotationAgentActions, autoCreateNoteAgentActions } from '../utils/agentActionUtils';
 import { extractZoteroReferencesFromToolCall } from '@beaver/agent-core/run-state/toolLabels';
 import {
@@ -464,6 +464,62 @@ async function truncateThreadOnServer(
     }
 }
 
+/** What an abandoned automatic retry tells the user. */
+const AUTO_RETRY_ABANDONED_TEXT =
+    'Beaver was retrying a failed response when you switched chats, so the retry was not sent. '
+    + 'Reopen that chat to see where it stands.';
+
+/** What an abandoned user-initiated retry tells the user. */
+const USER_RETRY_ABANDONED_TEXT =
+    'You switched chats while the retry was starting, so it was not sent. '
+    + 'Reopen that chat to see where it stands and retry from there.';
+
+/**
+ * Give up a replacement whose chat the user has left, and say so.
+ *
+ * Returns true when the caller must stop.
+ */
+function abandonReplacementIfThreadChanged(
+    get: Getter,
+    set: Setter,
+    options: {
+        navSeqBeforeAwait: number;
+        pendingRetryRunId: string;
+        logPrefix: string;
+        popupText: string;
+    },
+): boolean {
+    const current = get(threadNavigationSeqAtom);
+    if (current === options.navSeqBeforeAwait) return false;
+    logger(
+        `${options.logPrefix}: chat changed while the replacement was in flight ` +
+            `(navigation ${options.navSeqBeforeAwait} -> ${current}) — abandoning it`,
+        1,
+    );
+    // Release only what this replacement still owns, and the retry lock is the
+    // proof of ownership: `retryCommitInFlight` blocks every send while it is
+    // held, so nothing newer can have taken the composer's pending flag out
+    // from under it.
+    //
+    // Before the lock is taken — the check that runs as soon as the replaced
+    // run is cancelled — neither belongs to this replacement. The pending flag
+    // there is the cancelled run's, and the navigation doing the abandoning
+    // clears that itself on its way out of the chat. Clearing it here instead
+    // would re-enable the composer over a run the user has since started in the
+    // chat they moved to, and let them send a second one on top of it.
+    if (get(retryPendingRunIdAtom) === options.pendingRetryRunId) {
+        set(retryPendingRunIdAtom, null);
+        set(isWSChatPendingAtom, false);
+    }
+    set(addPopupMessageAtom, {
+        type: 'warning',
+        title: 'Retry not sent',
+        text: options.popupText,
+        expire: true,
+    });
+    return true;
+}
+
 /**
  * Create the initial AgentRun shell when user presses send.
  * This happens BEFORE WebSocket connection.
@@ -682,6 +738,10 @@ async function startAutoRetryRun(
     let newRunId: string | null = null;
 
     try {
+        // Which chat this replacement belongs to, captured before every await
+        // in the function. See `abandonReplacementIfThreadChanged`.
+        const navSeqBeforeAwait = get(threadNavigationSeqAtom);
+
         const model = get(selectedModelAtom);
         if (!model) {
             logger(`${logPrefix}: No model selected`, 1);
@@ -712,11 +772,11 @@ async function startAutoRetryRun(
             return;
         }
 
+        // Null for a first run that died before the backend named the thread.
+        // Nothing is persisted to truncate then, and the replacement opens the
+        // thread the same way the original request would have — the same shape
+        // the user-driven retry allows.
         const threadId = get(currentThreadIdAtom) || failedRun.thread_id;
-        if (!threadId) {
-            logger(`${logPrefix}: No thread ID found`, 1);
-            return;
-        }
 
         // Walk back to the original user message — resume runs carry an empty
         // user_prompt.content, so we need the root to preserve the question.
@@ -725,49 +785,73 @@ async function startAutoRetryRun(
         const truncateFromIndex = chainRootIndex >= 0 ? chainRootIndex : threadRuns.length;
         const runIdsToRemove = threadRuns.slice(truncateFromIndex).map(r => r.id);
 
-        // The failed run's error card shows a loading state while the
-        // truncate round trip runs; every exit below clears it (the catch
-        // handles the throw on a failed POST).
+        // The failed run keeps its card while the truncate round trip runs,
+        // with the status indicator in place of the error it suppresses (see
+        // `autoReplacementPendingRunIdsAtom`); every exit below clears the
+        // pending state (the catch handles the throw on a failed POST).
         set(retryPendingRunIdAtom, failedRunId);
         set(isWSChatPendingAtom, true);
 
-        // Commit the removal on the backend before anything local changes.
-        // Skipped when nothing was removed (nothing persisted to delete).
         if (runIdsToRemove.length > 0) {
-            const expectedTailRunId =
-                truncateFromIndex > 0 ? threadRuns[truncateFromIndex - 1].id : null;
-            const outcome = await truncateThreadOnServer(
-                threadId,
-                runIdsToRemove,
-                expectedTailRunId,
-                logPrefix,
-            );
-            if (outcome === 'refused') {
-                // The thread was rewritten by another client. There is no
-                // user decision to retry against a history this client has
-                // never seen — reload instead, so the UI shows the thread
-                // whole (including the failed run's error card, from which
-                // the user can retry deliberately).
-                set(retryPendingRunIdAtom, null);
-                set(isWSChatPendingAtom, false);
-                set(addPopupMessageAtom, {
-                    type: 'warning',
-                    title: 'Chat changed elsewhere',
-                    text: 'This chat was changed somewhere else, so the failed run was not retried automatically. Reloading the chat.',
-                    expire: true,
-                });
-                await set(loadThreadAtom, {
-                    user_id: userId,
+            // Commit the removal on the backend before anything local changes.
+            // A thread the backend never named has nothing persisted to
+            // truncate, but its runs still have to leave the local view.
+            if (threadId) {
+                const expectedTailRunId =
+                    truncateFromIndex > 0 ? threadRuns[truncateFromIndex - 1].id : null;
+                const outcome = await truncateThreadOnServer(
                     threadId,
-                    skipInstanceMismatchConfirm: true,
-                });
-                return;
-            }
-            if (outcome === 'failed') {
-                throw new Error('Failed to automatically retry run');
+                    runIdsToRemove,
+                    expectedTailRunId,
+                    logPrefix,
+                );
+                if (abandonReplacementIfThreadChanged(get, set, {
+                    navSeqBeforeAwait,
+                    pendingRetryRunId: failedRunId,
+                    logPrefix,
+                    popupText: AUTO_RETRY_ABANDONED_TEXT,
+                })) {
+                    return;
+                }
+                if (outcome === 'refused') {
+                    // The thread was rewritten by another client. There is no
+                    // user decision to retry against a history this client has
+                    // never seen — reload instead, so the UI shows the thread
+                    // whole (including the failed run's error card, from which
+                    // the user can retry deliberately).
+                    set(retryPendingRunIdAtom, null);
+                    set(isWSChatPendingAtom, false);
+                    set(addPopupMessageAtom, {
+                        type: 'warning',
+                        title: 'Chat changed elsewhere',
+                        text: 'This chat was changed somewhere else, so the failed run was not retried automatically. Reloading the chat.',
+                        expire: true,
+                    });
+                    await set(loadThreadAtom, {
+                        user_id: userId,
+                        threadId,
+                        skipInstanceMismatchConfirm: true,
+                    });
+                    return;
+                }
+                if (outcome === 'failed') {
+                    throw new Error('Failed to automatically retry run');
+                }
             }
 
             await cleanupTemporaryAnnotationsForRunReplacement(logPrefix);
+
+            // Re-checked after the cleanup, which is the last await before the
+            // writes — and the only one on the path where the thread was never
+            // named and no POST was made.
+            if (abandonReplacementIfThreadChanged(get, set, {
+                navSeqBeforeAwait,
+                pendingRetryRunId: failedRunId,
+                logPrefix,
+                popupText: AUTO_RETRY_ABANDONED_TEXT,
+            })) {
+                return;
+            }
 
             set(threadRunsAtom, prev => prev.filter(r => !runIdsToRemove.includes(r.id)));
             set(threadAgentActionsAtom, prev => prev.filter(a => !runIdsToRemove.includes(a.run_id)));
@@ -1552,7 +1636,15 @@ export function createWSCallbacks(
             // Clear retry state when run completes
             set(wsRetryAtom, null);
 
-            // Store transient backend flags (not persisted on AgentRun)
+            // Store transient backend flags (not persisted on AgentRun).
+            // The only frame that carries this flag, failed and canceled runs
+            // included: a run that ends with partial output still gets a
+            // run_complete ahead of its error frame, and that frame reports the
+            // usage. (Not a run the socket dropped — but there is nobody left to
+            // warn there.) Keyed by run id in an atom that never consults run
+            // status, so a failed run drives the same composer warning a
+            // finished one does — the composer's own fallback reads
+            // `total_usage`, which a failed run has none of.
             if (event.high_token_usage) {
                 set(backendHighTokenUsageRunsAtom, (prev) => ({ ...prev, [event.run_id]: true }));
             }
@@ -1680,16 +1772,6 @@ export function createWSCallbacks(
             set(clearAllPendingCreditConfirmationsAtom);
             set(clearAllPendingBatchApprovalsAtom);
             set(clearRunApprovalPolicyAtom);
-
-            // Run quality flag for a run that did not complete. Keyed by run id
-            // in an atom that never consults run status, so a failed run drives
-            // the same composer warning a finished one does — the composer's
-            // own fallback reads `total_usage`, which a failed run has none of.
-            // Defensive: the backend carries this on the `run_complete` frame it
-            // sends ahead of the error, so `onRunComplete` normally has it first.
-            if (errorRunId && event.high_token_usage) {
-                set(backendHighTokenUsageRunsAtom, (prev) => ({ ...prev, [errorRunId]: true }));
-            }
 
             if (
                 event.try_auto_resume &&
@@ -2580,6 +2662,13 @@ async function startRegenerateRun(
     let newRunId: string | null = null;
 
     try {
+        // Which chat this replacement belongs to. Must precede every await in
+        // the function — retrying a still-live run cancels it first, and a
+        // sequence captured after that flush would already carry a switch made
+        // during it, blinding every later check. See
+        // `abandonReplacementIfThreadChanged`.
+        const navSeqBeforeAwait = get(threadNavigationSeqAtom);
+
         // Get current model
         const model = get(selectedModelAtom);
         if (!model) {
@@ -2626,6 +2715,21 @@ async function startRegenerateRun(
             // composer guard keeps blocking new sends during the flush.
             set(activeRunAtom, null);
             await agentService.cancel();
+
+            // The earliest await in this function, and everything after it
+            // reads live state: the thread id the truncate is addressed to,
+            // and the applied actions the undo dialog lists. Checking only
+            // after the POST would let a switch made during this flush put
+            // that dialog in front of the new chat and aim the removal at it.
+            // Ahead of the clear below, which abandoning does for itself.
+            if (abandonReplacementIfThreadChanged(get, set, {
+                navSeqBeforeAwait,
+                pendingRetryRunId: runId,
+                logPrefix,
+                popupText: USER_RETRY_ABANDONED_TEXT,
+            })) {
+                return;
+            }
             set(isWSChatPendingAtom, false);
         }
 
@@ -2654,7 +2758,10 @@ async function startRegenerateRun(
             }
         }
 
-        // Get thread ID from the target run (may not be set in currentThreadIdAtom yet)
+        // Get thread ID from the target run (may not be set in currentThreadIdAtom yet).
+        // Deliberately read after the cancel above: a first run's `thread` event
+        // can land during that flush, and reading earlier would miss the id and
+        // leave the run stranded server-side.
         const threadId = get(currentThreadIdAtom) || targetRun.thread_id;
 
         // Runs the retry replaces: the target and everything after it. A live
@@ -2757,6 +2864,14 @@ async function startRegenerateRun(
                 expectedTailRunId,
                 logPrefix,
             );
+            if (abandonReplacementIfThreadChanged(get, set, {
+                navSeqBeforeAwait,
+                pendingRetryRunId: runId,
+                logPrefix,
+                popupText: USER_RETRY_ABANDONED_TEXT,
+            })) {
+                return;
+            }
             if (outcome === 'failed') {
                 set(retryPendingRunIdAtom, null);
                 set(isWSChatPendingAtom, false);
@@ -2798,6 +2913,18 @@ async function startRegenerateRun(
 
         await cleanupTemporaryAnnotationsForRunReplacement(logPrefix);
 
+        // Re-checked after the undo and the cleanup: the undo awaits one Zotero
+        // operation per applied action, so it is the longest window in this
+        // function and the easiest one to switch chats in.
+        if (abandonReplacementIfThreadChanged(get, set, {
+            navSeqBeforeAwait,
+            pendingRetryRunId: runId,
+            logPrefix,
+            popupText: USER_RETRY_ABANDONED_TEXT,
+        })) {
+            return;
+        }
+
         // Truncate runs - keep only runs before the target
         set(threadRunsAtom, (prev) =>
             prev.filter(r => !runIdsToRemove.includes(r.id))
@@ -2834,7 +2961,12 @@ async function startRegenerateRun(
             model.provider,
             customInstructions,
             model.is_custom ? model.custom_model : undefined,
-            { retryTrigger: 'user' },
+            // A retry re-asks the same question, and the trigger is what tells
+            // the backend a person asked for it. An edited prompt is a new
+            // question that happens to replace the old turn, so it is not one:
+            // reporting it as a retry would count it among the runs that stand
+            // in for a failed one.
+            { retryTrigger: editedPrompt ? undefined : 'user' },
         );
 
         // Set active run - UI now shows user message + spinner, which takes

--- a/react/atoms/threads.ts
+++ b/react/atoms/threads.ts
@@ -276,6 +276,12 @@ async function cancelActiveRunIfNeeded(get: (atom: any) => any, set: (atom: any,
 }
 
 /**
+ * Counts chat navigations, so work started in one chat can tell it has been
+ * left behind.
+ */
+export const threadNavigationSeqAtom = atom(0);
+
+/**
  * Atom to create a new thread
  */
 export const newThreadAtom = atom(
@@ -295,6 +301,8 @@ export const newThreadAtom = atom(
             }
             set(isLoadingThreadAtom, true);
         }
+        // The user has committed to leaving. See threadNavigationSeqAtom.
+        set(threadNavigationSeqAtom, (seq) => seq + 1);
 
         try {
             // Cancel any active run before switching threads
@@ -395,6 +403,11 @@ export const loadThreadAtom = atom(
 
         // Show loading state immediately for instant UI feedback
         set(isLoadingThreadAtom, true);
+        // The user has committed to leaving, and everything below this point —
+        // starting with the identity preflight's round trip — is time in which
+        // work belonging to the chat being left must not finish and act. See
+        // threadNavigationSeqAtom.
+        set(threadNavigationSeqAtom, (seq) => seq + 1);
 
         // Resolve the thread's instance identity (and name, from the same
         // request) BEFORE any thread-state mutation, so a canceled mismatch

--- a/react/components/agentRuns/AgentRunView.tsx
+++ b/react/components/agentRuns/AgentRunView.tsx
@@ -60,7 +60,8 @@ export const AgentRunView = React.memo(forwardRef<HTMLDivElement, AgentRunViewPr
     const wasResumed = wasRunContinued(run, resumedRunIds);
 
     // A run the client is already replacing on its own. Its error card is
-    // suppressed until the replacement lands.
+    // suppressed until the replacement lands — the failure is about to be
+    // undone, and flashing it up would report a problem the reader never had.
     const autoReplacementPending = useAtomValue(autoReplacementPendingRunIdsAtom).has(run.id);
 
     // A run that was cut off (Beaver closed, connection dropped, server
@@ -87,7 +88,12 @@ export const AgentRunView = React.memo(forwardRef<HTMLDivElement, AgentRunViewPr
         () => shouldShowRunStatus(run, resultsMap, { isStreamQuiet }),
         [run, resultsMap, isStreamQuiet],
     );
-    const showStatusIndicator = isLastRun && runHasNothingToShow;
+    // The replacement is not instant: an auto-retry commits the failed run's
+    // removal on the backend first, and that round trip would otherwise leave
+    // the card with a suppressed error, no spinner, and nothing to say the
+    // client is working. The run's own status is terminal, so this is the one
+    // wait `shouldShowRunStatus` cannot see.
+    const showStatusIndicator = isLastRun && (runHasNothingToShow || autoReplacementPending);
 
     // Where the visible wait started, so the indicator can count it up. Null
     // while the run has produced nothing yet: there is no event to count from,
@@ -152,6 +158,11 @@ export const AgentRunView = React.memo(forwardRef<HTMLDivElement, AgentRunViewPr
                 showStatusIndicator={showStatusIndicator}
                 status={run.status}
                 waitingSince={waitingSince}
+                // The pending signal covers an auto-resume too, but only the
+                // auto-retry has a wait to label: a resume installs its
+                // replacement in the same synchronous batch, so the failed run
+                // has stopped being the last one before anything renders.
+                statusIdleLabel={autoReplacementPending ? 'Retrying' : undefined}
             />
 
             {/* Error display (includes retry/resume buttons) - hide if run was resumed */}

--- a/react/components/agentRuns/ModelMessagesView.tsx
+++ b/react/components/agentRuns/ModelMessagesView.tsx
@@ -18,6 +18,8 @@ interface ModelMessagesViewProps {
      * the run has produced nothing to date it from.
      */
     waitingSince?: number | null;
+    /** What the status indicator says while nothing more specific applies. */
+    statusIdleLabel?: string;
 }
 
 /**
@@ -35,6 +37,7 @@ export const ModelMessagesView: React.FC<ModelMessagesViewProps> = React.memo(fu
     showStatusIndicator,
     status,
     waitingSince,
+    statusIdleLabel,
 }) {
     // Don't render anything if there's no content to show
     if (messages.length === 0 && !showStatusIndicator) {
@@ -100,6 +103,7 @@ export const ModelMessagesView: React.FC<ModelMessagesViewProps> = React.memo(fu
                     lastMessageHasToolCall={lastMessageHasToolCall}
                     followsText={followsText}
                     waitingSince={waitingSince}
+                    idleLabel={statusIdleLabel}
                 />
             )}
         </div>

--- a/react/components/agentRuns/RunStatusIndicator.tsx
+++ b/react/components/agentRuns/RunStatusIndicator.tsx
@@ -31,6 +31,12 @@ interface RunStatusIndicatorProps {
      * is the better estimate anyway, since that is when the wait became visible.
      */
     waitingSince?: number | null;
+    /**
+     * What the line says when neither a reconnect nor a backend retry is
+     * speaking for it. Defaults to the ordinary wait for a model's next token;
+     * a caller waiting on something else names that instead.
+     */
+    idleLabel?: string;
 }
 
 /**
@@ -61,7 +67,7 @@ function useElapsedSeconds(since: number | null | undefined): number {
  * connection.
  * Note: Errors are displayed separately by RunErrorDisplay.
  */
-export const RunStatusIndicator: React.FC<RunStatusIndicatorProps> = ({ status, runId, lastMessageHasToolCall, followsText, waitingSince }) => {
+export const RunStatusIndicator: React.FC<RunStatusIndicatorProps> = ({ status, runId, lastMessageHasToolCall, followsText, waitingSince, idleLabel = 'Generating' }) => {
     const retryState = useAtomValue(wsRetryAtom);
     const reconnectState = useAtomValue(wsReconnectingAtom);
     const elapsedSeconds = useElapsedSeconds(waitingSince);
@@ -74,7 +80,7 @@ export const RunStatusIndicator: React.FC<RunStatusIndicatorProps> = ({ status, 
     const state = {
         reconnect: reconnectState,
         backendRetry: isRetrying ? retryState : null,
-        idleLabel: 'Generating',
+        idleLabel,
     };
     const text = runStatusText({
         ...state,

--- a/tests/unit/atoms/interruptActiveRunConfirm.test.ts
+++ b/tests/unit/atoms/interruptActiveRunConfirm.test.ts
@@ -8,13 +8,14 @@ import { createStore } from 'jotai';
 
 const cancelMock = vi.fn();
 const getThreadRunsMock = vi.fn();
+const getThreadMock = vi.fn();
 vi.mock('@beaver/agent-core/transport/agentService', () => ({
     agentRunService: { getThreadRuns: (...args: unknown[]) => getThreadRunsMock(...args) },
     agentService: { cancel: (...args: unknown[]) => cancelMock(...args) },
 }));
 
 vi.mock('@beaver/agent-core/transport/threadService', () => ({
-    threadService: { getThread: vi.fn() },
+    threadService: { getThread: (...args: unknown[]) => getThreadMock(...args) },
 }));
 
 vi.mock('../../../src/utils/zoteroUtils', () => ({
@@ -170,7 +171,12 @@ vi.mock('../../../src/utils/libraryIdentity', () => ({
     resolveItemReference: vi.fn(async () => ({ status: 'not_found' })),
 }));
 
-import { newThreadAtom, loadThreadAtom, currentThreadIdAtom } from '../../../react/atoms/threads';
+import {
+    newThreadAtom,
+    loadThreadAtom,
+    currentThreadIdAtom,
+    threadNavigationSeqAtom,
+} from '../../../react/atoms/threads';
 import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { isWSChatPendingAtom } from '../../../react/atoms/agentRunAtoms';
 
@@ -196,6 +202,7 @@ describe('interrupt-active-run confirm', () => {
         getPrefMock.mockReturnValue(false);
         confirmMock.mockReturnValue(true);
         getThreadRunsMock.mockResolvedValue({ runs: [], agent_actions: [] });
+        getThreadMock.mockResolvedValue({ name: 'Thread', zotero_user_id: '111', zotero_local_id: 'CURKEY' });
     });
 
     describe('newThreadAtom', () => {
@@ -270,6 +277,99 @@ describe('interrupt-active-run confirm', () => {
 
             expect(confirmMock).toHaveBeenCalledTimes(1);
             expect(confirmMock.mock.calls[0][0]).toMatchObject({ title: 'Switch chat?' });
+        });
+    });
+
+    /**
+     * Work started in one chat asks this counter whether it has been left
+     * behind. The thread id cannot answer: a new chat opened from an unnamed
+     * first run leaves it null on both sides, and a load writes it only after
+     * its own awaits.
+     */
+    describe('threadNavigationSeqAtom', () => {
+        it('counts a new chat even when the thread id does not change', async () => {
+            store.set(currentThreadIdAtom, null);
+            const before = store.get(threadNavigationSeqAtom);
+
+            await store.set(newThreadAtom, { skipAutoPopulate: true });
+
+            expect(store.get(currentThreadIdAtom)).toBeNull();
+            expect(store.get(threadNavigationSeqAtom)).toBe(before + 1);
+        });
+
+        it('counts a load', async () => {
+            const before = store.get(threadNavigationSeqAtom);
+
+            await store.set(loadThreadAtom, loadArgs);
+
+            expect(store.get(threadNavigationSeqAtom)).toBe(before + 1);
+        });
+
+        it('counts before the identity preflight, not after it', async () => {
+            // The preflight is a network round trip, and the confirm the user
+            // just cleared is added to it. A count taken after would leave a
+            // retry that finishes inside that window free to act on the chat
+            // being left.
+            getPrefMock.mockImplementation((k: string) => k === 'statefulChat');
+            const before = store.get(threadNavigationSeqAtom);
+            let seqAtFetch: number | null = null;
+            getThreadMock.mockImplementation(async () => {
+                seqAtFetch = store.get(threadNavigationSeqAtom);
+                return { name: 'Thread', zotero_user_id: '111', zotero_local_id: 'CURKEY' };
+            });
+
+            await store.set(loadThreadAtom, {
+                user_id: 'u1',
+                threadId: 'thread-1',
+                skipInstanceMismatchConfirm: true,
+            });
+
+            expect(getThreadMock).toHaveBeenCalled();
+            expect(seqAtFetch).toBe(before + 1);
+        });
+
+        it('still counts a load that aborts after the user committed', async () => {
+            // The accepted cost of counting at the commit point: work already
+            // abandoned cannot be un-abandoned when the load later fails. Safe
+            // direction — see the atom's own note.
+            getPrefMock.mockImplementation((k: string) => k === 'statefulChat');
+            getThreadMock.mockRejectedValue(new Error('offline'));
+            const before = store.get(threadNavigationSeqAtom);
+
+            const loaded = await store.set(loadThreadAtom, {
+                user_id: 'u1',
+                threadId: 'thread-1',
+            });
+
+            expect(loaded).toBe(false);
+            expect(store.get(threadNavigationSeqAtom)).toBe(before + 1);
+        });
+
+        it('does not count a navigation the user declined', async () => {
+            confirmMock.mockReturnValue(false);
+            store.set(activeRunAtom, run('in_progress'));
+            const before = store.get(threadNavigationSeqAtom);
+
+            await store.set(newThreadAtom, { skipAutoPopulate: true });
+            await store.set(loadThreadAtom, loadArgs);
+
+            expect(confirmMock).toHaveBeenCalledTimes(2);
+            expect(store.get(threadNavigationSeqAtom)).toBe(before);
+        });
+
+        it('moves before the new chat state does', async () => {
+            store.set(currentThreadIdAtom, 'thread-0');
+            const seenWhenIdChanged: number[] = [];
+            store.sub(currentThreadIdAtom, () => {
+                seenWhenIdChanged.push(store.get(threadNavigationSeqAtom));
+            });
+            const before = store.get(threadNavigationSeqAtom);
+
+            await store.set(loadThreadAtom, loadArgs);
+
+            // Already incremented by the time the id is written, so nothing can
+            // observe the new chat under the old count.
+            expect(seenWhenIdChanged).toContain(before + 1);
         });
     });
 });

--- a/tests/unit/atoms/retryTruncation.test.ts
+++ b/tests/unit/atoms/retryTruncation.test.ts
@@ -12,14 +12,26 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { connectMock, truncateMock, loadThreadRunsMock, undoEditMetadataMock } = vi.hoisted(() => ({
+const {
+    connectMock,
+    truncateMock,
+    loadThreadRunsMock,
+    undoEditMetadataMock,
+    cleanupAnnotationsMock,
+    cancelMock,
+} = vi.hoisted(() => ({
     connectMock: vi.fn().mockResolvedValue(undefined),
     truncateMock: vi.fn(),
     loadThreadRunsMock: vi.fn(),
     undoEditMetadataMock: vi.fn().mockResolvedValue(undefined),
+    // The last await before a replacement writes anything — and on the
+    // new-thread path, the only one.
+    cleanupAnnotationsMock: vi.fn().mockResolvedValue(undefined),
+    // The FIRST await, reached only when the retried run is still live.
+    cancelMock: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@beaver/agent-core/transport/agentService', () => ({
-    agentService: { connect: connectMock, close: vi.fn(), cancel: vi.fn() },
+    agentService: { connect: connectMock, close: vi.fn(), cancel: cancelMock },
     AgentConnectionError: class AgentConnectionError extends Error {},
 }));
 vi.mock('@beaver/agent-core/transport/threadService', () => ({
@@ -56,6 +68,9 @@ vi.mock('@beaver/agent-core/transport/supabaseClient', () => ({
     supabase: { auth: { getSession: vi.fn(), refreshSession: vi.fn() } },
 }));
 vi.mock('../../../src/beaver-extract', () => ({ prewarmMuPDFWorker: vi.fn() }));
+vi.mock('../../../react/utils/annotationUtils', () => ({
+    BeaverTemporaryAnnotations: { cleanupAll: cleanupAnnotationsMock },
+}));
 vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
 
 import type { AgentRun } from '@beaver/agent-core/agents/types';
@@ -68,6 +83,8 @@ import {
 import { citationsAtom } from '@beaver/agent-core/citations/atoms';
 import { threadAgentActionsAtom } from '../../../react/agents/agentActions';
 import { popupMessagesAtom } from '../../../react/atoms/ui';
+import type { PopupMessage } from '../../../react/types/popupMessage';
+import { threadNavigationSeqAtom } from '../../../react/atoms/threads';
 import {
     autoRetryErroredRunAtom,
     isWSChatPendingAtom,
@@ -109,6 +126,23 @@ function makeAppliedMetadataEdit(id: string, runId: string) {
     } as any;
 }
 
+/**
+ * What a chat switch looks like from inside an awaited call.
+ *
+ * Models the real ordering rather than the convenient one: `loadThreadAtom`
+ * bumps the navigation counter before its own awaits and writes the new thread
+ * id only after them, so a replacement checking mid-flight sees the counter
+ * move while the id still reads as the chat being left. `newThreadAtom` from an
+ * unnamed first run never changes the id at all.
+ */
+function beginNavigation() {
+    store.set(threadNavigationSeqAtom, (seq: number) => seq + 1);
+    // What `cancelActiveRunIfNeeded` does on the way out of the old chat. The
+    // guard relies on it: the pending flag it does not own is released here,
+    // not by the abandoned replacement.
+    store.set(isWSChatPendingAtom, false);
+}
+
 /** A successful truncation report naming exactly the given runs. */
 function okReport(deletedRunIds: string[]) {
     return { deleted_run_ids: deletedRunIds, refused_run_ids: [], reason: null };
@@ -131,6 +165,10 @@ function threadRunIds(): string[] {
     return store.get(threadRunsAtom).map((run: AgentRun) => run.id);
 }
 
+function popupTitles(): Array<string | undefined> {
+    return store.get(popupMessagesAtom).map((m: PopupMessage) => m.title);
+}
+
 const promptConfirmMock = vi.fn();
 
 describe('retry via synchronous truncation', () => {
@@ -140,6 +178,8 @@ describe('retry via synchronous truncation', () => {
         truncateMock.mockResolvedValue(okReport([]));
         loadThreadRunsMock.mockResolvedValue({ runs: [], citations: [], agentActions: [] });
         undoEditMetadataMock.mockResolvedValue(undefined);
+        cleanupAnnotationsMock.mockResolvedValue(undefined);
+        cancelMock.mockResolvedValue(undefined);
         // 'Undo && Retry' = 0, cancel = 1, 'Retry' (skip undo) = 2.
         promptConfirmMock.mockReturnValue(2);
         (globalThis as any).Zotero.Prompt = {
@@ -160,6 +200,7 @@ describe('retry via synchronous truncation', () => {
         store.set(citationsAtom, []);
         store.set(popupMessagesAtom, []);
         store.set(retryPendingRunIdAtom, null);
+        store.set(threadNavigationSeqAtom, 0);
     });
 
     it('cancel in the confirm dialog aborts with no POST and no local change', async () => {
@@ -191,7 +232,7 @@ describe('retry via synchronous truncation', () => {
         expect(store.get(citationsAtom)).toHaveLength(1);
         expect(store.get(isWSChatPendingAtom)).toBe(false);
         expect(store.get(retryPendingRunIdAtom)).toBeNull();
-        expect(store.get(popupMessagesAtom).some(m => m.title === 'Retry failed')).toBe(true);
+        expect(popupTitles()).toContain('Retry failed');
     });
 
     it('shows the retry loading state exactly while the removal commits', async () => {
@@ -221,7 +262,7 @@ describe('retry via synchronous truncation', () => {
         await store.set(regenerateFromRunAtom, 'b');
 
         expect(connectMock).not.toHaveBeenCalled();
-        expect(store.get(popupMessagesAtom).some(m => m.title === 'Chat changed elsewhere')).toBe(true);
+        expect(popupTitles()).toContain('Chat changed elsewhere');
         // The thread was reloaded rather than truncated.
         expect(loadThreadRunsMock).toHaveBeenCalledWith('thread-1', expect.anything());
         expect(threadRunIds()).toEqual(['a', 'b', 'c']);
@@ -239,7 +280,7 @@ describe('retry via synchronous truncation', () => {
         await store.set(regenerateFromRunAtom, 'b');
 
         expect(connectMock).not.toHaveBeenCalled();
-        expect(store.get(popupMessagesAtom).some(m => m.title === 'Chat changed elsewhere')).toBe(true);
+        expect(popupTitles()).toContain('Chat changed elsewhere');
         expect(loadThreadRunsMock).toHaveBeenCalledWith('thread-1', expect.anything());
         expect(threadRunIds()).toEqual(['a', 'b']);
     });
@@ -295,6 +336,120 @@ describe('retry via synchronous truncation', () => {
         expect(request.user_prompt.content).toBe('rewritten');
         expect(request.retry_run_id).toBeUndefined();
         expect(request.thread_run_ids).toBeUndefined();
+    });
+
+    it('abandons a user retry when the user opens another chat mid-POST', async () => {
+        store.set(threadRunsAtom, [makeRun('a'), makeRun('b'), makeRun('c')]);
+        store.set(citationsAtom, [{ run_id: 'c' } as any]);
+        truncateMock.mockImplementation(async () => {
+            beginNavigation();
+            return okReport(['b', 'c']);
+        });
+
+        await store.set(regenerateFromRunAtom, 'b');
+
+        expect(truncateMock).toHaveBeenCalledWith('thread-1', ['b', 'c'], 'a');
+        expect(connectMock).not.toHaveBeenCalled();
+        // The other chat's state is left exactly as the switch left it.
+        expect(threadRunIds()).toEqual(['a', 'b', 'c']);
+        expect(store.get(citationsAtom)).toHaveLength(1);
+        expect(store.get(isWSChatPendingAtom)).toBe(false);
+        expect(store.get(retryPendingRunIdAtom)).toBeNull();
+        expect(popupTitles()).toContain('Retry not sent');
+    });
+
+    it('abandons a retry of a live run when the chat changes during the cancel', async () => {
+        // Retrying a still-streaming run cancels it first, and that cancel is
+        // the earliest await in the flow. A navigation captured after it would
+        // already carry the switch, leaving every later check blind.
+        store.set(threadRunsAtom, [makeRun('a')]);
+        store.set(activeRunAtom, makeRun('live', { status: 'in_progress' }));
+        store.set(citationsAtom, [{ run_id: 'a' } as any]);
+        truncateMock.mockResolvedValue(okReport(['live']));
+        cancelMock.mockImplementation(async () => {
+            beginNavigation();
+        });
+
+        await store.set(regenerateFromRunAtom, 'live');
+
+        expect(cancelMock).toHaveBeenCalled();
+        // Abandoned at the cancel, before anything reads live state: no
+        // removal aimed at whichever chat is now open, and no undo dialog
+        // built from its actions.
+        expect(truncateMock).not.toHaveBeenCalled();
+        expect(promptConfirmMock).not.toHaveBeenCalled();
+        expect(connectMock).not.toHaveBeenCalled();
+        // The other chat's state is left exactly as the switch left it.
+        expect(threadRunIds()).toEqual(['a']);
+        expect(store.get(citationsAtom)).toHaveLength(1);
+        expect(store.get(activeRunAtom)).toBeNull();
+        expect(store.get(isWSChatPendingAtom)).toBe(false);
+        expect(store.get(retryPendingRunIdAtom)).toBeNull();
+        expect(popupTitles()).toContain('Retry not sent');
+    });
+
+    it('leaves a run started in the destination chat holding the composer', async () => {
+        // Abandoning at the cancel happens before the retry lock is taken, so
+        // the pending flag there is not the retry's to release. Clearing it
+        // would re-enable the composer over the new chat's run and let a second
+        // send land on top of it.
+        store.set(threadRunsAtom, [makeRun('a')]);
+        store.set(activeRunAtom, makeRun('live', { status: 'in_progress' }));
+        cancelMock.mockImplementation(async () => {
+            beginNavigation();
+            // The user starts a run in the chat they moved to.
+            store.set(isWSChatPendingAtom, true);
+        });
+
+        await store.set(regenerateFromRunAtom, 'live');
+
+        expect(connectMock).not.toHaveBeenCalled();
+        expect(store.get(isWSChatPendingAtom)).toBe(true);
+        expect(store.get(retryPendingRunIdAtom)).toBeNull();
+    });
+
+    it('abandons a user retry when the chat changes during the undo, not just the POST', async () => {
+        // The undo awaits one Zotero operation per applied action, so it is the
+        // longest window in the flow — a guard that only covers the POST leaves
+        // it open.
+        store.set(threadRunsAtom, [makeRun('a'), makeRun('b'), makeRun('c')]);
+        store.set(citationsAtom, [{ run_id: 'c' } as any]);
+        store.set(threadAgentActionsAtom, [makeAppliedMetadataEdit('act-1', 'b')]);
+        promptConfirmMock.mockReturnValue(0); // Undo && Retry
+        truncateMock.mockResolvedValue(okReport(['b', 'c']));
+        undoEditMetadataMock.mockImplementation(async () => {
+            beginNavigation();
+        });
+
+        await store.set(regenerateFromRunAtom, 'b');
+
+        expect(truncateMock).toHaveBeenCalledWith('thread-1', ['b', 'c'], 'a');
+        expect(undoEditMetadataMock).toHaveBeenCalled();
+        expect(connectMock).not.toHaveBeenCalled();
+        expect(threadRunIds()).toEqual(['a', 'b', 'c']);
+        expect(store.get(citationsAtom)).toHaveLength(1);
+        expect(store.get(threadAgentActionsAtom)).toHaveLength(1);
+        expect(store.get(isWSChatPendingAtom)).toBe(false);
+        expect(store.get(retryPendingRunIdAtom)).toBeNull();
+        expect(popupTitles()).toContain('Retry not sent');
+    });
+
+    it('marks a user retry as user-initiated, and an edited prompt as neither', async () => {
+        // The trigger says a person asked for this retry. An edited prompt is
+        // a new question, not a retry, so it carries no trigger at all.
+        store.set(threadRunsAtom, [makeRun('a'), makeRun('b')]);
+        truncateMock.mockResolvedValue(okReport(['b']));
+
+        await store.set(regenerateFromRunAtom, 'b');
+        expect(sentRequest().retry_trigger).toBe('user');
+
+        store.set(threadRunsAtom, [makeRun('a'), makeRun('b')]);
+        store.set(isWSChatPendingAtom, false);
+        await store.set(regenerateWithEditedPromptAtom, {
+            runId: 'b',
+            editedPrompt: { content: 'rewritten' },
+        });
+        expect(sentRequest().retry_trigger).toBeUndefined();
     });
 
     it('folds a terminal active run into the dialog and the POSTed removal', async () => {
@@ -382,6 +537,102 @@ describe('retry via synchronous truncation', () => {
             expect(threadRunIds()).toEqual(['a', 'failed']);
         });
 
+        it('marks itself automatic so the backend can reorder its chain', async () => {
+            store.set(threadRunsAtom, [makeRun('a')]);
+            store.set(activeRunAtom, makeRun('failed', { status: 'error' }));
+            truncateMock.mockResolvedValue(okReport(['failed']));
+
+            await store.set(autoRetryErroredRunAtom, 'failed');
+
+            expect(sentRequest().retry_trigger).toBe('auto');
+        });
+
+        it('restarts a first run that died before the thread was named', async () => {
+            // The backend never sent a thread event, so nothing is persisted
+            // to truncate — but the question still deserves its restart, the
+            // same one the user-driven retry would give it.
+            store.set(currentThreadIdAtom, null);
+            store.set(threadRunsAtom, []);
+            store.set(activeRunAtom, makeRun('failed', { status: 'error', thread_id: null as any }));
+
+            await store.set(autoRetryErroredRunAtom, 'failed');
+
+            expect(truncateMock).not.toHaveBeenCalled();
+            // The failed run still leaves the local view — there was simply
+            // nothing on the server to delete.
+            expect(threadRunIds()).toEqual([]);
+            const request = sentRequest();
+            expect(request.thread_id).toBeNull();
+            expect(request.user_prompt.content).toBe('prompt for failed');
+            expect(request.retry_trigger).toBe('auto');
+        });
+
+        it('abandons the restart when the user opens another chat mid-POST', async () => {
+            // The replacement would land in whatever chat is open now, which
+            // is not the one it belongs to.
+            store.set(threadRunsAtom, [makeRun('a')]);
+            store.set(activeRunAtom, makeRun('failed', { status: 'error' }));
+            truncateMock.mockImplementation(async () => {
+                beginNavigation();
+                return okReport(['failed']);
+            });
+
+            await store.set(autoRetryErroredRunAtom, 'failed');
+
+            expect(truncateMock).toHaveBeenCalledWith('thread-1', ['failed'], 'a');
+            expect(connectMock).not.toHaveBeenCalled();
+            expect(store.get(activeRunAtom)).toBeNull();
+            expect(store.get(isWSChatPendingAtom)).toBe(false);
+            expect(store.get(retryPendingRunIdAtom)).toBeNull();
+            expect(store.get(wsErrorAtom)).toBeNull();
+            // The removal is committed server-side, so the chat the user left
+            // is not the one they left — they are told rather than left to
+            // find a thread that quietly lost a turn.
+            expect(popupTitles()).toContain('Retry not sent');
+        });
+
+        it('abandons the restart when the chat changes during the annotation cleanup', async () => {
+            // The cleanup is the last await before the writes, so a guard that
+            // only covers the POST leaves this window open.
+            store.set(threadRunsAtom, [makeRun('a')]);
+            store.set(activeRunAtom, makeRun('failed', { status: 'error' }));
+            store.set(citationsAtom, [{ run_id: 'failed' } as any]);
+            truncateMock.mockResolvedValue(okReport(['failed']));
+            cleanupAnnotationsMock.mockImplementation(async () => {
+                beginNavigation();
+            });
+
+            await store.set(autoRetryErroredRunAtom, 'failed');
+
+            expect(truncateMock).toHaveBeenCalledWith('thread-1', ['failed'], 'a');
+            expect(cleanupAnnotationsMock).toHaveBeenCalled();
+            expect(connectMock).not.toHaveBeenCalled();
+            expect(threadRunIds()).toEqual(['a', 'failed']);
+            expect(store.get(citationsAtom)).toHaveLength(1);
+            expect(store.get(isWSChatPendingAtom)).toBe(false);
+            expect(store.get(retryPendingRunIdAtom)).toBeNull();
+            expect(popupTitles()).toContain('Retry not sent');
+        });
+
+        it('abandons a new-thread restart when the chat changes, its only await', async () => {
+            // No thread means no POST, so the cleanup is the only window —
+            // and the only guard covering it.
+            store.set(currentThreadIdAtom, null);
+            store.set(threadRunsAtom, []);
+            store.set(activeRunAtom, makeRun('failed', { status: 'error', thread_id: null as any }));
+            cleanupAnnotationsMock.mockImplementation(async () => {
+                beginNavigation();
+            });
+
+            await store.set(autoRetryErroredRunAtom, 'failed');
+
+            expect(truncateMock).not.toHaveBeenCalled();
+            expect(connectMock).not.toHaveBeenCalled();
+            expect(threadRunIds()).toEqual(['failed']);
+            expect(store.get(isWSChatPendingAtom)).toBe(false);
+            expect(store.get(retryPendingRunIdAtom)).toBeNull();
+        });
+
         it('a refusal reloads the thread instead of raising a retry error', async () => {
             // The auto-retry raced a rewrite from another client. There is no
             // user decision to retry against unseen history — the UI must
@@ -397,7 +648,7 @@ describe('retry via synchronous truncation', () => {
 
             expect(connectMock).not.toHaveBeenCalled();
             expect(store.get(wsErrorAtom)).toBeNull();
-            expect(store.get(popupMessagesAtom).some(m => m.title === 'Chat changed elsewhere')).toBe(true);
+            expect(popupTitles()).toContain('Chat changed elsewhere');
             expect(loadThreadRunsMock).toHaveBeenCalledWith('thread-1', expect.anything());
             expect(store.get(isWSChatPendingAtom)).toBe(false);
             expect(store.get(retryPendingRunIdAtom)).toBeNull();


### PR DESCRIPTION
- Introduced `threadNavigationSeqAtom` to track chat navigations, ensuring that ongoing work is abandoned when switching chats.
- Updated `abandonReplacementIfThreadChanged` function to manage retries more effectively during chat transitions.
- Enhanced `AgentRunView` and `ModelMessagesView` components to reflect changes in retry status and navigation state.
- Added unit tests to validate the new navigation sequence logic and its impact on retry behavior.