### PR TITLE
feat(caretNavigation): add focus and caret rectangle utilities for im…

### DIFF
--- a/packages/agent-ui/src/composer/LexicalEditorInput.tsx
+++ b/packages/agent-ui/src/composer/LexicalEditorInput.tsx
@@ -51,7 +51,7 @@ import {
     registerImeTrace,
     type ImeCompositionTracker,
 } from './imeComposition';
-import { collapsesToRangeEnd } from './caretNavigation';
+import { collapsesToRangeEnd, getFocusRect } from './caretNavigation';
 import { SlashCommandHoverCardPlugin } from './SlashCommandHoverCardPlugin';
 import {
     $getFlatSelectionOffsets,
@@ -193,37 +193,6 @@ function getDomFlatSelectionOffsets(root: HTMLElement, sel: Selection): { anchor
     }
     if (anchor === null || focus === null) return null;
     return { anchor, focus };
-}
-
-/** Client rect of the selection's moving edge (its focus point). A collapsed
- *  range has no client rect at some node boundaries, so widen it by one
- *  character before falling back to the containing element's box. */
-function getFocusRect(sel: Selection): DOMRect | null {
-    const node = sel.focusNode;
-    const doc = node?.ownerDocument;
-    if (!node || !doc) return null;
-    const offset = sel.focusOffset;
-    const range = doc.createRange();
-    try {
-        range.setStart(node, offset);
-        range.setEnd(node, offset);
-    } catch {
-        return null;
-    }
-    let rect: DOMRect | null = range.getClientRects()?.[0] ?? null;
-    if (!rect && node.nodeType === Node.TEXT_NODE) {
-        const length = (node as Text).length;
-        try {
-            if (offset < length) range.setEnd(node, offset + 1);
-            else if (offset > 0) range.setStart(node, offset - 1);
-            rect = range.getClientRects()?.[0] ?? null;
-        } catch { /* the offsets may not be addressable */ }
-    }
-    if (!rect) {
-        const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
-        rect = el?.getBoundingClientRect() ?? null;
-    }
-    return rect;
 }
 
 /** Scroll the caret (the selection's moving edge) back into view inside the

--- a/packages/agent-ui/src/composer/caretNavigation.ts
+++ b/packages/agent-ui/src/composer/caretNavigation.ts
@@ -24,3 +24,42 @@ export function collapsesToRangeEnd(key: string): boolean {
             return true;
     }
 }
+
+/** Client rect of a DOM selection's moving edge (its focus point). A collapsed
+ *  range has no client rect at some node boundaries, so widen it by one
+ *  character before falling back to the containing element's box. */
+export function getFocusRect(sel: Selection): DOMRect | null {
+    const node = sel.focusNode;
+    const doc = node?.ownerDocument;
+    if (!node || !doc) return null;
+    const offset = sel.focusOffset;
+    const range = doc.createRange();
+    try {
+        range.setStart(node, offset);
+        range.setEnd(node, offset);
+    } catch {
+        return null;
+    }
+    let rect: DOMRect | null = range.getClientRects?.()?.[0] ?? null;
+    if (!rect && node.nodeType === Node.TEXT_NODE) {
+        const length = (node as Text).length;
+        try {
+            if (offset < length) range.setEnd(node, offset + 1);
+            else if (offset > 0) range.setStart(node, offset - 1);
+            rect = range.getClientRects?.()?.[0] ?? null;
+        } catch { /* the offsets may not be addressable */ }
+    }
+    if (!rect) {
+        const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+        rect = el?.getBoundingClientRect() ?? null;
+    }
+    return rect;
+}
+
+/** Client rect of the caret inside `root`, or null when the document's
+ *  selection is somewhere else entirely (another editor, another element). */
+export function getCaretRectWithin(root: HTMLElement): DOMRect | null {
+    const sel = root.ownerDocument.defaultView?.getSelection();
+    if (!sel || !sel.focusNode || !root.contains(sel.focusNode)) return null;
+    return getFocusRect(sel);
+}

--- a/packages/agent-ui/src/composer/useAddSourcesMenu.ts
+++ b/packages/agent-ui/src/composer/useAddSourcesMenu.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { MenuPosition, SearchMenuCloseReason } from '../primitives/SearchMenu';
+import { getCaretRectWithin } from './caretNavigation';
 
 /** The character that opens the Add Sources menu from the chat editor. */
 const TRIGGER = '@';
