### PR TITLE
feat(item-links): support Zotero object links in chat markdown

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -390,6 +390,10 @@ export default tseslint.config(
             "react/components/agentRuns/slashCommandRendering.tsx",
             "react/components/agentRuns/requestChips/**/*.{ts,tsx}",
             "react/components/messages/NoteDisplay.tsx",
+            // The markdown body renderer and the pure item-link grammar it
+            // uses: links are followed through getHost().navigation.
+            "react/components/messages/MarkdownRenderer.tsx",
+            "react/utils/itemLinks.ts",
             // ToolCallPartView resolves request-side display names through
             // getHost(), not the Zotero global. The label layer it calls lives in
             // the core and is covered by the stricter block below.

--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -2516,6 +2516,13 @@ export const CLIENT_FEATURES = {
      * PDF might be downloaded from.
      */
     PDF_CANDIDATES: 'pdf_candidates',
+    /**
+     * Chat markdown follows `[label](u-KEY)` (and `zotero://select/...`) as a
+     * link that reveals the named library object. Without it those hrefs render
+     * as ordinary relative links, so the backend must not instruct the model to
+     * write them.
+     */
+    ITEM_LINKS: 'item_links',
 } as const;
 
 /** Client type identifier for the Zotero plugin. */

--- a/packages/agent-ui/src/host/types.ts
+++ b/packages/agent-ui/src/host/types.ts
@@ -109,6 +109,15 @@ export interface NavigationHost {
      * `zotero_key` is the collection key (not an item key).
      */
     revealCollection(ref: ZoteroItemReference): void;
+    /**
+     * Reveal whatever `zotero_key` names in the referenced library: a regular
+     * item, attachment, or note is selected in the library view, an annotation
+     * is opened in the reader, and a collection is selected. Used by the object
+     * links the model writes in prose (`[Smith 2004](u-KEY)`), which carry a
+     * key but not the object type. Optional — clients without it leave such
+     * links inert.
+     */
+    revealObject?(ref: ZoteroItemReference): void | Promise<void>;
     /** Open a local file (e.g. a PDF/text attachment) in the host's default handler. */
     launchFile(filePath: string): void;
     /** Open an external URL. */

--- a/react/components/messages/MarkdownRenderer.tsx
+++ b/react/components/messages/MarkdownRenderer.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../utils/citationPreprocessing';
 import { processPartialContent } from '../../utils/markdownPartialContent';
 import { getHost } from '@beaver/agent-ui/host';
+import { resolveObjectIdReference } from '@beaver/agent-core/identity/libraryRef';
+import { itemLinkExportHref, parseItemLinkHref, type ItemLinkTarget } from '../../utils/itemLinks';
 import { useFindQuery } from '@beaver/agent-ui/chat/findContext';
 import { rehypeFindHighlight } from '@beaver/agent-ui/chat/rehypeFindHighlight';
 
@@ -126,23 +128,50 @@ function urlTransform(url: string): string {
 }
 
 /**
+ * Export variant: the rendered HTML is saved into a Zotero note, where a bare
+ * object id (`u-KEY`) is not a working href, so item links are written as
+ * `zotero://select` URIs the note editor can follow.
+ */
+function exportUrlTransform(url: string): string {
+    return itemLinkExportHref(url) ?? urlTransform(url);
+}
+
+/**
+ * Follow a link to a Zotero object. The object id is resolved here, at click
+ * time, so rendering never touches the host's libraries.
+ */
+function activateItemLink(link: ItemLinkTarget): void {
+    const ref = resolveObjectIdReference(link.objectId);
+    if (!ref) return;
+    const navigation = getHost().navigation;
+    if (link.kind === 'collection') void navigation?.revealCollection(ref);
+    else void navigation?.revealObject?.(ref);
+}
+
+/**
  * Anchor rendered inside the chat.
  *
  * The UI is hosted in a chrome document, where a bare `<a href>` has no
  * navigation behavior — clicking one only selects its text. Links must be
  * opened explicitly through the host, so the default click is always
  * suppressed. Fragment-only links have no target to open and stay inert.
+ *
+ * A link whose href is a Zotero object id (`[Smith 2004](u-KEY)`, see
+ * `itemLinks.ts`) reveals that object in the host instead of opening a URL.
  */
 function MarkdownLink({ href, children, title, ...props }: any) {
-    const isExternal = Boolean(href) && !href.startsWith('#');
+    const itemLink = parseItemLinkHref(href);
+    const isExternal = !itemLink && Boolean(href) && !href.startsWith('#');
+    const defaultTitle = itemLink ? 'Show in Zotero' : isExternal ? href : undefined;
     return (
         <a
             {...props}
             href={href}
-            title={title ?? (isExternal ? href : undefined)}
+            title={title ?? defaultTitle}
             onClick={(event) => {
                 event.preventDefault();
-                if (isExternal) getHost().navigation?.openExternalUrl(href);
+                if (itemLink) activateItemLink(itemLink);
+                else if (isExternal) getHost().navigation?.openExternalUrl(href);
             }}
         >
             {children}
@@ -358,7 +387,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(function Ma
                         <ReactMarkdown
                             remarkPlugins={[remarkMath, remarkGfm]}
                             rehypePlugins={rehypePlugins}
-                            urlTransform={urlTransform}
+                            urlTransform={exportRendering ? exportUrlTransform : urlTransform}
                             components={{
                                 // @ts-expect-error - Custom component not in ReactMarkdown types
                                 citation: ({node, ...props}: any) => {

--- a/react/host/zotero/navigation.ts
+++ b/react/host/zotero/navigation.ts
@@ -86,6 +86,33 @@ export const zoteroNavigation: NavigationHost = {
         if (found) selectCollection(found);
         else notifyReferenceUnavailable('collection');
     },
+    async revealObject(ref: ZoteroItemReference): Promise<void> {
+        // Click handler: an uncaught throw here is a silent dead link.
+        try {
+            const libraryID = resolveLibraryRef(ref);
+            if (!libraryID) {
+                notifyReferenceUnavailable('link', 'library_unavailable');
+                return;
+            }
+            const item = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, ref.zotero_key);
+            if (item) {
+                // Annotations have no row in the items tree; the reader is
+                // the only place they can be shown.
+                if (item.isAnnotation()) await navigateToAnnotation(item);
+                else revealSource({ ...ref, library_id: libraryID });
+                return;
+            }
+            // Items and collections have separate key spaces, so a key that
+            // is not an item may still be a collection.
+            const collection = Zotero.Collections.getByLibraryAndKey(libraryID, ref.zotero_key);
+            // Trashed collections still resolve but cannot be selected.
+            if (collection && (await selectCollection(collection as Zotero.Collection))) return;
+            notifyReferenceUnavailable('link');
+        } catch (error) {
+            logger(`revealObject: failed to reveal ${ref.zotero_key}: ${error}`, 2);
+            notifyReferenceUnavailable('link');
+        }
+    },
     launchFile(filePath: string): void {
         Zotero.launchFile(filePath);
     },

--- a/react/host/zotero/sourceActions.ts
+++ b/react/host/zotero/sourceActions.ts
@@ -17,10 +17,11 @@ function notifyExternalFileUnavailable(): void {
 }
 
 /**
- * A navigation target (item, collection, annotation, saved action, tag) that
- * was rendered from persisted run history but no longer exists on this computer.
+ * A navigation target (item, collection, annotation, saved action, tag, or the
+ * object an in-prose link names) that was rendered from persisted run history
+ * but does not exist on this computer.
  */
-export type UnavailableReferenceKind = 'item' | 'collection' | 'annotation' | 'action' | 'tag';
+export type UnavailableReferenceKind = 'item' | 'collection' | 'annotation' | 'action' | 'tag' | 'link';
 export type UnavailableReferenceCause = 'missing' | 'library_unavailable';
 
 const UNAVAILABLE_REFERENCE_COPY: Record<UnavailableReferenceKind, { title: string; text: string }> = {
@@ -44,6 +45,12 @@ const UNAVAILABLE_REFERENCE_COPY: Record<UnavailableReferenceKind, { title: stri
         title: 'Tag Not Available',
         text: 'This tag is no longer on any item in your Zotero libraries. It may have been renamed or removed.',
     },
+    // The link was written by the model, so unlike the other kinds the target
+    // may never have existed.
+    link: {
+        title: 'Item Not Found',
+        text: "This link doesn't match any item or collection in your Zotero library. It may have been deleted, or the link may be incorrect.",
+    },
 };
 
 const LIBRARY_UNAVAILABLE_COPY: Record<Exclude<UnavailableReferenceKind, 'action'>, { title: string; text: string }> = {
@@ -62,6 +69,10 @@ const LIBRARY_UNAVAILABLE_COPY: Record<Exclude<UnavailableReferenceKind, 'action
     tag: {
         title: 'Tag Not Available',
         text: "This tag was applied in a library that isn't available on this computer. It may be a group library you haven't joined on this device.",
+    },
+    link: {
+        title: 'Item Not Found',
+        text: "This link points to a library that isn't available on this computer. It may be a group library you haven't joined on this device.",
     },
 };
 

--- a/react/utils/citationRenderers.ts
+++ b/react/utils/citationRenderers.ts
@@ -12,7 +12,8 @@ import { ZoteroItemReference } from '@beaver/agent-core/types/zotero';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { ExternalReference } from '@beaver/agent-core/types/externalReferences';
 import { formatExternalCitation } from '@beaver/agent-core/citations/externalReferences';
-import { UNRESOLVED_LIBRARY_ID } from '../../src/utils/libraryIdentity';
+import { UNRESOLVED_LIBRARY_ID, libraryRefForLibraryID } from '../../src/utils/libraryIdentity';
+import { hydrateItemLinkLibraryRefs } from './itemLinks';
 import {
     baseCitationKey,
     getPageLocator,
@@ -291,6 +292,11 @@ export function renderToHTML(
     contextData?: RenderContextData
 ): string {
     let renderStore = store;
+
+    // Data boundary for the export render: legacy device-local item links in
+    // older history become portable here, so the renderer can write them as
+    // note links without consulting library state itself.
+    content = hydrateItemLinkLibraryRefs(content, libraryRefForLibraryID);
 
     // Pre-calculate citation markers for static render to avoid React state updates during render.
     // This must happen before the render since effects don't run during renderToStaticMarkup.

--- a/react/utils/itemLinks.ts
+++ b/react/utils/itemLinks.ts
@@ -12,7 +12,7 @@
  * Parsing is pure. Resolving a link against the libraries on this computer
  * happens at click time, through the host (`navigation.revealObject`).
  */
-import { parseItemReference, resolveLibraryRefForLibraryID } from '@beaver/agent-core/identity/libraryRef';
+import { parseItemReference } from '@beaver/agent-core/identity/libraryRef';
 
 /**
  * Shape of a Zotero object key. Zotero generates eight characters from an
@@ -59,10 +59,40 @@ export function parseItemLinkHref(href: string | null | undefined): ItemLinkTarg
 }
 
 /**
+ * Legacy `<libraryID>-KEY` hrefs in markdown link syntax and raw `href`
+ * attributes. Only a link's target position is matched, so the same text in
+ * prose is untouched.
+ */
+const LEGACY_LINK_HREF_PATTERN = /(\]\(|href=")([1-9][0-9]*)-([A-Z0-9]{8})(?=[)\s"])/g;
+
+/**
+ * Rewrite legacy `<libraryID>-KEY` link targets to their portable
+ * `<library_ref>-KEY` form, using the caller's device-local library mapping.
+ *
+ * Run this at the data boundary, before content reaches a render, so the
+ * renderer itself never has to consult library state: older thread history
+ * still carries device-local ids, and a note exported from it must link
+ * portably. A library with no portable identity leaves its link as written.
+ */
+export function hydrateItemLinkLibraryRefs(
+    markdown: string,
+    libraryRefForLibraryID: (libraryID: number) => string | null,
+): string {
+    return markdown.replace(LEGACY_LINK_HREF_PATTERN, (match, opener: string, libraryID: string, key: string) => {
+        const libraryRef = libraryRefForLibraryID(Number(libraryID));
+        return libraryRef ? `${opener}${libraryRef}-${key}` : match;
+    });
+}
+
+/**
  * The `zotero://select` URI an item link should carry when the rendered
  * markdown is saved into a Zotero note, where a bare object id is not a
- * working link. Returns `null` when the href is not an item link, or when a
- * legacy numeric id names a library with no portable identity on this device.
+ * working link. Returns `null` when the href is not an item link.
+ *
+ * Only portable ids are rewritten; the export boundary hydrates legacy ids
+ * first (`hydrateItemLinkLibraryRefs`), so by the time content renders, a
+ * remaining numeric id names a library with no portable identity and is left
+ * as written rather than resolved here.
  *
  * A bare object id is written as an item URI: it cannot say whether it names a
  * collection, and items are what prose links point at in practice.
@@ -70,11 +100,10 @@ export function parseItemLinkHref(href: string | null | undefined): ItemLinkTarg
 export function itemLinkExportHref(href: string): string | null {
     const target = parseItemLinkHref(href);
     if (!target) return null;
-    const parsed = parseItemReference(target.objectId);
-    if (!parsed) return null;
-    const libraryRef = parsed.library_ref ?? resolveLibraryRefForLibraryID(parsed.library_id!);
+    const libraryRef = parseItemReference(target.objectId)?.library_ref;
     if (!libraryRef) return null;
+    const zoteroKey = target.objectId.slice(libraryRef.length + 1);
     const scope = libraryRef === 'u' ? 'library' : `groups/${libraryRef.slice(1)}`;
     const type = target.kind === 'collection' ? 'collections' : 'items';
-    return `zotero://select/${scope}/${type}/${parsed.zotero_key}`;
+    return `zotero://select/${scope}/${type}/${zoteroKey}`;
 }

--- a/react/utils/itemLinks.ts
+++ b/react/utils/itemLinks.ts
@@ -1,0 +1,80 @@
+/**
+ * Zotero object links in chat markdown.
+ *
+ * The model can link prose to something it has seen in the library —
+ * `[Smith 2004](u-ANVV522N)` — using the same object id every tool result
+ * reports: `u-KEY`, `g<groupID>-KEY`, or the legacy device-local
+ * `<libraryID>-KEY`. The key may name any keyed Zotero object in that library:
+ * a regular item, attachment, note, annotation, or collection. Zotero's own
+ * `zotero://select/...` item and collection URIs are accepted too, so a link
+ * written in that grammar behaves the same way.
+ *
+ * Parsing is pure. Resolving a link against the libraries on this computer
+ * happens at click time, through the host (`navigation.revealObject`).
+ */
+import { parseItemReference, resolveLibraryRefForLibraryID } from '@beaver/agent-core/identity/libraryRef';
+
+/**
+ * Shape of a Zotero object key. Zotero generates eight characters from an
+ * uppercase alphanumeric alphabet; this is what keeps an ordinary relative link
+ * such as `u-turn` from being mistaken for an object id.
+ */
+const OBJECT_KEY_PATTERN = /^[A-Z0-9]{8}$/;
+
+/** `zotero://select/library/items/KEY`, `.../groups/<id>/collections/KEY`, ... */
+const SELECT_URI_PATTERN = /^zotero:\/\/select\/(library|groups\/([1-9][0-9]*))\/(items|collections)\/([^/?#]+)$/;
+
+/** A markdown href recognized as a link to a Zotero object. */
+export type ItemLinkTarget = {
+    /** Model-facing object id: `u-KEY`, `g<groupID>-KEY`, or `<libraryID>-KEY`. */
+    objectId: string;
+    /**
+     * What the key names. A bare object id does not say, so it is an `object`
+     * (item or collection, decided when the link is followed); only a
+     * `zotero://select/.../collections/KEY` URI is a known `collection`.
+     */
+    kind: 'object' | 'collection';
+};
+
+/**
+ * Recognize an href as a link to a Zotero object. Returns `null` for every
+ * other href (web links, fragments, `zotero://beaver/...` thread links, ...),
+ * which then keep their ordinary link behavior.
+ */
+export function parseItemLinkHref(href: string | null | undefined): ItemLinkTarget | null {
+    if (!href) return null;
+
+    const select = SELECT_URI_PATTERN.exec(href);
+    if (select) {
+        const [, scope, groupID, type, key] = select;
+        if (!OBJECT_KEY_PATTERN.test(key)) return null;
+        const libraryRef = scope === 'library' ? 'u' : `g${groupID}`;
+        return { objectId: `${libraryRef}-${key}`, kind: type === 'collections' ? 'collection' : 'object' };
+    }
+
+    if (href.includes('/') || href.includes(':')) return null;
+    const parsed = parseItemReference(href);
+    if (!parsed || !OBJECT_KEY_PATTERN.test(parsed.zotero_key)) return null;
+    return { objectId: href, kind: 'object' };
+}
+
+/**
+ * The `zotero://select` URI an item link should carry when the rendered
+ * markdown is saved into a Zotero note, where a bare object id is not a
+ * working link. Returns `null` when the href is not an item link, or when a
+ * legacy numeric id names a library with no portable identity on this device.
+ *
+ * A bare object id is written as an item URI: it cannot say whether it names a
+ * collection, and items are what prose links point at in practice.
+ */
+export function itemLinkExportHref(href: string): string | null {
+    const target = parseItemLinkHref(href);
+    if (!target) return null;
+    const parsed = parseItemReference(target.objectId);
+    if (!parsed) return null;
+    const libraryRef = parsed.library_ref ?? resolveLibraryRefForLibraryID(parsed.library_id!);
+    if (!libraryRef) return null;
+    const scope = libraryRef === 'u' ? 'library' : `groups/${libraryRef.slice(1)}`;
+    const type = target.kind === 'collection' ? 'collections' : 'items';
+    return `zotero://select/${scope}/${type}/${parsed.zotero_key}`;
+}

--- a/tests/unit/host/zoteroNavigationRevealObject.test.ts
+++ b/tests/unit/host/zoteroNavigationRevealObject.test.ts
@@ -1,0 +1,134 @@
+/**
+ * `navigation.revealObject`: an object link carries a key but not a type, so
+ * the host decides what the key names and how to show it.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+declare const Zotero: any;
+
+const { resolveLibraryRef, revealSource, selectCollection, navigateToAnnotation, notifyReferenceUnavailable } =
+    vi.hoisted(() => ({
+        resolveLibraryRef: vi.fn(),
+        revealSource: vi.fn(),
+        selectCollection: vi.fn(),
+        navigateToAnnotation: vi.fn(),
+        notifyReferenceUnavailable: vi.fn(),
+    }));
+
+vi.mock('../../../src/utils/libraryIdentity', () => ({
+    resolveLibraryRef,
+    resolveItemReference: vi.fn(),
+}));
+vi.mock('../../../react/utils/sourceUtils', () => ({
+    revealSource,
+    openSource: vi.fn(),
+}));
+vi.mock('../../../src/utils/selectItem', () => ({
+    selectCollection,
+    selectLibrary: vi.fn(),
+    selectTagFilter: vi.fn(),
+}));
+vi.mock('../../../react/host/zotero/citationActivation', () => ({
+    activateCitation: vi.fn(),
+}));
+vi.mock('../../../react/host/zotero/sourceActions', () => ({
+    launchExternalFile: vi.fn(),
+    notifyReferenceUnavailable,
+    notifyTagAmbiguous: vi.fn(),
+}));
+vi.mock('../../../react/utils/readerUtils', () => ({
+    navigateToAnnotation,
+}));
+vi.mock('../../../react/utils/attachmentMatchNavigation', () => ({
+    navigateToAttachmentMatch: vi.fn(),
+}));
+vi.mock('../../../src/ui/openPreferencesWindow', () => ({
+    openPreferencesWindow: vi.fn(),
+}));
+vi.mock('../../../react/types/actionStorage', () => ({
+    getMergedActions: vi.fn(() => []),
+}));
+
+import { zoteroNavigation } from '../../../react/host/zotero/navigation';
+
+const ref = { library_id: 0, library_ref: 'u', zotero_key: 'ANVV522N' };
+
+describe('zoteroNavigation.revealObject', () => {
+    const getByLibraryAndKeyAsync = vi.fn();
+    const getByLibraryAndKey = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Zotero.Items = { getByLibraryAndKeyAsync };
+        Zotero.Collections = { getByLibraryAndKey };
+        resolveLibraryRef.mockReturnValue(1);
+        getByLibraryAndKeyAsync.mockResolvedValue(false);
+        getByLibraryAndKey.mockReturnValue(false);
+        selectCollection.mockResolvedValue(true);
+    });
+
+    it('reveals a library item in the library view', async () => {
+        getByLibraryAndKeyAsync.mockResolvedValue({ isAnnotation: () => false });
+
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(getByLibraryAndKeyAsync).toHaveBeenCalledWith(1, 'ANVV522N');
+        expect(revealSource).toHaveBeenCalledWith({ ...ref, library_id: 1 });
+        expect(notifyReferenceUnavailable).not.toHaveBeenCalled();
+    });
+
+    it('opens an annotation in the reader instead of the library view', async () => {
+        const annotation = { isAnnotation: () => true };
+        getByLibraryAndKeyAsync.mockResolvedValue(annotation);
+
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(navigateToAnnotation).toHaveBeenCalledWith(annotation);
+        expect(revealSource).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a collection with that key', async () => {
+        const collection = { id: 7 };
+        getByLibraryAndKey.mockReturnValue(collection);
+
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(getByLibraryAndKey).toHaveBeenCalledWith(1, 'ANVV522N');
+        expect(selectCollection).toHaveBeenCalledWith(collection);
+        expect(notifyReferenceUnavailable).not.toHaveBeenCalled();
+    });
+
+    it('tells the user when the key names nothing in the library', async () => {
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(revealSource).not.toHaveBeenCalled();
+        expect(selectCollection).not.toHaveBeenCalled();
+        expect(notifyReferenceUnavailable).toHaveBeenCalledWith('link');
+    });
+
+    it('treats a collection that cannot be selected as unavailable', async () => {
+        getByLibraryAndKey.mockReturnValue({ id: 7 });
+        selectCollection.mockResolvedValue(false);
+
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(notifyReferenceUnavailable).toHaveBeenCalledWith('link');
+    });
+
+    it('tells the user when the library is not on this computer', async () => {
+        resolveLibraryRef.mockReturnValue(null);
+
+        await zoteroNavigation.revealObject!({ ...ref, library_ref: 'g99' });
+
+        expect(getByLibraryAndKeyAsync).not.toHaveBeenCalled();
+        expect(notifyReferenceUnavailable).toHaveBeenCalledWith('link', 'library_unavailable');
+    });
+
+    it('never lets a lookup failure turn into a dead link', async () => {
+        getByLibraryAndKeyAsync.mockRejectedValue(new Error('boom'));
+
+        await zoteroNavigation.revealObject!(ref);
+
+        expect(notifyReferenceUnavailable).toHaveBeenCalledWith('link');
+    });
+});

--- a/tests/unit/services/clientFeatures.test.ts
+++ b/tests/unit/services/clientFeatures.test.ts
@@ -70,6 +70,10 @@ const VERSION_GATES: { feature: string; minVersion: string; op: Op }[] = [
 // pdf_candidates is declaration-only because the backend would otherwise send a
 // ranked candidate list to clients that ignore it, paying the payload for
 // nothing.
+// item_links is declaration-only because it describes what the chat client's
+// markdown renderer does with object-id hrefs; a client that predates it would
+// treat `[Smith 2004](u-KEY)` as a broken relative link, so the backend only
+// tells the model to write those when this feature is declared.
 const DECLARATION_ONLY_FEATURES = [
     'external_files',
     'pdf_candidates',
@@ -88,6 +92,7 @@ const DECLARATION_ONLY_FEATURES = [
     'credit_confirmation',
     'batch_jobs',
     'citation_graph',
+    'item_links',
 ];
 
 // The full backend feature vocabulary (ALL_FEATURES in version_gates.py): every

--- a/tests/unit/utils/itemLinks.test.ts
+++ b/tests/unit/utils/itemLinks.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The grammar of Zotero object links in chat markdown: which hrefs are
+ * recognized as object ids, and how they are written when saved into a note.
+ */
+import { describe, expect, it } from 'vitest';
+import { setLibraryRefResolver } from '@beaver/agent-core/identity/libraryRef';
+import { itemLinkExportHref, parseItemLinkHref } from '../../../react/utils/itemLinks';
+
+describe('parseItemLinkHref', () => {
+    it('recognizes a bare object id in every library form', () => {
+        expect(parseItemLinkHref('u-ANVV522N')).toEqual({ objectId: 'u-ANVV522N', kind: 'object' });
+        expect(parseItemLinkHref('g12345-ANVV522N')).toEqual({ objectId: 'g12345-ANVV522N', kind: 'object' });
+        expect(parseItemLinkHref('3-ANVV522N')).toEqual({ objectId: '3-ANVV522N', kind: 'object' });
+    });
+
+    it('recognizes zotero://select item and collection URIs', () => {
+        expect(parseItemLinkHref('zotero://select/library/items/ANVV522N'))
+            .toEqual({ objectId: 'u-ANVV522N', kind: 'object' });
+        expect(parseItemLinkHref('zotero://select/groups/42/items/ANVV522N'))
+            .toEqual({ objectId: 'g42-ANVV522N', kind: 'object' });
+        expect(parseItemLinkHref('zotero://select/library/collections/ANVV522N'))
+            .toEqual({ objectId: 'u-ANVV522N', kind: 'collection' });
+        expect(parseItemLinkHref('zotero://select/groups/42/collections/ANVV522N'))
+            .toEqual({ objectId: 'g42-ANVV522N', kind: 'collection' });
+    });
+
+    it('leaves every other href alone', () => {
+        for (const href of [
+            undefined,
+            null,
+            '',
+            '#section',
+            'https://example.org/u-ANVV522N',
+            'mailto:u-ANVV522N@example.org',
+            'zotero://beaver/thread/abc',
+            'zotero://open-pdf/library/items/ANVV522N',
+            'zotero://select/library/items/ANVV522N?page=2',
+            // Relative links that happen to start like an object id.
+            'u-turn',
+            'g1-notes.md',
+            '2-column',
+            'u-anvv522n',
+            'u-ANVV522',
+            'u-ANVV522N/extra',
+            // Malformed library prefixes.
+            '0-ANVV522N',
+            'g0-ANVV522N',
+            'x-ANVV522N',
+            '-ANVV522N',
+            'ANVV522N',
+        ]) {
+            expect(parseItemLinkHref(href), String(href)).toBeNull();
+        }
+    });
+});
+
+describe('itemLinkExportHref', () => {
+    it('writes portable object ids as zotero://select URIs', () => {
+        expect(itemLinkExportHref('u-ANVV522N')).toBe('zotero://select/library/items/ANVV522N');
+        expect(itemLinkExportHref('g42-ANVV522N')).toBe('zotero://select/groups/42/items/ANVV522N');
+    });
+
+    it('keeps a collection URI a collection URI', () => {
+        expect(itemLinkExportHref('zotero://select/groups/42/collections/ANVV522N'))
+            .toBe('zotero://select/groups/42/collections/ANVV522N');
+    });
+
+    it('resolves a legacy numeric library id through the library-ref seam', () => {
+        setLibraryRefResolver((libraryID) => (libraryID === 1 ? 'u' : libraryID === 3 ? 'g77' : null));
+        expect(itemLinkExportHref('1-ANVV522N')).toBe('zotero://select/library/items/ANVV522N');
+        expect(itemLinkExportHref('3-ANVV522N')).toBe('zotero://select/groups/77/items/ANVV522N');
+        // No portable identity for this library on this device: nothing better to write.
+        expect(itemLinkExportHref('9-ANVV522N')).toBeNull();
+    });
+
+    it('returns null for hrefs that are not item links', () => {
+        expect(itemLinkExportHref('https://example.org')).toBeNull();
+        expect(itemLinkExportHref('u-turn')).toBeNull();
+    });
+});

--- a/tests/unit/utils/itemLinks.test.ts
+++ b/tests/unit/utils/itemLinks.test.ts
@@ -3,8 +3,7 @@
  * recognized as object ids, and how they are written when saved into a note.
  */
 import { describe, expect, it } from 'vitest';
-import { setLibraryRefResolver } from '@beaver/agent-core/identity/libraryRef';
-import { itemLinkExportHref, parseItemLinkHref } from '../../../react/utils/itemLinks';
+import { hydrateItemLinkLibraryRefs, itemLinkExportHref, parseItemLinkHref } from '../../../react/utils/itemLinks';
 
 describe('parseItemLinkHref', () => {
     it('recognizes a bare object id in every library form', () => {
@@ -65,16 +64,35 @@ describe('itemLinkExportHref', () => {
             .toBe('zotero://select/groups/42/collections/ANVV522N');
     });
 
-    it('resolves a legacy numeric library id through the library-ref seam', () => {
-        setLibraryRefResolver((libraryID) => (libraryID === 1 ? 'u' : libraryID === 3 ? 'g77' : null));
-        expect(itemLinkExportHref('1-ANVV522N')).toBe('zotero://select/library/items/ANVV522N');
-        expect(itemLinkExportHref('3-ANVV522N')).toBe('zotero://select/groups/77/items/ANVV522N');
-        // No portable identity for this library on this device: nothing better to write.
-        expect(itemLinkExportHref('9-ANVV522N')).toBeNull();
+    it('never resolves a legacy device-local library id itself', () => {
+        // Hydration at the export boundary is responsible for legacy ids.
+        expect(itemLinkExportHref('1-ANVV522N')).toBeNull();
+        expect(itemLinkExportHref('3-ANVV522N')).toBeNull();
     });
 
     it('returns null for hrefs that are not item links', () => {
         expect(itemLinkExportHref('https://example.org')).toBeNull();
         expect(itemLinkExportHref('u-turn')).toBeNull();
+    });
+});
+
+describe('hydrateItemLinkLibraryRefs', () => {
+    const libraryRef = (libraryID: number) => (libraryID === 1 ? 'u' : libraryID === 3 ? 'g77' : null);
+
+    it('rewrites legacy link targets to their portable form', () => {
+        expect(hydrateItemLinkLibraryRefs('See [Smith 2004](1-ANVV522N) and [Doe](3-BBBB2222).', libraryRef))
+            .toBe('See [Smith 2004](u-ANVV522N) and [Doe](g77-BBBB2222).');
+    });
+
+    it('handles link titles and raw href attributes', () => {
+        expect(hydrateItemLinkLibraryRefs('[Smith](1-ANVV522N "Smith 2004")', libraryRef))
+            .toBe('[Smith](u-ANVV522N "Smith 2004")');
+        expect(hydrateItemLinkLibraryRefs('<a href="3-ANVV522N">Doe</a>', libraryRef))
+            .toBe('<a href="g77-ANVV522N">Doe</a>');
+    });
+
+    it('leaves portable ids, prose, and unmappable libraries as written', () => {
+        const content = 'Id 1-ANVV522N in prose, [ok](u-ANVV522N), [gone](9-ANVV522N), [web](https://x.org/1-ANVV522N)';
+        expect(hydrateItemLinkLibraryRefs(content, libraryRef)).toBe(content);
     });
 });

--- a/tests/unit/utils/markdownItemLinks.test.ts
+++ b/tests/unit/utils/markdownItemLinks.test.ts
@@ -21,6 +21,9 @@ vi.mock('../../../react/components/messages/NoteDisplay', () => ({
 
 import { setHost } from '@beaver/agent-ui/host';
 import MarkdownRenderer from '../../../react/components/messages/MarkdownRenderer';
+import { renderToHTML } from '../../../react/utils/citationRenderers';
+
+declare const Zotero: any;
 
 const navigation = {
     revealObject: vi.fn(),
@@ -99,5 +102,22 @@ describe('MarkdownRenderer item links', () => {
         const html = staticHtml('See [Smith 2004](u-ANVV522N).', true);
         expect(html).toContain('href="zotero://select/library/items/ANVV522N"');
         expect(html).not.toContain('title="Show in Zotero"');
+    });
+
+    it('exports legacy device-local ids from older history as working note links', () => {
+        // Older history names libraries by rowid; the export boundary maps them
+        // through this device's libraries before the render sees the content.
+        Zotero.Libraries.userLibraryID = 1;
+        Zotero.Groups = {
+            getGroupIDFromLibraryID: (libraryID: number) => {
+                if (libraryID === 3) return 77;
+                throw new Error('not a group library');
+            },
+        };
+
+        const html = renderToHTML('See [Smith 2004](1-ANVV522N) and [Doe 2010](3-BBBB2222).');
+
+        expect(html).toContain('href="zotero://select/library/items/ANVV522N"');
+        expect(html).toContain('href="zotero://select/groups/77/items/BBBB2222"');
     });
 });

--- a/tests/unit/utils/markdownItemLinks.test.ts
+++ b/tests/unit/utils/markdownItemLinks.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+/**
+ * Zotero object links in the rendered chat body: `[Smith 2004](u-KEY)` renders
+ * as an anchor that reveals the object through the host on click, while every
+ * other link keeps its behavior. Export renders carry a working
+ * `zotero://select` href instead.
+ */
+import React, { act } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-ui/chat/Citation', () => ({
+    default: () => null,
+}));
+
+vi.mock('../../../react/components/messages/NoteDisplay', () => ({
+    default: () => null,
+}));
+
+import { setHost } from '@beaver/agent-ui/host';
+import MarkdownRenderer from '../../../react/components/messages/MarkdownRenderer';
+
+const navigation = {
+    revealObject: vi.fn(),
+    revealCollection: vi.fn(),
+    openExternalUrl: vi.fn(),
+};
+
+function staticHtml(content: string, exportRendering = false): string {
+    return renderToStaticMarkup(React.createElement(MarkdownRenderer, { content, exportRendering }));
+}
+
+describe('MarkdownRenderer item links', () => {
+    let root: ReturnType<typeof createRoot> | null = null;
+    let container: HTMLDivElement | null = null;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+        setHost({ navigation: navigation as any });
+    });
+
+    afterEach(() => {
+        if (root) act(() => root?.unmount());
+        container?.remove();
+        root = null;
+        container = null;
+        setHost({});
+        delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+    });
+
+    /** Mount `content` and click the first anchor. */
+    function clickFirstLink(content: string): HTMLAnchorElement {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+        act(() => {
+            root?.render(React.createElement(MarkdownRenderer, { content }));
+        });
+        const anchor = container.querySelector('a');
+        expect(anchor).not.toBeNull();
+        act(() => {
+            anchor!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        });
+        return anchor!;
+    }
+
+    it('renders an object id link as an anchor that says what it does', () => {
+        const html = staticHtml('See [Smith 2004](u-ANVV522N).');
+        expect(html).toContain('<a href="u-ANVV522N" title="Show in Zotero">Smith 2004</a>');
+    });
+
+    it('reveals the object through the host on click', () => {
+        clickFirstLink('See [Smith 2004](g42-ANVV522N).');
+        expect(navigation.revealObject).toHaveBeenCalledTimes(1);
+        expect(navigation.revealObject).toHaveBeenCalledWith(
+            expect.objectContaining({ library_ref: 'g42', zotero_key: 'ANVV522N' }),
+        );
+        expect(navigation.openExternalUrl).not.toHaveBeenCalled();
+    });
+
+    it('reveals a collection when the link says it is one', () => {
+        clickFirstLink('Filed under [Methods](zotero://select/library/collections/ANVV522N).');
+        expect(navigation.revealCollection).toHaveBeenCalledWith(
+            expect.objectContaining({ library_ref: 'u', zotero_key: 'ANVV522N' }),
+        );
+        expect(navigation.revealObject).not.toHaveBeenCalled();
+    });
+
+    it('still opens ordinary links through the host', () => {
+        clickFirstLink('See [the docs](https://example.org/u-ANVV522N).');
+        expect(navigation.openExternalUrl).toHaveBeenCalledWith('https://example.org/u-ANVV522N');
+        expect(navigation.revealObject).not.toHaveBeenCalled();
+    });
+
+    it('writes a zotero://select href when rendering for note export', () => {
+        const html = staticHtml('See [Smith 2004](u-ANVV522N).', true);
+        expect(html).toContain('href="zotero://select/library/items/ANVV522N"');
+        expect(html).not.toContain('title="Show in Zotero"');
+    });
+});


### PR DESCRIPTION
## Summary

- Add portable Zotero object-link parsing for items, annotations, and collections.
- Reveal linked objects through Zotero navigation from chat markdown.
- Export item links as working `zotero://select` note links, including legacy library IDs.
- Advertise the `ITEM_LINKS` client feature and add coverage for parsing, navigation, and rendering.

## Testing

- Added unit tests for item-link parsing and export conversion.
- Added navigation tests for items, annotations, collections, unavailable libraries, and lookup failures.
- Added markdown rendering and click-behavior tests for Zotero and external links.