### PR TITLE
feat(citations): support alternate item activation on Shift-click

### DIFF
--- a/packages/agent-ui/src/chat/Citation.tsx
+++ b/packages/agent-ui/src/chat/Citation.tsx
@@ -11,7 +11,7 @@ import { pageLabelsByAttachmentIdAtom, externalFileLocalPathsAtom } from '@beave
 import { useCitationMarker } from './useCitationMarker';
 import { getHost } from '../host';
 import { useCitationViewModel } from './useCitationViewModel';
-import { useAlternateActivation } from './useAlternateActivation';
+import { hasAlternateModifier, useAlternateActivation } from './useAlternateActivation';
 import { Icon, LibraryIcon, PdfIcon, FileIcon, GlobalSearchIcon, NoteIcon, HighlighterIcon, TextAlignLeftIcon, ExternalLinkIcon } from '../icons';
 const TOOLTIP_WIDTH = '250px';
 
@@ -107,7 +107,6 @@ const Citation: React.FC<CitationProps> = (props) => {
     const numericMarker = useCitationMarker(markerKey, exportRendering);
 
     // Whether the alternate-activation modifier is held over this citation.
-    // See `useAlternateActivation` for why it is Shift.
     const { isAlternate, hoverProps } = useAlternateActivation();
 
     // Render as soon as we have an identifier; citationMetadata may arrive later.
@@ -132,7 +131,9 @@ const Citation: React.FC<CitationProps> = (props) => {
             metadata: citationMetadata,
             // Read the modifier off the click rather than the hover state, so
             // the action always matches the key that was actually held down.
-            intent: (e.shiftKey && canRevealItem) ? 'item' : 'passage',
+            intent: (canRevealItem && hasAlternateModifier(e, e.currentTarget.ownerDocument.defaultView?.navigator))
+                ? 'item'
+                : 'passage',
             isExternal,
             isExternalFile,
             externalFileKey,

--- a/packages/agent-ui/src/chat/Citation.tsx
+++ b/packages/agent-ui/src/chat/Citation.tsx
@@ -106,46 +106,13 @@ const Citation: React.FC<CitationProps> = (props) => {
     // Uses markerKey (without sid/page) so all citations to the same item share a marker
     const numericMarker = useCitationMarker(markerKey, exportRendering);
 
-    // Whether the alternate-activation modifier is held over this citation.
-    const { isAlternate, hoverProps } = useAlternateActivation();
+    // Whether the alternate-activation modifier is being held. Document-wide, so
+    // every citation flips together and the hold reads as a mode.
+    const { isAlternate, ref: citationRef } = useAlternateActivation();
 
     // Render as soon as we have an identifier; citationMetadata may arrive later.
     // 'error' state means no valid identifier was found - don't render.
     if (displayState === 'error') return null;
-
-    // Alternate activation acts on the cited work rather than the cited passage.
-    // It is only offered where there is a work to reveal: an unmapped external
-    // reference and an external file have no library item behind them.
-    const canRevealItem = !isExternalFile
-        && (!isExternal || !!mappedZoteroItem)
-        && !!effectiveItemKey;
-    const showItemInfo = isAlternate && canRevealItem;
-
-    // Click handler — delegates all client-specific navigation to the host.
-    // The streaming/invalid states don't attach this handler (see below), so it
-    // only runs for "ready" citations where metadata is present.
-    const handleClick = (e: React.MouseEvent) => {
-        e.preventDefault();
-        if (!citationMetadata) return;
-        getHost().navigation?.activateCitation({
-            metadata: citationMetadata,
-            // Read the modifier off the click rather than the hover state, so
-            // the action always matches the key that was actually held down.
-            intent: (canRevealItem && hasAlternateModifier(e, e.currentTarget.ownerDocument.defaultView?.navigator))
-                ? 'item'
-                : 'passage',
-            isExternal,
-            isExternalFile,
-            externalFileKey,
-            externalSourceId,
-            hasMappedItem: !!mappedZoteroItem,
-            effectiveLibraryID,
-            effectiveItemKey,
-            effectiveLibraryRef,
-            previewText,
-            ownerDocument: e.currentTarget.ownerDocument,
-        });
-    };
 
     // Format for display
     let displayText = '';
@@ -254,9 +221,58 @@ const Citation: React.FC<CitationProps> = (props) => {
     // synthetic page that must not be presented as a PDF page locator.
     const hasLocator = !isNoteCitation && !isAnnotationCitation && !isSnapshotCitation
         && (pages.length > 0 || hasBoundingBoxes || hasEpubSymbolicLocator);
+    // Alternate activation acts on the cited work rather than the cited passage.
+    // It stays inert wherever it would change nothing: an unmapped external
+    // reference and an external file have no library item behind them; a
+    // streaming or invalid citation has no click at all; and a plain
+    // locator-less item is already revealed in the library by an ordinary
+    // click. What is left is exactly the set whose click it redirects.
+    const defaultRevealsItem = !hasLocator
+        && !isSnapshotCitation
+        && !isTextCitation
+        && !isNoteCitation
+        && !isAnnotationCitation;
+    const canRevealItem = !isExternalFile
+        && (!isExternal || !!mappedZoteroItem)
+        && !!effectiveItemKey
+        && !isStreaming
+        && !isInvalid
+        && !defaultRevealsItem;
+    const showItemInfo = isAlternate && canRevealItem;
+
+    // Click handler — delegates all client-specific navigation to the host.
+    // The streaming/invalid states don't attach this handler (see below), so it
+    // only runs for "ready" citations where metadata is present.
+    const handleClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        if (!citationMetadata) return;
+        getHost().navigation?.activateCitation({
+            metadata: citationMetadata,
+            // Read the modifier off the click rather than the hover state, so
+            // the action always matches the key that was actually held down.
+            intent: (canRevealItem && hasAlternateModifier(e, e.currentTarget.ownerDocument.defaultView?.navigator))
+                ? 'item'
+                : 'passage',
+            isExternal,
+            isExternalFile,
+            externalFileKey,
+            externalSourceId,
+            hasMappedItem: !!mappedZoteroItem,
+            effectiveLibraryID,
+            effectiveItemKey,
+            effectiveLibraryRef,
+            previewText,
+            ownerDocument: e.currentTarget.ownerDocument,
+        });
+    };
+
+    // The locator style promises navigation to a place inside the document.
+    // While the modifier is held the click reveals the work instead, so the
+    // marker drops to the plain style — which is already exactly how a citation
+    // whose click reveals its item is drawn.
     const citationClassBase = isExternal && !mappedZoteroItem
         ? "zotero-citation external-citation"
-        : (hasLocator || isAnnotationCitation || hasSnapshotSymbolicLocator) && !isExternalFile
+        : (hasLocator || isAnnotationCitation || hasSnapshotSymbolicLocator) && !isExternalFile && !showItemInfo
         ? "zotero-citation with-locator"
         : "zotero-citation";
     const citationClass = isStreaming
@@ -273,8 +289,8 @@ const Citation: React.FC<CitationProps> = (props) => {
 
     const citationElement = (
         <span 
+            ref={citationRef}
             onClick={(isStreaming || isInvalid) ? undefined : handleClick}
-            {...hoverProps}
             className={citationClass}
             data-pages={pages}
             data-item-key={itemKey}

--- a/packages/agent-ui/src/chat/Citation.tsx
+++ b/packages/agent-ui/src/chat/Citation.tsx
@@ -11,6 +11,7 @@ import { pageLabelsByAttachmentIdAtom, externalFileLocalPathsAtom } from '@beave
 import { useCitationMarker } from './useCitationMarker';
 import { getHost } from '../host';
 import { useCitationViewModel } from './useCitationViewModel';
+import { useAlternateActivation } from './useAlternateActivation';
 import { Icon, LibraryIcon, PdfIcon, FileIcon, GlobalSearchIcon, NoteIcon, HighlighterIcon, TextAlignLeftIcon, ExternalLinkIcon } from '../icons';
 const TOOLTIP_WIDTH = '250px';
 
@@ -82,6 +83,7 @@ const Citation: React.FC<CitationProps> = (props) => {
         effectiveLibraryRef,
         consecutive,
         citation,
+        formatted_citation,
         previewText,
         pagesDisplay,
         pages,
@@ -104,9 +106,21 @@ const Citation: React.FC<CitationProps> = (props) => {
     // Uses markerKey (without sid/page) so all citations to the same item share a marker
     const numericMarker = useCitationMarker(markerKey, exportRendering);
 
+    // Whether the alternate-activation modifier is held over this citation.
+    // See `useAlternateActivation` for why it is Shift.
+    const { isAlternate, hoverProps } = useAlternateActivation();
+
     // Render as soon as we have an identifier; citationMetadata may arrive later.
     // 'error' state means no valid identifier was found - don't render.
     if (displayState === 'error') return null;
+
+    // Alternate activation acts on the cited work rather than the cited passage.
+    // It is only offered where there is a work to reveal: an unmapped external
+    // reference and an external file have no library item behind them.
+    const canRevealItem = !isExternalFile
+        && (!isExternal || !!mappedZoteroItem)
+        && !!effectiveItemKey;
+    const showItemInfo = isAlternate && canRevealItem;
 
     // Click handler — delegates all client-specific navigation to the host.
     // The streaming/invalid states don't attach this handler (see below), so it
@@ -116,6 +130,9 @@ const Citation: React.FC<CitationProps> = (props) => {
         if (!citationMetadata) return;
         getHost().navigation?.activateCitation({
             metadata: citationMetadata,
+            // Read the modifier off the click rather than the hover state, so
+            // the action always matches the key that was actually held down.
+            intent: (e.shiftKey && canRevealItem) ? 'item' : 'passage',
             isExternal,
             isExternalFile,
             externalFileKey,
@@ -247,10 +264,16 @@ const Citation: React.FC<CitationProps> = (props) => {
         ? `${citationClassBase} invalid`
         : citationClassBase;
     const showPreviewText = previewText && previewText !== citation;
+    // Body of the alternate ("item") hover state: the full bibliographic
+    // reference. Suppressed when it would only repeat the header.
+    const itemInfoText = formatted_citation && formatted_citation !== citation
+        ? formatted_citation
+        : '';
 
     const citationElement = (
         <span 
             onClick={(isStreaming || isInvalid) ? undefined : handleClick}
+            {...hoverProps}
             className={citationClass}
             data-pages={pages}
             data-item-key={itemKey}
@@ -267,12 +290,12 @@ const Citation: React.FC<CitationProps> = (props) => {
                     {citation}
                 </span>
                 <span className="flex-1" />
-                {hasLocatorDisplay && (
+                {!showItemInfo && hasLocatorDisplay && (
                     <span className="font-color-secondary text-sm" style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>
                         {`Page ${pagesDisplay}`}
                     </span>
                 )}
-                {(!pages || pages.length === 0) && textLineLocation && (
+                {!showItemInfo && (!pages || pages.length === 0) && textLineLocation && (
                     <span className="font-color-secondary text-sm" style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>
                         {textLineLocation.line_end && textLineLocation.line_end !== textLineLocation.line
                             ? `Lines ${textLineLocation.line}–${textLineLocation.line_end}`
@@ -280,94 +303,114 @@ const Citation: React.FC<CitationProps> = (props) => {
                     </span>
                 )}
             </span>
-            {showPreviewText && (
-                <span className="font-color-secondary text-sm px-3 py-15 block" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }}>
-                    {previewText}
-                </span>
-            )}
-            {isExternal && !mappedZoteroItem && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={GlobalSearchIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            View details
+            {showItemInfo ? (
+                <>
+                    {itemInfoText && (
+                        <span className="font-color-secondary text-sm px-3 py-15 block" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
+                            {itemInfoText}
+                        </span>
+                    )}
+                    <span className={`px-3 py-15 block ${itemInfoText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={LibraryIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                Reveals item in library
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {isExternalFile && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={ExternalLinkIcon} className="font-color-secondary scale-90" />
-                        <span className="text-sm font-color-secondary">
-                            Opens external file
+                </>
+            ) : (
+                <>
+                {showPreviewText && (
+                    <span className="font-color-secondary text-sm px-3 py-15 block" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }}>
+                        {previewText}
+                    </span>
+                )}
+                {isExternal && !mappedZoteroItem && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={GlobalSearchIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                View details
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {isNoteCitation && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={NoteIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            Opens note
+                )}
+                {isExternalFile && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={ExternalLinkIcon} className="font-color-secondary scale-90" />
+                            <span className="text-sm font-color-secondary">
+                                Opens external file
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {isAnnotationCitation && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={HighlighterIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            Opens annotation in PDF
+                )}
+                {isNoteCitation && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={NoteIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                Opens note
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {hasLocator && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={PdfIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            {isEpubCitation
-                                ? (hasLocatorDisplay ? `Opens EPUB at page ${pagesDisplay}` : 'Opens EPUB at location')
-                                : hasBoundingBoxes
-                                    ? (hasLocatorDisplay ? `Highlights passage on page ${pagesDisplay}` : 'Highlights passage in PDF')
-                                    : (hasLocatorDisplay ? `Opens PDF on page ${pagesDisplay}` : 'Opens PDF at location')}
+                )}
+                {isAnnotationCitation && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={HighlighterIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                Opens annotation in PDF
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {isTextCitation && !isExternalFile && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={TextAlignLeftIcon} className="font-color-secondary scale-90" />
-                        <span className="text-sm font-color-secondary">
-                            Opens text file (external application)
+                )}
+                {hasLocator && !isExternalFile && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={PdfIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                {isEpubCitation
+                                    ? (hasLocatorDisplay ? `Opens EPUB at page ${pagesDisplay}` : 'Opens EPUB at location')
+                                    : hasBoundingBoxes
+                                        ? (hasLocatorDisplay ? `Highlights passage on page ${pagesDisplay}` : 'Highlights passage in PDF')
+                                        : (hasLocatorDisplay ? `Opens PDF on page ${pagesDisplay}` : 'Opens PDF at location')}
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {isSnapshotCitation && !isExternalFile && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={FileIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            {hasSnapshotSymbolicLocator ? 'Opens Snapshot at location' : 'Opens Snapshot'}
+                )}
+                {isTextCitation && !isExternalFile && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={TextAlignLeftIcon} className="font-color-secondary scale-90" />
+                            <span className="text-sm font-color-secondary">
+                                Opens text file (external application)
+                            </span>
                         </span>
                     </span>
-                </span>
-            )}
-            {!hasLocator && !isSnapshotCitation && !isExternalFile && !isTextCitation && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
-                <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
-                    <span className="display-flex flex-row items-center gap-15">
-                        <Icon icon={LibraryIcon} className="font-color-secondary" />
-                        <span className="text-sm font-color-secondary">
-                            Reveals item in library
+                )}
+                {isSnapshotCitation && !isExternalFile && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={FileIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                {hasSnapshotSymbolicLocator ? 'Opens Snapshot at location' : 'Opens Snapshot'}
+                            </span>
                         </span>
                     </span>
-                </span>
+                )}
+                {!hasLocator && !isSnapshotCitation && !isExternalFile && !isTextCitation && !isNoteCitation && !isAnnotationCitation && (!isExternal || !!mappedZoteroItem) && (
+                    <span className={`px-3 py-15 block ${showPreviewText ? 'border-top-quinary' : ''}`}>
+                        <span className="display-flex flex-row items-center gap-15">
+                            <Icon icon={LibraryIcon} className="font-color-secondary" />
+                            <span className="text-sm font-color-secondary">
+                                Reveals item in library
+                            </span>
+                        </span>
+                    </span>
+                )}
+                </>
             )}
         </span>
     )
@@ -396,6 +439,7 @@ const Citation: React.FC<CitationProps> = (props) => {
                     <Tooltip
                         content={previewText}
                         customContent={citationPreview}
+                        contentKey={showItemInfo ? 'item' : 'passage'}
                         width={TOOLTIP_WIDTH}
                         padding={false}
                     >

--- a/packages/agent-ui/src/chat/index.ts
+++ b/packages/agent-ui/src/chat/index.ts
@@ -14,7 +14,7 @@ export type { CitationDisplayState, CitationViewModel } from './useCitationViewM
 
 export { useCitationMarker } from './useCitationMarker';
 
-export { useAlternateActivation } from './useAlternateActivation';
+export { hasAlternateModifier, useAlternateActivation } from './useAlternateActivation';
 export type { AlternateActivation } from './useAlternateActivation';
 
 export { default as ChipWithPopup, ChipPopupCard, ChipWithListPopup } from './ChipPopup';

--- a/packages/agent-ui/src/chat/index.ts
+++ b/packages/agent-ui/src/chat/index.ts
@@ -14,6 +14,9 @@ export type { CitationDisplayState, CitationViewModel } from './useCitationViewM
 
 export { useCitationMarker } from './useCitationMarker';
 
+export { useAlternateActivation } from './useAlternateActivation';
+export type { AlternateActivation } from './useAlternateActivation';
+
 export { default as ChipWithPopup, ChipPopupCard, ChipWithListPopup } from './ChipPopup';
 export type {
     ChipPopupAction,

--- a/packages/agent-ui/src/chat/useAlternateActivation.ts
+++ b/packages/agent-ui/src/chat/useAlternateActivation.ts
@@ -1,5 +1,31 @@
 import { useEffect, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
+import { isMacPlatform } from '../utils/platform';
+
+/**
+ * Whether an event carries the alternate-activation modifier: the platform
+ * accelerator, Cmd on macOS and Ctrl everywhere else.
+ *
+ * It has to be the accelerator rather than Shift or Alt, because a citation sits
+ * inside selectable prose in a chrome document:
+ *
+ * - Shift-click extends the text selection. That happens on *mousedown*, so a
+ *   `preventDefault()` on the click cannot undo it — the user gets a selection
+ *   and an activation at once.
+ * - A bare Alt keydown activates Gecko's menu bar on Windows and Linux, which
+ *   would fire while the user is merely hovering.
+ *
+ * Neither accelerator chord has a default action over a plain `<span>`, and
+ * mapping macOS to Cmd keeps Ctrl-click free for the context menu there.
+ *
+ * @param navigator - The navigator of the window the event was delivered to
+ */
+export function hasAlternateModifier(
+    event: { metaKey: boolean; ctrlKey: boolean },
+    navigator: Navigator | undefined | null,
+): boolean {
+    return navigator && isMacPlatform(navigator) ? event.metaKey : event.ctrlKey;
+}
 
 /**
  * Tracks whether the alternate-activation modifier is held while the pointer is
@@ -10,10 +36,7 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
  * modifier acts on the work. The hover preview and the click handler both need
  * to agree on which one is currently selected, so the state lives here.
  *
- * Shift is the modifier because it is the only one that is inert on its own in
- * every host: a bare Alt keydown activates Gecko's menu bar on Windows and
- * Linux, and Ctrl-click is the context-menu gesture on macOS — either would
- * fire while the user is merely hovering.
+ * See {@link hasAlternateModifier} for which key that is and why.
  *
  * Key listeners are attached only while hovering, and on the document the
  * pointer actually entered, so a citation rendered in a second window tracks
@@ -36,7 +59,8 @@ export function useAlternateActivation(): AlternateActivation {
     useEffect(() => {
         if (!hoveredDocument) return;
 
-        const sync = (event: KeyboardEvent) => setIsAlternate(event.shiftKey);
+        const win = hoveredDocument.defaultView;
+        const sync = (event: KeyboardEvent) => setIsAlternate(hasAlternateModifier(event, win?.navigator));
         const clear = () => setIsAlternate(false);
 
         // Capture phase: a citation can render inside surfaces that stop key
@@ -45,7 +69,7 @@ export function useAlternateActivation(): AlternateActivation {
         hoveredDocument.addEventListener('keyup', sync, true);
         // Focus can leave the window while the key is still down, in which case
         // the keyup is delivered elsewhere and the state would stay stuck on.
-        const win = hoveredDocument.defaultView;
+        // On macOS that includes Cmd-Tab, which is exactly this chord.
         win?.addEventListener('blur', clear);
 
         return () => {
@@ -59,9 +83,10 @@ export function useAlternateActivation(): AlternateActivation {
         isAlternate,
         hoverProps: {
             onMouseEnter: (event: ReactMouseEvent) => {
+                const doc = event.currentTarget.ownerDocument;
                 // The modifier may already be held when the pointer arrives.
-                setIsAlternate(event.shiftKey);
-                setHoveredDocument(event.currentTarget.ownerDocument);
+                setIsAlternate(hasAlternateModifier(event, doc.defaultView?.navigator));
+                setHoveredDocument(doc);
             },
             onMouseLeave: () => {
                 setIsAlternate(false);

--- a/packages/agent-ui/src/chat/useAlternateActivation.ts
+++ b/packages/agent-ui/src/chat/useAlternateActivation.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+/**
+ * Tracks whether the alternate-activation modifier is held while the pointer is
+ * over an element.
+ *
+ * A citation names two things at once: the passage it cites and the work the
+ * passage comes from. The default hover/click acts on the passage; holding the
+ * modifier acts on the work. The hover preview and the click handler both need
+ * to agree on which one is currently selected, so the state lives here.
+ *
+ * Shift is the modifier because it is the only one that is inert on its own in
+ * every host: a bare Alt keydown activates Gecko's menu bar on Windows and
+ * Linux, and Ctrl-click is the context-menu gesture on macOS — either would
+ * fire while the user is merely hovering.
+ *
+ * Key listeners are attached only while hovering, and on the document the
+ * pointer actually entered, so a citation rendered in a second window tracks
+ * that window's keyboard rather than another one's.
+ */
+export interface AlternateActivation {
+    /** Whether the modifier is currently held over the tracked element. */
+    isAlternate: boolean;
+    /** Spread onto the element whose hover should be tracked. */
+    hoverProps: {
+        onMouseEnter: (event: ReactMouseEvent) => void;
+        onMouseLeave: () => void;
+    };
+}
+
+export function useAlternateActivation(): AlternateActivation {
+    const [hoveredDocument, setHoveredDocument] = useState<Document | null>(null);
+    const [isAlternate, setIsAlternate] = useState(false);
+
+    useEffect(() => {
+        if (!hoveredDocument) return;
+
+        const sync = (event: KeyboardEvent) => setIsAlternate(event.shiftKey);
+        const clear = () => setIsAlternate(false);
+
+        // Capture phase: a citation can render inside surfaces that stop key
+        // events on their way up (the composer, the reader).
+        hoveredDocument.addEventListener('keydown', sync, true);
+        hoveredDocument.addEventListener('keyup', sync, true);
+        // Focus can leave the window while the key is still down, in which case
+        // the keyup is delivered elsewhere and the state would stay stuck on.
+        const win = hoveredDocument.defaultView;
+        win?.addEventListener('blur', clear);
+
+        return () => {
+            hoveredDocument.removeEventListener('keydown', sync, true);
+            hoveredDocument.removeEventListener('keyup', sync, true);
+            win?.removeEventListener('blur', clear);
+        };
+    }, [hoveredDocument]);
+
+    return {
+        isAlternate,
+        hoverProps: {
+            onMouseEnter: (event: ReactMouseEvent) => {
+                // The modifier may already be held when the pointer arrives.
+                setIsAlternate(event.shiftKey);
+                setHoveredDocument(event.currentTarget.ownerDocument);
+            },
+            onMouseLeave: () => {
+                setIsAlternate(false);
+                setHoveredDocument(null);
+            },
+        },
+    };
+}

--- a/packages/agent-ui/src/chat/useAlternateActivation.ts
+++ b/packages/agent-ui/src/chat/useAlternateActivation.ts
@@ -1,6 +1,19 @@
-import { useEffect, useState } from 'react';
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
 import { isMacPlatform } from '../utils/platform';
+
+/**
+ * How long the modifier must be held before the alternate state engages.
+ *
+ * The accelerator is pressed constantly for unrelated shortcuts, and every
+ * citation on screen restyles when the state flips, so reacting instantly would
+ * flash the whole transcript on each Cmd-C. A brief hold separates "I am holding
+ * this to see what it does" from "I am typing a chord".
+ */
+export const HOLD_DELAY_MS = 250;
+
+/** Keys that are themselves modifiers, and so don't make a keypress a chord. */
+const MODIFIER_KEYS = new Set(['Meta', 'Control', 'Shift', 'Alt', 'AltGraph', 'OS', 'CapsLock']);
 
 /**
  * Whether an event carries the alternate-activation modifier: the platform
@@ -13,7 +26,7 @@ import { isMacPlatform } from '../utils/platform';
  *   `preventDefault()` on the click cannot undo it — the user gets a selection
  *   and an activation at once.
  * - A bare Alt keydown activates Gecko's menu bar on Windows and Linux, which
- *   would fire while the user is merely hovering.
+ *   would fire while the user is merely holding the key down.
  *
  * Neither accelerator chord has a default action over a plain `<span>`, and
  * mapping macOS to Cmd keeps Ctrl-click free for the context menu there.
@@ -27,71 +40,141 @@ export function hasAlternateModifier(
     return navigator && isMacPlatform(navigator) ? event.metaKey : event.ctrlKey;
 }
 
+type Subscriber = (held: boolean) => void;
+
+interface DocumentTracker {
+    subscribers: Set<Subscriber>;
+    isHeld: () => boolean;
+    teardown: () => void;
+}
+
 /**
- * Tracks whether the alternate-activation modifier is held while the pointer is
- * over an element.
- *
- * A citation names two things at once: the passage it cites and the work the
- * passage comes from. The default hover/click acts on the passage; holding the
- * modifier acts on the work. The hover preview and the click handler both need
- * to agree on which one is currently selected, so the state lives here.
- *
- * See {@link hasAlternateModifier} for which key that is and why.
- *
- * Key listeners are attached only while hovering, and on the document the
- * pointer actually entered, so a citation rendered in a second window tracks
- * that window's keyboard rather than another one's.
+ * One tracker per document, shared by every citation in it. Keyed weakly so a
+ * closed window's entry goes away with the window; timers are scheduled on that
+ * window, so they die with it rather than firing into a dead realm.
  */
-export interface AlternateActivation {
-    /** Whether the modifier is currently held over the tracked element. */
-    isAlternate: boolean;
-    /** Spread onto the element whose hover should be tracked. */
-    hoverProps: {
-        onMouseEnter: (event: ReactMouseEvent) => void;
-        onMouseLeave: () => void;
+const trackers = new WeakMap<Document, DocumentTracker>();
+
+function createTracker(doc: Document): DocumentTracker {
+    const win = doc.defaultView;
+    const subscribers = new Set<Subscriber>();
+    let held = false;
+    let timer: number | null = null;
+    // Set once a non-modifier key is pressed with the accelerator down: the user
+    // is typing a chord, so the alternate state stays off until they let go.
+    let chording = false;
+
+    const publish = (next: boolean) => {
+        if (next === held) return;
+        held = next;
+        subscribers.forEach((notify) => notify(next));
+    };
+
+    const cancelPending = () => {
+        if (timer === null) return;
+        win?.clearTimeout(timer);
+        timer = null;
+    };
+
+    const release = () => {
+        cancelPending();
+        chording = false;
+        publish(false);
+    };
+
+    const onKey = (event: KeyboardEvent) => {
+        if (!hasAlternateModifier(event, win?.navigator)) {
+            release();
+            return;
+        }
+        if (event.type === 'keydown' && !MODIFIER_KEYS.has(event.key)) {
+            chording = true;
+            cancelPending();
+            publish(false);
+            return;
+        }
+        if (chording || held || timer !== null) return;
+        timer = win?.setTimeout(() => {
+            timer = null;
+            publish(true);
+        }, HOLD_DELAY_MS) ?? null;
+    };
+
+    // Capture phase: a citation can render inside surfaces that stop key events
+    // on their way up (the composer, the reader).
+    doc.addEventListener('keydown', onKey, true);
+    doc.addEventListener('keyup', onKey, true);
+    // Focus can leave the window while the key is still down, in which case the
+    // keyup is delivered elsewhere and the state would stay stuck on. On macOS
+    // that includes Cmd-Tab, which is exactly this chord.
+    win?.addEventListener('blur', release);
+
+    return {
+        subscribers,
+        isHeld: () => held,
+        teardown: () => {
+            cancelPending();
+            doc.removeEventListener('keydown', onKey, true);
+            doc.removeEventListener('keyup', onKey, true);
+            win?.removeEventListener('blur', release);
+        },
     };
 }
 
+function subscribe(doc: Document, notify: Subscriber): () => void {
+    let tracker = trackers.get(doc);
+    if (!tracker) {
+        tracker = createTracker(doc);
+        trackers.set(doc, tracker);
+    }
+    const active = tracker;
+    active.subscribers.add(notify);
+    // Adopt whatever the state already is — a citation can mount (or a thread
+    // can re-render) while the key is down.
+    notify(active.isHeld());
+
+    return () => {
+        active.subscribers.delete(notify);
+        if (active.subscribers.size === 0) {
+            active.teardown();
+            trackers.delete(doc);
+        }
+    };
+}
+
+/** What {@link useAlternateActivation} hands back to a citation. */
+export interface AlternateActivation {
+    /** Whether the modifier is currently held. */
+    isAlternate: boolean;
+    /** Attach to the rendered element, so the hook can find its document. */
+    ref: MutableRefObject<HTMLSpanElement | null>;
+}
+
+/**
+ * Tracks whether the alternate-activation modifier is being held.
+ *
+ * A citation names two things at once: the passage it cites and the work the
+ * passage comes from. The default hover/click acts on the passage; holding the
+ * modifier acts on the work. See {@link hasAlternateModifier} for which key that
+ * is and why.
+ *
+ * The state is document-wide rather than per-hover, so holding the key restyles
+ * every citation at once and reads as a mode — which is also the only thing that
+ * makes the gesture discoverable. Listeners are shared across all citations in a
+ * document and torn down with the last one, and each citation tracks the
+ * document it actually renders in, so a second window follows its own keyboard.
+ */
 export function useAlternateActivation(): AlternateActivation {
-    const [hoveredDocument, setHoveredDocument] = useState<Document | null>(null);
+    const ref = useRef<HTMLSpanElement | null>(null);
     const [isAlternate, setIsAlternate] = useState(false);
 
     useEffect(() => {
-        if (!hoveredDocument) return;
+        // Effects run after mount, so the element (and its document) is present.
+        // A citation never moves between documents, so this subscribes once.
+        const doc = ref.current?.ownerDocument;
+        if (!doc) return;
+        return subscribe(doc, setIsAlternate);
+    }, []);
 
-        const win = hoveredDocument.defaultView;
-        const sync = (event: KeyboardEvent) => setIsAlternate(hasAlternateModifier(event, win?.navigator));
-        const clear = () => setIsAlternate(false);
-
-        // Capture phase: a citation can render inside surfaces that stop key
-        // events on their way up (the composer, the reader).
-        hoveredDocument.addEventListener('keydown', sync, true);
-        hoveredDocument.addEventListener('keyup', sync, true);
-        // Focus can leave the window while the key is still down, in which case
-        // the keyup is delivered elsewhere and the state would stay stuck on.
-        // On macOS that includes Cmd-Tab, which is exactly this chord.
-        win?.addEventListener('blur', clear);
-
-        return () => {
-            hoveredDocument.removeEventListener('keydown', sync, true);
-            hoveredDocument.removeEventListener('keyup', sync, true);
-            win?.removeEventListener('blur', clear);
-        };
-    }, [hoveredDocument]);
-
-    return {
-        isAlternate,
-        hoverProps: {
-            onMouseEnter: (event: ReactMouseEvent) => {
-                const doc = event.currentTarget.ownerDocument;
-                // The modifier may already be held when the pointer arrives.
-                setIsAlternate(hasAlternateModifier(event, doc.defaultView?.navigator));
-                setHoveredDocument(doc);
-            },
-            onMouseLeave: () => {
-                setIsAlternate(false);
-                setHoveredDocument(null);
-            },
-        },
-    };
+    return { isAlternate, ref };
 }

--- a/packages/agent-ui/src/host/index.ts
+++ b/packages/agent-ui/src/host/index.ts
@@ -22,6 +22,7 @@ export type {
     HostButtonVariant,
     ResolvedItemDisplay,
     CitationActivation,
+    CitationActivationIntent,
     CitationExportRequest,
     CitationExportRender,
 } from './types';

--- a/packages/agent-ui/src/host/types.ts
+++ b/packages/agent-ui/src/host/types.ts
@@ -18,7 +18,7 @@ import type { BatchOutcomeTarget } from '@beaver/agent-core/run-state/batchProgr
  *   highlight the quoted text, open the note, launch the external file, ... This
  *   is the default.
  * - `item` — reveal the cited work itself where the user keeps it, ignoring the
- *   locator. Selected by holding the alternate-activation modifier (Shift).
+ *   locator. Selected by holding the platform accelerator (Cmd / Ctrl).
  */
 export type CitationActivationIntent = 'passage' | 'item';
 

--- a/packages/agent-ui/src/host/types.ts
+++ b/packages/agent-ui/src/host/types.ts
@@ -12,6 +12,17 @@ import type { AgentActionType } from '@beaver/agent-core/protocol/agentProtocol'
 import type { BatchOutcomeTarget } from '@beaver/agent-core/run-state/batchProgress';
 
 /**
+ * What a citation click should act on.
+ *
+ * - `passage` — navigate to the cited location: open the reader at the page and
+ *   highlight the quoted text, open the note, launch the external file, ... This
+ *   is the default.
+ * - `item` — reveal the cited work itself where the user keeps it, ignoring the
+ *   locator. Selected by holding the alternate-activation modifier (Shift).
+ */
+export type CitationActivationIntent = 'passage' | 'item';
+
+/**
  * Everything the host needs to activate (navigate to / open) a cited location.
  *
  * The render layer derives this from the client-agnostic citation view model and
@@ -23,6 +34,12 @@ import type { BatchOutcomeTarget } from '@beaver/agent-core/run-state/batchProgr
 export interface CitationActivation {
     /** Self-contained citation metadata (content kind, locations, pages, preview, ...). */
     metadata: Citation;
+    /**
+     * What the click should act on. Optional: a host that does not distinguish
+     * the two treats every click as `passage`, which is the behavior it had
+     * before the alternate activation existed.
+     */
+    intent?: CitationActivationIntent;
     isExternal: boolean;
     isExternalFile: boolean;
     externalFileKey: string | null;

--- a/packages/agent-ui/src/primitives/Tooltip.tsx
+++ b/packages/agent-ui/src/primitives/Tooltip.tsx
@@ -30,6 +30,14 @@ export interface TooltipProps {
     allowHtml?: boolean;
     /** Custom content to render instead of the default content */
     customContent?: ReactNode;
+    /**
+     * Identifies the *shape* of the current content. The tooltip is positioned
+     * from its own measured size, so content that changes height while the
+     * tooltip is open must trigger a re-measure. The content itself can't be a
+     * dependency — a fresh element identity on every parent render would
+     * re-measure constantly — so callers that swap content pass a stable key.
+     */
+    contentKey?: string | number;
     /** Whether the tooltip should stay open when clicking the anchor element */
     stayOpenOnAnchorClick?: boolean;
     /** Optional preferred placement ('top' or 'bottom') */
@@ -56,6 +64,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     width,
     allowHtml = false,
     customContent,
+    contentKey,
     stayOpenOnAnchorClick = false,
     placement: preferredPlacement,
     horizontalAlign = 'center',
@@ -182,7 +191,7 @@ const Tooltip: React.FC<TooltipProps> = ({
             win.removeEventListener('scroll', handleScroll, true);
             win.removeEventListener('click', handleClick);
         };
-    }, [isOpen, stayOpenOnAnchorClick]);
+    }, [isOpen, stayOpenOnAnchorClick, contentKey]);
     
     // Close tooltip when disabled prop changes to true
     useEffect(() => {

--- a/packages/agent-ui/tsconfig.json
+++ b/packages/agent-ui/tsconfig.json
@@ -208,6 +208,7 @@
     "./src/chat/highlightText.tsx",
     "./src/chat/rehypeFindHighlight.ts",
     "./src/chat/actionPopup.ts",
+    "./src/chat/useAlternateActivation.ts",
     "./src/chat/useCitationMarker.ts",
     "./src/chat/useCitationViewModel.ts",
 

--- a/react/host/zotero/citationActivation.ts
+++ b/react/host/zotero/citationActivation.ts
@@ -39,6 +39,18 @@ import { BEAVER_CITATION_ANNOTATION_AUTHOR } from '../../../src/constants/annota
 import { libraryRefForLibraryID, resolveItemReference } from '../../../src/utils/libraryIdentity';
 import type { CitationActivation } from '@beaver/agent-ui/host/types';
 
+/**
+ * Walk to the top-level item. An annotation or attachment citation names a child
+ * row; "the item" the user wants revealed is the work it hangs off.
+ */
+function topLevelItemOf(item: Zotero.Item): Zotero.Item {
+    let current = item;
+    while (current.parentItem) {
+        current = current.parentItem;
+    }
+    return current;
+}
+
 /** Reveal the cited item in the library view. */
 function revealInLibrary(libraryID: number, zoteroKey: string): void {
     revealSource({
@@ -56,6 +68,7 @@ function revealInLibrary(libraryID: number, zoteroKey: string): void {
 export async function activateCitation(activation: CitationActivation): Promise<void> {
     const {
         metadata,
+        intent = 'passage',
         isExternal,
         isExternalFile,
         externalFileKey,
@@ -118,6 +131,15 @@ export async function activateCitation(activation: CitationActivation): Promise<
     const item = resolved.item;
 
     await item.loadAllData();
+
+    // Alternate activation: the user asked for the cited work, not the cited
+    // passage. Reveal it and skip every locator-driven path below.
+    if (intent === 'item') {
+        const target = topLevelItemOf(item);
+        logger(`Citation activation: revealing cited item in library (${target.id})`);
+        revealInLibrary(target.libraryID, target.key);
+        return;
+    }
 
     const contentKind = getContentKind(metadata);
     const symbolicLocation = getSymbolicLocation(metadata);

--- a/react/host/zotero/citationActivation.ts
+++ b/react/host/zotero/citationActivation.ts
@@ -42,11 +42,23 @@ import type { CitationActivation } from '@beaver/agent-ui/host/types';
 /**
  * Walk to the top-level item. An annotation or attachment citation names a child
  * row; "the item" the user wants revealed is the work it hangs off.
+ *
+ * Walks by parent *ID* rather than the `parentItem` getter: that getter resolves
+ * through `Zotero.Items.get()`, which throws `UnloadedDataException` when the
+ * parent is registered but not yet in the object cache. A child item reached
+ * directly by key — which is how a citation resolves — routinely has an
+ * unloaded parent, and `loadAllData()` only loads the child itself.
  */
-function topLevelItemOf(item: Zotero.Item): Zotero.Item {
+async function topLevelItemOf(item: Zotero.Item): Promise<Zotero.Item> {
     let current = item;
-    while (current.parentItem) {
-        current = current.parentItem;
+    // Zotero nests at most annotation -> attachment -> item; the bound just
+    // stops a malformed parent cycle from spinning here.
+    for (let depth = 0; depth < 5; depth++) {
+        const parentID = current.parentItemID;
+        if (!parentID) break;
+        const parent = await Zotero.Items.getAsync(parentID);
+        if (!parent) break;
+        current = parent;
     }
     return current;
 }
@@ -135,7 +147,7 @@ export async function activateCitation(activation: CitationActivation): Promise<
     // Alternate activation: the user asked for the cited work, not the cited
     // passage. Reveal it and skip every locator-driven path below.
     if (intent === 'item') {
-        const target = topLevelItemOf(item);
+        const target = await topLevelItemOf(item);
         logger(`Citation activation: revealing cited item in library (${target.id})`);
         revealInLibrary(target.libraryID, target.key);
         return;

--- a/tests/unit/citations/citationAlternateActivation.test.ts
+++ b/tests/unit/citations/citationAlternateActivation.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+/**
+ * A citation names two things at once: the passage it cites and the work the
+ * passage comes from. Holding Shift switches both the hover preview and the
+ * click from the first to the second.
+ *
+ * The two halves have to agree, and each can break independently: the hover
+ * state lives in the shared component while the click is executed by the host,
+ * so this drives the real component against a stub host and asserts on both.
+ */
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { citationsAtom } from '@beaver/agent-core/citations/atoms';
+import type { Citation as CitationMetadata } from '@beaver/agent-core/types/citations';
+import type { ClientHost } from '@beaver/agent-ui/host';
+import { setHost } from '@beaver/agent-ui/host';
+import Citation from '@beaver/agent-ui/chat/Citation';
+
+// Tells React that `act()` is available, so it doesn't warn on every render.
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const LIBRARY_ID = 1;
+const ITEM_KEY = 'ABCD1234';
+
+const pageCitation: CitationMetadata = {
+    citation_id: 'c1',
+    requested_ref: { kind: 'zotero', library_id: LIBRARY_ID, zotero_key: ITEM_KEY, loc: { kind: 'page', value: '12', raw: 'page12' } },
+    resolved_ref: { kind: 'zotero', library_id: LIBRARY_ID, zotero_key: ITEM_KEY, loc: { kind: 'page', value: '12', raw: 'page12' } },
+    citation_type: 'attachment',
+    content_kind: 'pdf',
+    display_name: 'Smith, 2024',
+    formatted_citation: 'Smith, J. (2024). A study of beavers. Journal of Rodents, 12(3), 1–20.',
+    preview: 'Beavers build dams.',
+    pages: [12],
+    run_id: 'run-1',
+} as unknown as CitationMetadata;
+
+let activateCitation: ReturnType<typeof vi.fn>;
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+function mount(): HTMLElement {
+    const store = createStore();
+    store.set(citationsAtom, [pageCitation]);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+        root?.render(
+            React.createElement(
+                Provider,
+                { store },
+                React.createElement(Citation, {
+                    'data-library-id': String(LIBRARY_ID),
+                    'data-zotero-key': ITEM_KEY,
+                    'data-loc': 'page12',
+                    'data-loc-kind': 'page',
+                    'data-loc-value': '12',
+                }),
+            ),
+        );
+    });
+    const marker = container.querySelector('.zotero-citation');
+    if (!marker) throw new Error('citation marker did not render');
+    return marker as HTMLElement;
+}
+
+/** Open the hover preview, optionally with the modifier already held. */
+function hover(marker: HTMLElement, shiftKey = false): void {
+    act(() => {
+        marker.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, shiftKey }));
+    });
+}
+
+function tooltipText(): string {
+    return container?.querySelector('[role="tooltip"]')?.textContent ?? '';
+}
+
+beforeEach(() => {
+    activateCitation = vi.fn();
+    setHost({ navigation: { activateCitation } } as unknown as ClientHost);
+});
+
+afterEach(() => {
+    if (root) act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    setHost({});
+    vi.clearAllMocks();
+});
+
+describe('citation hover preview', () => {
+    it('previews the cited passage and its page by default', () => {
+        hover(mount());
+
+        expect(tooltipText()).toContain('Beavers build dams.');
+        expect(tooltipText()).toContain('Page 12');
+        expect(tooltipText()).toContain('Opens PDF on page 12');
+    });
+
+    it('swaps to the full reference while the modifier is held', () => {
+        const marker = mount();
+        hover(marker);
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift', shiftKey: true, bubbles: true }));
+        });
+
+        expect(tooltipText()).toContain('A study of beavers');
+        expect(tooltipText()).toContain('Reveals item in library');
+        // The passage and its locator describe what the *unmodified* click does.
+        expect(tooltipText()).not.toContain('Beavers build dams.');
+        expect(tooltipText()).not.toContain('Page 12');
+    });
+
+    it('restores the passage preview when the modifier is released', () => {
+        const marker = mount();
+        hover(marker);
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift', shiftKey: true, bubbles: true }));
+        });
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift', shiftKey: false, bubbles: true }));
+        });
+
+        expect(tooltipText()).toContain('Beavers build dams.');
+        expect(tooltipText()).not.toContain('A study of beavers');
+    });
+
+    it('shows the item state when the modifier is already held on arrival', () => {
+        hover(mount(), true);
+
+        expect(tooltipText()).toContain('Reveals item in library');
+    });
+});
+
+describe('citation click', () => {
+    it('activates the cited passage on a plain click', () => {
+        const marker = mount();
+        act(() => {
+            marker.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(activateCitation).toHaveBeenCalledTimes(1);
+        expect(activateCitation.mock.calls[0][0]).toMatchObject({
+            intent: 'passage',
+            effectiveLibraryID: LIBRARY_ID,
+            effectiveItemKey: ITEM_KEY,
+        });
+    });
+
+    it('activates the cited work on a modified click', () => {
+        const marker = mount();
+        act(() => {
+            marker.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+        });
+
+        expect(activateCitation).toHaveBeenCalledTimes(1);
+        expect(activateCitation.mock.calls[0][0]).toMatchObject({ intent: 'item' });
+    });
+});

--- a/tests/unit/citations/citationAlternateActivation.test.ts
+++ b/tests/unit/citations/citationAlternateActivation.test.ts
@@ -2,12 +2,15 @@
 
 /**
  * A citation names two things at once: the passage it cites and the work the
- * passage comes from. Holding Shift switches both the hover preview and the
- * click from the first to the second.
+ * passage comes from. Holding the platform accelerator switches both the hover
+ * preview and the click from the first to the second.
  *
  * The two halves have to agree, and each can break independently: the hover
  * state lives in the shared component while the click is executed by the host,
  * so this drives the real component against a stub host and asserts on both.
+ *
+ * The component cases derive the chord from the running platform, so the choice
+ * of accelerator is pinned by the `hasAlternateModifier` cases instead.
  */
 
 import React, { act } from 'react';
@@ -19,12 +22,21 @@ import type { Citation as CitationMetadata } from '@beaver/agent-core/types/cita
 import type { ClientHost } from '@beaver/agent-ui/host';
 import { setHost } from '@beaver/agent-ui/host';
 import Citation from '@beaver/agent-ui/chat/Citation';
+import { hasAlternateModifier } from '@beaver/agent-ui/chat/useAlternateActivation';
+import { isMacPlatform } from '@beaver/agent-ui/utils/platform';
 
 // Tells React that `act()` is available, so it doesn't warn on every render.
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 const LIBRARY_ID = 1;
 const ITEM_KEY = 'ABCD1234';
+
+/** The accelerator chord as this platform delivers it. */
+const ACCEL_DOWN = isMacPlatform(window.navigator) ? { metaKey: true } : { ctrlKey: true };
+
+const macNavigator = { platform: 'MacIntel', userAgent: '' } as Navigator;
+const winNavigator = { platform: 'Win32', userAgent: '' } as Navigator;
+const NO_MODIFIER = { metaKey: false, ctrlKey: false };
 
 const pageCitation: CitationMetadata = {
     citation_id: 'c1',
@@ -71,9 +83,23 @@ function mount(): HTMLElement {
 }
 
 /** Open the hover preview, optionally with the modifier already held. */
-function hover(marker: HTMLElement, shiftKey = false): void {
+function hover(marker: HTMLElement, withModifier = false): void {
     act(() => {
-        marker.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, shiftKey }));
+        marker.dispatchEvent(
+            new MouseEvent('mouseover', { bubbles: true, ...(withModifier ? ACCEL_DOWN : {}) }),
+        );
+    });
+}
+
+/** Press or release the accelerator on the document the citation lives in. */
+function setModifier(held: boolean): void {
+    act(() => {
+        document.dispatchEvent(
+            new KeyboardEvent(held ? 'keydown' : 'keyup', {
+                bubbles: true,
+                ...(held ? ACCEL_DOWN : {}),
+            }),
+        );
     });
 }
 
@@ -108,9 +134,7 @@ describe('citation hover preview', () => {
         const marker = mount();
         hover(marker);
 
-        act(() => {
-            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift', shiftKey: true, bubbles: true }));
-        });
+        setModifier(true);
 
         expect(tooltipText()).toContain('A study of beavers');
         expect(tooltipText()).toContain('Reveals item in library');
@@ -123,12 +147,8 @@ describe('citation hover preview', () => {
         const marker = mount();
         hover(marker);
 
-        act(() => {
-            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift', shiftKey: true, bubbles: true }));
-        });
-        act(() => {
-            document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift', shiftKey: false, bubbles: true }));
-        });
+        setModifier(true);
+        setModifier(false);
 
         expect(tooltipText()).toContain('Beavers build dams.');
         expect(tooltipText()).not.toContain('A study of beavers');
@@ -159,10 +179,39 @@ describe('citation click', () => {
     it('activates the cited work on a modified click', () => {
         const marker = mount();
         act(() => {
-            marker.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+            marker.dispatchEvent(new MouseEvent('click', { bubbles: true, ...ACCEL_DOWN }));
         });
 
         expect(activateCitation).toHaveBeenCalledTimes(1);
         expect(activateCitation.mock.calls[0][0]).toMatchObject({ intent: 'item' });
+    });
+
+    // Shift-click extends the text selection around the citation, on mousedown,
+    // where the click handler can no longer prevent it. It must stay a plain
+    // activation rather than doubling as the alternate one.
+    it('ignores Shift, which belongs to the text selection', () => {
+        const marker = mount();
+        act(() => {
+            marker.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+        });
+
+        expect(activateCitation.mock.calls[0][0]).toMatchObject({ intent: 'passage' });
+    });
+});
+
+describe('hasAlternateModifier', () => {
+    it('is Cmd on macOS, where Ctrl-click is the context menu', () => {
+        expect(hasAlternateModifier({ metaKey: true, ctrlKey: false }, macNavigator)).toBe(true);
+        expect(hasAlternateModifier({ metaKey: false, ctrlKey: true }, macNavigator)).toBe(false);
+    });
+
+    it('is Ctrl everywhere else', () => {
+        expect(hasAlternateModifier({ metaKey: false, ctrlKey: true }, winNavigator)).toBe(true);
+        expect(hasAlternateModifier({ metaKey: true, ctrlKey: false }, winNavigator)).toBe(false);
+    });
+
+    it('is not triggered by an unmodified event', () => {
+        expect(hasAlternateModifier(NO_MODIFIER, macNavigator)).toBe(false);
+        expect(hasAlternateModifier(NO_MODIFIER, winNavigator)).toBe(false);
     });
 });

--- a/tests/unit/citations/citationAlternateActivation.test.ts
+++ b/tests/unit/citations/citationAlternateActivation.test.ts
@@ -2,12 +2,13 @@
 
 /**
  * A citation names two things at once: the passage it cites and the work the
- * passage comes from. Holding the platform accelerator switches both the hover
- * preview and the click from the first to the second.
+ * passage comes from. Holding the platform accelerator switches the hover
+ * preview, the marker style and the click from the first to the second.
  *
- * The two halves have to agree, and each can break independently: the hover
- * state lives in the shared component while the click is executed by the host,
- * so this drives the real component against a stub host and asserts on both.
+ * Those three have to agree, and each can break independently: the held state is
+ * document-wide shared state, the preview is rendered by the component, and the
+ * click is executed by the host. So this drives the real component against a
+ * stub host and asserts on all three.
  *
  * The component cases derive the chord from the running platform, so the choice
  * of accelerator is pinned by the `hasAlternateModifier` cases instead.
@@ -22,7 +23,7 @@ import type { Citation as CitationMetadata } from '@beaver/agent-core/types/cita
 import type { ClientHost } from '@beaver/agent-ui/host';
 import { setHost } from '@beaver/agent-ui/host';
 import Citation from '@beaver/agent-ui/chat/Citation';
-import { hasAlternateModifier } from '@beaver/agent-ui/chat/useAlternateActivation';
+import { HOLD_DELAY_MS, hasAlternateModifier } from '@beaver/agent-ui/chat/useAlternateActivation';
 import { isMacPlatform } from '@beaver/agent-ui/utils/platform';
 
 // Tells React that `act()` is available, so it doesn't warn on every render.
@@ -30,100 +31,145 @@ import { isMacPlatform } from '@beaver/agent-ui/utils/platform';
 
 const LIBRARY_ID = 1;
 const ITEM_KEY = 'ABCD1234';
+const OTHER_ITEM_KEY = 'EFGH5678';
 
-/** The accelerator chord as this platform delivers it. */
-const ACCEL_DOWN = isMacPlatform(window.navigator) ? { metaKey: true } : { ctrlKey: true };
+/** The accelerator as this platform delivers it. */
+const IS_MAC = isMacPlatform(window.navigator);
+const ACCEL_KEY = IS_MAC ? 'Meta' : 'Control';
+const ACCEL_DOWN = IS_MAC ? { metaKey: true } : { ctrlKey: true };
 
 const macNavigator = { platform: 'MacIntel', userAgent: '' } as Navigator;
 const winNavigator = { platform: 'Win32', userAgent: '' } as Navigator;
 const NO_MODIFIER = { metaKey: false, ctrlKey: false };
 
-const pageCitation: CitationMetadata = {
-    citation_id: 'c1',
-    requested_ref: { kind: 'zotero', library_id: LIBRARY_ID, zotero_key: ITEM_KEY, loc: { kind: 'page', value: '12', raw: 'page12' } },
-    resolved_ref: { kind: 'zotero', library_id: LIBRARY_ID, zotero_key: ITEM_KEY, loc: { kind: 'page', value: '12', raw: 'page12' } },
-    citation_type: 'attachment',
-    content_kind: 'pdf',
-    display_name: 'Smith, 2024',
-    formatted_citation: 'Smith, J. (2024). A study of beavers. Journal of Rodents, 12(3), 1–20.',
-    preview: 'Beavers build dams.',
-    pages: [12],
-    run_id: 'run-1',
-} as unknown as CitationMetadata;
+/** A citation into a PDF at page 12 — the modifier redirects its click. */
+function pageCitation(itemKey: string, citationId: string): CitationMetadata {
+    const ref = {
+        kind: 'zotero',
+        library_id: LIBRARY_ID,
+        zotero_key: itemKey,
+        loc: { kind: 'page', value: '12', raw: 'page12' },
+    };
+    return {
+        citation_id: citationId,
+        requested_ref: ref,
+        resolved_ref: ref,
+        citation_type: 'attachment',
+        content_kind: 'pdf',
+        display_name: 'Smith, 2024',
+        formatted_citation: 'Smith, J. (2024). A study of beavers. Journal of Rodents, 12(3), 1–20.',
+        preview: 'Beavers build dams.',
+        pages: [12],
+        run_id: 'run-1',
+    } as unknown as CitationMetadata;
+}
+
+/** A library citation with no locator: an ordinary click already reveals it. */
+function locatorlessCitation(): CitationMetadata {
+    const ref = { kind: 'zotero', library_id: LIBRARY_ID, zotero_key: ITEM_KEY };
+    return {
+        citation_id: 'c-plain',
+        requested_ref: ref,
+        resolved_ref: ref,
+        citation_type: 'item',
+        display_name: 'Smith, 2024',
+        formatted_citation: 'Smith, J. (2024). A study of beavers. Journal of Rodents, 12(3), 1–20.',
+        run_id: 'run-1',
+    } as unknown as CitationMetadata;
+}
 
 let activateCitation: ReturnType<typeof vi.fn>;
-let root: ReturnType<typeof createRoot> | null = null;
-let container: HTMLDivElement | null = null;
+// More than one root can be mounted at a time, to exercise citations that share
+// a document without sharing a render tree.
+let roots: { root: ReturnType<typeof createRoot>; container: HTMLDivElement }[] = [];
 
-function mount(): HTMLElement {
+function citationTag(itemKey: string, withLocator = true) {
+    return React.createElement(Citation, {
+        key: itemKey,
+        'data-library-id': String(LIBRARY_ID),
+        'data-zotero-key': itemKey,
+        ...(withLocator ? { 'data-loc': 'page12', 'data-loc-kind': 'page', 'data-loc-value': '12' } : {}),
+    });
+}
+
+/** Render the given citations into a new root, and return their markers. */
+function mount(citations: CitationMetadata[], tags: React.ReactNode[]): HTMLElement[] {
     const store = createStore();
-    store.set(citationsAtom, [pageCitation]);
+    store.set(citationsAtom, citations);
 
-    container = document.createElement('div');
+    const container = document.createElement('div');
     document.body.appendChild(container);
-    root = createRoot(container);
+    const root = createRoot(container);
+    roots.push({ root, container });
     act(() => {
-        root?.render(
-            React.createElement(
-                Provider,
-                { store },
-                React.createElement(Citation, {
-                    'data-library-id': String(LIBRARY_ID),
-                    'data-zotero-key': ITEM_KEY,
-                    'data-loc': 'page12',
-                    'data-loc-kind': 'page',
-                    'data-loc-value': '12',
-                }),
-            ),
-        );
+        root.render(React.createElement(Provider, { store }, ...tags));
     });
-    const marker = container.querySelector('.zotero-citation');
-    if (!marker) throw new Error('citation marker did not render');
-    return marker as HTMLElement;
+    const markers = Array.from(container.querySelectorAll('.zotero-citation')) as HTMLElement[];
+    if (markers.length !== tags.length) throw new Error('citation markers did not render');
+    return markers;
 }
 
-/** Open the hover preview, optionally with the modifier already held. */
-function hover(marker: HTMLElement, withModifier = false): void {
-    act(() => {
-        marker.dispatchEvent(
-            new MouseEvent('mouseover', { bubbles: true, ...(withModifier ? ACCEL_DOWN : {}) }),
-        );
-    });
+function unmountAll(): void {
+    for (const { root, container } of roots) {
+        act(() => root.unmount());
+        container.remove();
+    }
+    roots = [];
 }
 
-/** Press or release the accelerator on the document the citation lives in. */
-function setModifier(held: boolean): void {
+/** Mount the single default citation: one library item, cited at page 12. */
+function mountOne(): HTMLElement {
+    return mount([pageCitation(ITEM_KEY, 'c1')], [citationTag(ITEM_KEY)])[0];
+}
+
+function openPreview(marker: HTMLElement): void {
     act(() => {
-        document.dispatchEvent(
-            new KeyboardEvent(held ? 'keydown' : 'keyup', {
-                bubbles: true,
-                ...(held ? ACCEL_DOWN : {}),
-            }),
-        );
+        marker.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     });
 }
 
 function tooltipText(): string {
-    return container?.querySelector('[role="tooltip"]')?.textContent ?? '';
+    return document.querySelector('[role="tooltip"]')?.textContent ?? '';
+}
+
+function pressModifier(): void {
+    act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ACCEL_KEY, bubbles: true, ...ACCEL_DOWN }));
+    });
+}
+
+function releaseModifier(): void {
+    act(() => {
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ACCEL_KEY, bubbles: true }));
+    });
+}
+
+/** Press the accelerator and hold it past the engage delay. */
+function holdModifier(): void {
+    pressModifier();
+    act(() => {
+        vi.advanceTimersByTime(HOLD_DELAY_MS);
+    });
 }
 
 beforeEach(() => {
+    vi.useFakeTimers();
     activateCitation = vi.fn();
     setHost({ navigation: { activateCitation } } as unknown as ClientHost);
 });
 
 afterEach(() => {
-    if (root) act(() => root?.unmount());
-    container?.remove();
-    root = null;
-    container = null;
+    // The held state is document-wide and outlives an unmount, so clear it.
+    releaseModifier();
+    unmountAll();
     setHost({});
+    vi.useRealTimers();
     vi.clearAllMocks();
 });
 
 describe('citation hover preview', () => {
     it('previews the cited passage and its page by default', () => {
-        hover(mount());
+        openPreview(mountOne());
 
         expect(tooltipText()).toContain('Beavers build dams.');
         expect(tooltipText()).toContain('Page 12');
@@ -131,10 +177,8 @@ describe('citation hover preview', () => {
     });
 
     it('swaps to the full reference while the modifier is held', () => {
-        const marker = mount();
-        hover(marker);
-
-        setModifier(true);
+        openPreview(mountOne());
+        holdModifier();
 
         expect(tooltipText()).toContain('A study of beavers');
         expect(tooltipText()).toContain('Reveals item in library');
@@ -144,26 +188,72 @@ describe('citation hover preview', () => {
     });
 
     it('restores the passage preview when the modifier is released', () => {
-        const marker = mount();
-        hover(marker);
-
-        setModifier(true);
-        setModifier(false);
+        openPreview(mountOne());
+        holdModifier();
+        releaseModifier();
 
         expect(tooltipText()).toContain('Beavers build dams.');
         expect(tooltipText()).not.toContain('A study of beavers');
     });
+});
 
-    it('shows the item state when the modifier is already held on arrival', () => {
-        hover(mount(), true);
+describe('held-modifier marker styling', () => {
+    it('drops the locator style from every citation at once', () => {
+        const markers = mount(
+            [pageCitation(ITEM_KEY, 'c1'), pageCitation(OTHER_ITEM_KEY, 'c2')],
+            [citationTag(ITEM_KEY), citationTag(OTHER_ITEM_KEY)],
+        );
+        expect(markers.every((m) => m.className.includes('with-locator'))).toBe(true);
 
-        expect(tooltipText()).toContain('Reveals item in library');
+        holdModifier();
+        expect(markers.some((m) => m.className.includes('with-locator'))).toBe(false);
+
+        releaseModifier();
+        expect(markers.every((m) => m.className.includes('with-locator'))).toBe(true);
+    });
+
+    // Citations arrive mid-stream, so one can mount into a document that is
+    // already tracking a held key. It has to adopt that state, not start plain.
+    it('adopts the held state when it mounts while the key is already down', () => {
+        mountOne();
+        holdModifier();
+
+        const late = mount([pageCitation(OTHER_ITEM_KEY, 'c2')], [citationTag(OTHER_ITEM_KEY)])[0];
+
+        expect(late.className).not.toContain('with-locator');
+    });
+
+    // The accelerator is pressed constantly for unrelated shortcuts. Neither a
+    // quick tap nor a chord may restyle the transcript.
+    it('ignores a tap shorter than the hold delay', () => {
+        const marker = mountOne();
+        pressModifier();
+        act(() => {
+            vi.advanceTimersByTime(HOLD_DELAY_MS - 50);
+        });
+        releaseModifier();
+        act(() => {
+            vi.advanceTimersByTime(HOLD_DELAY_MS);
+        });
+
+        expect(marker.className).toContain('with-locator');
+    });
+
+    it('ignores a chord typed with the modifier down', () => {
+        const marker = mountOne();
+        pressModifier();
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', bubbles: true, ...ACCEL_DOWN }));
+            vi.advanceTimersByTime(HOLD_DELAY_MS * 4);
+        });
+
+        expect(marker.className).toContain('with-locator');
     });
 });
 
 describe('citation click', () => {
     it('activates the cited passage on a plain click', () => {
-        const marker = mount();
+        const marker = mountOne();
         act(() => {
             marker.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         });
@@ -176,8 +266,10 @@ describe('citation click', () => {
         });
     });
 
+    // The click reads the modifier off its own event rather than the held state,
+    // so it is correct even before the hold delay has elapsed.
     it('activates the cited work on a modified click', () => {
-        const marker = mount();
+        const marker = mountOne();
         act(() => {
             marker.dispatchEvent(new MouseEvent('click', { bubbles: true, ...ACCEL_DOWN }));
         });
@@ -190,9 +282,26 @@ describe('citation click', () => {
     // where the click handler can no longer prevent it. It must stay a plain
     // activation rather than doubling as the alternate one.
     it('ignores Shift, which belongs to the text selection', () => {
-        const marker = mount();
+        const marker = mountOne();
         act(() => {
             marker.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+        });
+
+        expect(activateCitation.mock.calls[0][0]).toMatchObject({ intent: 'passage' });
+    });
+});
+
+describe('citations the modifier does not apply to', () => {
+    // A locator-less item is already revealed in the library by an ordinary
+    // click, so the modifier would change neither the click nor the tooltip.
+    it('stays inert on a library citation with no locator', () => {
+        const marker = mount([locatorlessCitation()], [citationTag(ITEM_KEY, false)])[0];
+        openPreview(marker);
+        expect(tooltipText()).toContain('Reveals item in library');
+
+        holdModifier();
+        act(() => {
+            marker.dispatchEvent(new MouseEvent('click', { bubbles: true, ...ACCEL_DOWN }));
         });
 
         expect(activateCitation.mock.calls[0][0]).toMatchObject({ intent: 'passage' });


### PR DESCRIPTION
## Summary

- Add Shift-hover and Shift-click behavior for revealing the cited work in the library.
- Preserve passage navigation for standard citation activation.
- Add host activation intent support and Zotero top-level item resolution.
- Refresh tooltip content when switching between passage and item previews.

## Testing

- Added unit coverage for default and alternate hover previews, modifier transitions, and click intents.
- Not run.