@@ -169,12 +170,25 @@ export function useAddSourcesMenu({
         updateQuery(value);
     }, [updateQuery]);
 
-    /** Detect a typed `@` trigger. Returns true when the menu opened. */
-    const handleTrigger = useCallback((value: string, rect: DOMRect): boolean => {
+    /**
+     * Detect a typed `@` trigger. Returns true when the menu opened.
+     *
+     * `editorRoot` is the editor's contenteditable. The menu clears the whole
+     * composer vertically (it can be several lines tall), but is anchored
+     * horizontally on the caret, so in a wide composer it opens at the `@` the
+     * user just typed rather than at the far-away left edge. Falls back to that
+     * edge when the caret has no measurable rect.
+     */
+    const handleTrigger = useCallback((value: string, editorRoot: HTMLElement): boolean => {
         const match = matchSourcesTrigger(value);
         if (!match) return false;
+        const rect = editorRoot.getBoundingClientRect();
+        const caretRect = getCaretRectWithin(editorRoot);
+        const x = caretRect
+            ? Math.min(Math.max(caretRect.left, rect.left), rect.right)
+            : rect.left;
         const y = verticalPosition === 'above' ? rect.top - 5 : rect.bottom - 10;
-        open('editor', { prefix: match.prefix }, { x: rect.left, y });
+        open('editor', { prefix: match.prefix }, { x, y });
         setMessageContent(value);
         return true;
     }, [open, setMessageContent, verticalPosition]);

--- a/react/components/agentRuns/UserRequestView.tsx
+++ b/react/components/agentRuns/UserRequestView.tsx
@@ -443,7 +443,7 @@ export const UserRequestView: React.FC<UserRequestViewProps> = ({
             queueCaretToEnd(value.length);
             return;
         }
-        if (requestSourcesMenu && inputEl && handleAddSourcesTrigger(value, inputEl.getBoundingClientRect())) {
+        if (requestSourcesMenu && inputEl && handleAddSourcesTrigger(value, inputEl)) {
             queueCaretToEnd(value.length);
             return;
         }

--- a/react/components/input/InputArea.tsx
+++ b/react/components/input/InputArea.tsx
@@ -336,7 +336,7 @@ const InputArea: React.FC<InputAreaProps> = ({
             inputEl &&
             !isAwaitingApproval &&
             !hideAttachmentMenu &&
-            handleAddSourcesTrigger(value, inputEl.getBoundingClientRect())
+            handleAddSourcesTrigger(value, inputEl)
         ) {
             queueSelectionRestore(value.length, false);
             return;

--- a/tests/unit/hooks/useAddSourcesMenu.test.ts
+++ b/tests/unit/hooks/useAddSourcesMenu.test.ts
@@ -7,7 +7,18 @@ import { useAddSourcesMenu, AddSourcesMenuHandle } from '@beaver/agent-ui/compos
 
 type Hook = ReturnType<typeof useAddSourcesMenu>;
 
-const RECT = { left: 40, top: 200, bottom: 260 } as DOMRect;
+const RECT = { left: 40, right: 340, top: 200, bottom: 260 } as DOMRect;
+
+/** Stands in for the editor's contenteditable, which the hook measures to
+ *  place the menu. jsdom reports no caret rect, so the fallback (the editor's
+ *  own left edge) applies. */
+function editorElement(): HTMLElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => RECT;
+    return el;
+}
+
+const EDITOR = editorElement();
 
 /**
  * Renders the hook and exposes its latest return value, plus the editor seams
@@ -76,7 +87,7 @@ describe('useAddSourcesMenu', () => {
     describe('opening from a typed @', () => {
         it('opens when the @ starts a word, with the editor as its search box', () => {
             harness = mount();
-            expect(harness.run(h => h.handleTrigger('find @', RECT))).toBe(true);
+            expect(harness.run(h => h.handleTrigger('find @', EDITOR))).toBe(true);
             expect(harness.hook.isOpen).toBe(true);
             expect(harness.hook.query).toBe('');
             expect(harness.hook.querySource).toBe('editor');
@@ -84,19 +95,43 @@ describe('useAddSourcesMenu', () => {
 
         it('opens when the @ is the first character', () => {
             harness = mount();
-            expect(harness.run(h => h.handleTrigger('@', RECT))).toBe(true);
+            expect(harness.run(h => h.handleTrigger('@', EDITOR))).toBe(true);
             expect(harness.hook.isOpen).toBe(true);
         });
 
         it('leaves an @ inside a word alone', () => {
             harness = mount();
-            expect(harness.run(h => h.handleTrigger('joscha@', RECT))).toBe(false);
+            expect(harness.run(h => h.handleTrigger('joscha@', EDITOR))).toBe(false);
             expect(harness.hook.isOpen).toBe(false);
+        });
+
+        it('opens at the caret rather than the composer\'s left edge', () => {
+            // A wide composer whose text ends far to the right: the menu
+            // belongs under the `@`, not under the editor's left edge.
+            const editor = editorElement();
+            const line = document.createElement('span');
+            const text = document.createTextNode('a long line ending far right @');
+            line.appendChild(text);
+            line.getBoundingClientRect = () => ({ left: 280, top: 210, bottom: 230 } as DOMRect);
+            editor.appendChild(line);
+            document.body.appendChild(editor);
+            document.getSelection()!.collapse(text, text.length);
+
+            harness = mount();
+            harness.run(h => h.handleTrigger('a long line ending far right @', editor));
+            expect(harness.hook.position.x).toBe(280);
+            editor.remove();
+        });
+
+        it('falls back to the composer\'s left edge when the caret has no rect', () => {
+            harness = mount();
+            harness.run(h => h.handleTrigger('find @', EDITOR));
+            expect(harness.hook.position.x).toBe(40);
         });
 
         it('keeps the typed @ in the editor content', () => {
             harness = mount();
-            harness.run(h => h.handleTrigger('find @', RECT));
+            harness.run(h => h.handleTrigger('find @', EDITOR));
             expect(harness.contentRef.current).toBe('find @');
             expect(harness.deleted).toEqual([]);
         });
@@ -105,7 +140,7 @@ describe('useAddSourcesMenu', () => {
     describe('typing the query', () => {
         beforeEach(() => {
             harness = mount();
-            harness.run(h => h.handleTrigger('find @', RECT));
+            harness.run(h => h.handleTrigger('find @', EDITOR));
         });
 
         it('treats everything after the @ as the query', () => {
@@ -144,7 +179,7 @@ describe('useAddSourcesMenu', () => {
     describe('closing', () => {
         beforeEach(() => {
             harness = mount();
-            harness.run(h => h.handleTrigger('find @', RECT));
+            harness.run(h => h.handleTrigger('find @', EDITOR));
         });
 
         it('closes on a space typed as the first query character', () => {
@@ -209,7 +244,7 @@ describe('useAddSourcesMenu', () => {
         it('steps back out of a submenu on an empty-query Backspace', () => {
             const goBack = vi.fn(() => true);
             harness = mount({ goBack });
-            harness.run(h => h.handleTrigger('@', RECT));
+            harness.run(h => h.handleTrigger('@', EDITOR));
             const { event, prevented } = keyEvent('Backspace');
             expect(harness.run(h => h.handleKeyDown(event))).toBe(true);
             expect(goBack).toHaveBeenCalled();
@@ -220,7 +255,7 @@ describe('useAddSourcesMenu', () => {
         it('lets Backspace delete the @ when there is no submenu to leave', () => {
             const goBack = vi.fn(() => false);
             harness = mount({ goBack });
-            harness.run(h => h.handleTrigger('@', RECT));
+            harness.run(h => h.handleTrigger('@', EDITOR));
             const { event, prevented } = keyEvent('Backspace');
             expect(harness.run(h => h.handleKeyDown(event))).toBe(false);
             expect(prevented.value).toBe(false);
@@ -228,7 +263,7 @@ describe('useAddSourcesMenu', () => {
 
         it('drops the typed query from the editor when entering a submenu', () => {
             harness = mount();
-            harness.run(h => h.handleTrigger('@', RECT));
+            harness.run(h => h.handleTrigger('@', EDITOR));
             harness.run(h => h.handleChange('@lib'));
             harness.run(h => h.resetQuery());
             expect(harness.deleted).toEqual(['lib'.length]);


### PR DESCRIPTION
…proved selection handling

- Introduced `getFocusRect` to calculate the client rect of a selection's focus point, accommodating collapsed ranges and ensuring accurate positioning.
- Added `getCaretRectWithin` to retrieve the caret's position within a specified root element, enhancing the editor's ability to manage caret visibility and menu positioning.
- Updated `LexicalEditorInput` and `useAddSourcesMenu` to utilize the new caret rectangle utilities, improving the user experience when interacting with the editor.

These changes enhance the functionality of the editor by providing precise caret positioning, which is crucial for user interactions involving selections and menus.