### PR TITLE
refactor(preferences): redesign settings page with sidebar layout

### DIFF
--- a/addon/content/beaverPreferences.xhtml
+++ b/addon/content/beaverPreferences.xhtml
@@ -11,9 +11,10 @@
 <window
     id="beaver-preferences-window"
     orient="vertical"
-    width="695"
-    height="600"
-    minwidth="710"
+    width="920"
+    height="660"
+    minwidth="840"
+    minheight="560"
     title="Beaver Settings"
     persist="screenX screenY width height"
     windowtype="beaver:preferences"

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -78,15 +78,16 @@
 #beaver-pane-preferences .beaver-prefs-nav-item {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 9px;
     width: 100%;
     margin: 0;
-    padding: 6px 10px;
+    padding: 7px 10px;
     border: none;
     border-radius: 6px;
     background-color: transparent;
     color: var(--fill-primary);
     font: inherit;
+    font-size: 1.0625rem;
     line-height: 1.3;
     text-align: left;
     white-space: nowrap;
@@ -110,6 +111,8 @@
 
 #beaver-pane-preferences .beaver-prefs-nav-item svg {
     flex-shrink: 0;
+    width: 18px;
+    height: 18px;
     color: var(--fill-secondary);
 }
 
@@ -117,18 +120,49 @@
     color: var(--fill-primary);
 }
 
-/* Account block at the bottom of the sidebar. */
+/* Account block at the bottom of the sidebar: a button that opens Plan & Usage,
+ * styled like the navigation entries above it. */
+#beaver-pane-preferences .beaver-prefs-account {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-width: 0;
+    margin: 0;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 8px;
+    background-color: transparent;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+#beaver-pane-preferences .beaver-prefs-account:hover {
+    background-color: var(--fill-quinary);
+}
+
+#beaver-pane-preferences .beaver-prefs-account[aria-current="page"] {
+    background-color: var(--fill-quarternary);
+}
+
+#beaver-pane-preferences .beaver-prefs-account:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+}
+
 #beaver-pane-preferences .beaver-prefs-avatar {
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 30px;
-    height: 30px;
+    width: 38px;
+    height: 38px;
     border-radius: 50%;
     background-color: var(--fill-quarternary);
     color: var(--fill-primary);
-    font-size: 0.85rem;
+    font-size: 1.05rem;
     font-weight: 600;
     text-transform: uppercase;
 }

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -49,10 +49,88 @@
     min-height: 600px;
 }
 
-/* Preferences window: sizing and constraints. */
+/* Preferences window: sizing and constraints. The minimum keeps the sidebar
+ * (see .beaver-prefs-sidebar) plus a usable settings column on screen. */
 #beaver-preferences-window {
-    min-width: 695px;
-    min-height: 600px;
+    min-width: 840px;
+    min-height: 560px;
+}
+
+/* Preferences window: two-column shell. The sidebar keeps the window's
+ * sidepane material; the settings column sits on the plain background so the
+ * cards read against it the way they do in Zotero's own settings. */
+#beaver-pane-preferences .beaver-prefs-sidebar {
+    width: 212px;
+    background-color: var(--material-sidepane);
+}
+
+#beaver-pane-preferences .beaver-prefs-content {
+    background-color: var(--color-background);
+}
+
+#beaver-pane-preferences .beaver-prefs-page {
+    max-width: 860px;
+    padding: 22px 28px 40px;
+}
+
+/* Sidebar navigation entries. Plain buttons: the chrome default look is
+ * removed so only the selected / hovered pill shows. */
+#beaver-pane-preferences .beaver-prefs-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    margin: 0;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--fill-primary);
+    font: inherit;
+    line-height: 1.3;
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+#beaver-pane-preferences .beaver-prefs-nav-item:hover {
+    background-color: var(--fill-quinary);
+}
+
+#beaver-pane-preferences .beaver-prefs-nav-item[aria-selected="true"] {
+    background-color: var(--fill-quarternary);
+    font-weight: 500;
+}
+
+#beaver-pane-preferences .beaver-prefs-nav-item:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+}
+
+#beaver-pane-preferences .beaver-prefs-nav-item svg {
+    flex-shrink: 0;
+    color: var(--fill-secondary);
+}
+
+#beaver-pane-preferences .beaver-prefs-nav-item[aria-selected="true"] svg {
+    color: var(--fill-primary);
+}
+
+/* Account block at the bottom of the sidebar. */
+#beaver-pane-preferences .beaver-prefs-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background-color: var(--fill-quarternary);
+    color: var(--fill-primary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
 }
 
 /* Floating Popup Overlay - renders over main Zotero window, bottom-right */

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -143,13 +143,14 @@
     background-color: var(--fill-quinary);
 }
 
-#beaver-pane-preferences .beaver-prefs-account[aria-current="page"] {
-    background-color: var(--fill-quarternary);
-}
-
 #beaver-pane-preferences .beaver-prefs-account:focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: -2px;
+}
+
+/* Legal links: a footnote under the account, indented to the avatar's edge. */
+#beaver-pane-preferences .beaver-prefs-legal {
+    padding: 6px 8px 0;
 }
 
 #beaver-pane-preferences .beaver-prefs-avatar {

--- a/react/components/preferences/ActionsPreferenceSection.tsx
+++ b/react/components/preferences/ActionsPreferenceSection.tsx
@@ -14,7 +14,7 @@ import { isBuiltinAction, getActionCustomizations, getHiddenBuiltinActions, hasO
 import ActionCard from "./ActionCard";
 import MenuButton from "@beaver/agent-ui/primitives/MenuButton";
 import { MenuItem } from "@beaver/agent-ui/primitives/ContextMenu";
-import {SectionLabel, DocLink, SectionHeader} from "./components/SettingsElements";
+import {DocLink, PageHeader} from "./components/SettingsElements";
 
 // Filter dimensions. `targets` is what an action binds to (the filter matches
 // any action accepting the kind); `category` is the kind of work it is (both
@@ -213,9 +213,10 @@ const ActionsPreferenceSection: React.FC = () => {
 
     return (
         <>
-            <div className="display-flex flex-row items-end justify-between">
-                <SectionHeader>Actions</SectionHeader>
-                <div className="display-flex flex-row items-center gap-4 mb-15">
+            <PageHeader
+                title="Actions"
+                actions={
+                <div className="display-flex flex-row items-center gap-3">
                     <Button
                         variant="outline"
                         className="text-base"
@@ -236,13 +237,13 @@ const ActionsPreferenceSection: React.FC = () => {
                         Add Action
                     </Button>
                 </div>
-            </div>
-            <div className="text-base font-color-secondary mb-2" style={{ paddingLeft: '2px' }}>
+                }
+            >
                 Actions are reusable prompts for common research tasks.
                 They appear based on what you're doing in Zotero: on the Beaver homepage, in the slash menu, and Zotero's right-click menu.
                 Each action targets items, collections, or your whole library, and Beaver shows the relevant ones automatically.
                 {' '}<DocLink path="actions">Learn more</DocLink>.
-            </div>
+            </PageHeader>
 
             {/* Filter toolbar — narrow the list by target and/or category */}
             <div className="display-flex flex-row flex-1 items-center gap-3 flex-wrap mb-15 mt-4" style={{ paddingLeft: '2px' }}>

--- a/react/components/preferences/ApiKeysSection.tsx
+++ b/react/components/preferences/ApiKeysSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import Button from "@beaver/agent-ui/primitives/Button";
-import {SettingsGroup, SettingsRow, SectionLabel, DocLink, ExternalLink, SectionHeader, SectionDescription, INTELLIGENCE_INDEX_URL} from "./components/SettingsElements";
+import {SettingsGroup, SettingsRow, SectionLabel, DocLink, ExternalLink, SectionDescription, INTELLIGENCE_INDEX_URL} from "./components/SettingsElements";
 import ApiKeyInput from "./ApiKeyInput";
 import CustomProviderCard from "./CustomProviderCard";
 import PlusSignIcon from "@beaver/agent-ui/icons/PlusSignIcon";
@@ -125,7 +125,6 @@ const ApiKeysSection: React.FC = () => {
 
     return (
         <>
-            <SectionHeader>API Keys and Model Providers</SectionHeader>
             <SectionDescription>
                 Connect your own API keys (see our <DocLink path="api-key">guide</DocLink>),
                 or add a <DocLink path="custom-models">custom endpoint</DocLink>. Free and new paid keys (Tier 1) keys often hit rate limits. A key with higher rate limits works best (Tier 2+).

--- a/react/components/preferences/PermissionsSection.tsx
+++ b/react/components/preferences/PermissionsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import {SettingsGroup, SettingsRow, SectionLabel, DocLink, SectionHeader, SectionDescription} from "./components/SettingsElements";
+import {SettingsGroup, SettingsRow, SectionLabel, DocLink, SectionDescription} from "./components/SettingsElements";
 import DeferredToolPreferenceSetting from "./DeferredToolPreferenceSetting";
 import { getPref, setPref } from "../../../src/utils/prefs";
 
@@ -50,7 +50,7 @@ const PermissionsSection: React.FC = () => {
 
     return (
         <>
-            <SectionHeader>Library Modifications</SectionHeader>
+            <SectionLabel>Library Modifications</SectionLabel>
             <SectionDescription>
                 When Beaver modifies your library, all changes require your approval by default (the only exception is when Beaver creates a new note).
                 You can change this behavior here. Be careful, Beaver might make changes you didn't expect.

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { useAtom, useAtomValue } from 'jotai';
 import { logoutAtom, userAtom } from '../../atoms/auth';
 import { getPref, setPref } from '../../../src/utils/prefs';
-import { UserIcon, LogoutIcon, RepeatIcon, SettingsIcon, Icon, SearchIcon, LockIcon, KeyIcon, ZapIcon, ToolsIcon, DollarCircleIcon, ArrowUpRightIcon } from '../icons/icons';
+import { UserIcon, LogoutIcon, RepeatIcon, SettingsIcon, Icon, SearchIcon, LockIcon, KeyIcon, ZapIcon, ToolsIcon, DollarCircleIcon } from '../icons/icons';
 import Button from "@beaver/agent-ui/primitives/Button";
 import { useSetAtom } from 'jotai';
 import { profileWithPlanAtom, creditPlanAtom, hasCreditPlanAtom } from "../../atoms/profile";
@@ -264,21 +264,14 @@ const PreferencePage: React.FC = () => {
             id="beaver-preferences"
             className="flex-1 min-h-0 min-w-0 display-flex flex-row"
         >
-            {/* ===== SIDEBAR: title, section tabs, account ===== */}
+            {/* ===== SIDEBAR: section tabs, account ===== */}
             <div className="beaver-prefs-sidebar display-flex flex-col flex-shrink-0 min-h-0 border-right-quinary">
-                <div className="display-flex flex-row items-center gap-2" style={{ padding: '16px 16px 12px' }}>
-                    <Icon icon={SettingsIcon} className="scale-12" aria-hidden="true" focusable="false" />
-                    <h1 id="beaver-preferences-title" className="text-lg font-semibold font-color-primary" style={{ marginBlock: 0 }}>
-                        Settings
-                    </h1>
-                </div>
-
                 <div
                     role="tablist"
-                    aria-labelledby="beaver-preferences-title"
+                    aria-label="Settings sections"
                     aria-orientation="vertical"
                     className="display-flex flex-col gap-05 flex-1 min-h-0 overflow-y-auto scrollbar"
-                    style={{ padding: '0 10px' }}
+                    style={{ padding: '14px 10px 0' }}
                     onKeyDown={handleTabKeyDown}
                 >
                     {tabs.map((tab) => (
@@ -291,7 +284,7 @@ const PreferencePage: React.FC = () => {
                             aria-selected={tab.id === effectiveActiveTab}
                             aria-controls="beaver-preferences-panel"
                             tabIndex={tab.id === effectiveActiveTab ? 0 : -1}
-                            className="beaver-prefs-nav-item text-base"
+                            className="beaver-prefs-nav-item"
                         >
                             <Icon icon={tab.icon} aria-hidden="true" focusable="false" />
                             <span className="truncate">{tab.label}</span>
@@ -299,29 +292,28 @@ const PreferencePage: React.FC = () => {
                     ))}
                 </div>
 
-                {/* Account stays visible whichever section is open. */}
-                <div className="display-flex flex-col gap-2 border-top-quinary" style={{ padding: '12px 14px' }}>
+                {/* Account stays visible whichever section is open; it doubles as
+                    the shortcut to the Plan & Usage page. */}
+                <div className="display-flex flex-col gap-2 border-top-quinary" style={{ padding: '10px 10px 12px' }}>
                     {user ? (
                         <>
-                            <div className="display-flex flex-row items-center gap-2 min-w-0">
+                            <button
+                                type="button"
+                                className="beaver-prefs-account"
+                                onClick={() => setActiveTab('billing')}
+                                title={`${user.email} — open Plan & Usage`}
+                                aria-label={`Account ${user.email}, ${planLabel}. Open Plan & Usage`}
+                                aria-current={effectiveActiveTab === 'billing' ? 'page' : undefined}
+                            >
                                 <div className="beaver-prefs-avatar" aria-hidden="true">{accountInitial}</div>
-                                <div className="display-flex flex-col min-w-0">
-                                    <div className="text-sm font-color-primary font-medium truncate" title={user.email}>
+                                <div className="display-flex flex-col min-w-0" aria-hidden="true">
+                                    <div className="text-base font-color-primary font-medium truncate">
                                         {user.email}
                                     </div>
-                                    <div className="text-xs font-color-secondary truncate">{planLabel}</div>
+                                    <div className="text-sm font-color-secondary truncate">{planLabel}</div>
                                 </div>
-                            </div>
-                            <div className="display-flex flex-row items-center gap-2">
-                                <Button
-                                    variant="outline"
-                                    rightIcon={ArrowUpRightIcon}
-                                    onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/login')}
-                                    style={{ padding: '3px 6px' }}
-                                    title="Manage your account in the browser"
-                                >
-                                    Manage
-                                </Button>
+                            </button>
+                            <div className="display-flex flex-row items-center" style={{ paddingLeft: '4px' }}>
                                 <Button
                                     variant="outline"
                                     icon={LogoutIcon}
@@ -334,14 +326,14 @@ const PreferencePage: React.FC = () => {
                             </div>
                         </>
                     ) : (
-                        <div className="display-flex flex-row items-center gap-2 min-w-0">
+                        <div className="display-flex flex-row items-center gap-2 min-w-0" style={{ padding: '4px' }}>
                             <div className="beaver-prefs-avatar" aria-hidden="true">
-                                <Icon icon={UserIcon} className="scale-90" />
+                                <Icon icon={UserIcon} />
                             </div>
-                            <div className="text-sm font-color-secondary">Not signed in</div>
+                            <div className="text-base font-color-secondary">Not signed in</div>
                         </div>
                     )}
-                    <div className="display-flex flex-row items-center gap-1" style={{ paddingLeft: '2px' }}>
+                    <div className="display-flex flex-row items-center gap-1" style={{ paddingLeft: '6px' }}>
                         <button
                             type="button"
                             onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/terms')}

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { useAtom, useAtomValue } from 'jotai';
 import { logoutAtom, userAtom } from '../../atoms/auth';
 import { getPref, setPref } from '../../../src/utils/prefs';
-import { UserIcon, LogoutIcon, RepeatIcon, SettingsIcon, Icon, SearchIcon, LockIcon, KeyIcon, ZapIcon, ToolsIcon, DollarCircleIcon } from '../icons/icons';
+import { UserIcon, LogoutIcon, RepeatIcon, SettingsIcon, Icon, SearchIcon, LockIcon, KeyIcon, ZapIcon, ToolsIcon, DollarCircleIcon, ArrowUpRightIcon } from '../icons/icons';
 import Button from "@beaver/agent-ui/primitives/Button";
 import { useSetAtom } from 'jotai';
 import { profileWithPlanAtom, creditPlanAtom, hasCreditPlanAtom } from "../../atoms/profile";
@@ -15,7 +15,7 @@ import {
     isEmbeddingIndexingAtom 
 } from "../../atoms/embeddingIndex";
 import { accountService } from "@beaver/agent-core/transport/clients/accountService";
-import {SettingsGroup, SettingsRow, SectionLabel} from "./components/SettingsElements";
+import {SettingsGroup, SettingsRow, SectionLabel, PageHeader} from "./components/SettingsElements";
 import ActionsPreferenceSection from "./ActionsPreferenceSection";
 import BillingSection, { formatPlanName } from "./BillingSection";
 import ApiKeysSection from "./ApiKeysSection";
@@ -206,19 +206,28 @@ const PreferencePage: React.FC = () => {
     const sidebarShortcutLabel = `${Zotero.isMac ? '⌘' : 'Ctrl'}+${keyboardShortcut}`;
     const windowShortcutLabel = `${Zotero.isMac ? '⌘⇧' : 'Ctrl+Shift'}+${keyboardShortcut}`;
     type VisiblePreferencePageTab = Exclude<PreferencePageTab, 'account'>;
-    const tabs = useMemo<{ id: VisiblePreferencePageTab; label: string; icon: React.ComponentType<React.SVGProps<SVGSVGElement>> | React.ReactElement }[]>(() => [
+    interface PreferenceTabDefinition {
+        id: VisiblePreferencePageTab;
+        label: string;
+        icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+        /** The page renders its own title row (e.g. to place buttons next to it). */
+        ownsHeader?: boolean;
+    }
+    const tabs = useMemo<PreferenceTabDefinition[]>(() => [
         { id: 'general', label: 'General', icon: SettingsIcon },
         { id: 'sync', label: 'Search', icon: SearchIcon },
         { id: 'permissions', label: 'Permissions', icon: LockIcon },
         { id: 'billing', label: 'Plan & Usage', icon: DollarCircleIcon },
         { id: 'models', label: 'API Keys', icon: KeyIcon },
-        { id: 'actions', label: 'Actions', icon: ZapIcon },
+        { id: 'actions', label: 'Actions', icon: ZapIcon, ownsHeader: true },
         { id: 'advanced', label: 'Advanced', icon: ToolsIcon },
     ], []);
     const effectiveActiveTab: VisiblePreferencePageTab = activeTab === 'account' ? 'general' : activeTab;
+    const activeTabDefinition = tabs.find((tab) => tab.id === effectiveActiveTab) ?? tabs[0];
 
+    // The tab list is vertical: Up/Down move between tabs (wrapping), Home/End jump to the ends.
     const handleTabKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-        const navigationKeys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
+        const navigationKeys = ['ArrowUp', 'ArrowDown', 'Home', 'End'];
         if (!navigationKeys.includes(event.key)) {
             return;
         }
@@ -230,7 +239,7 @@ const PreferencePage: React.FC = () => {
             ? 0
             : event.key === 'End'
                 ? tabs.length - 1
-                : event.key === 'ArrowLeft'
+                : event.key === 'ArrowUp'
                     ? (normalizedIndex - 1 + tabs.length) % tabs.length
                     : (normalizedIndex + 1) % tabs.length;
         const nextTab = tabs[nextIndex];
@@ -247,375 +256,385 @@ const PreferencePage: React.FC = () => {
         }
     }, [activeTab, setActiveTab]);
 
+    const planLabel = hasCreditPlan ? `${formatPlanName(creditPlan.plan ?? undefined)} plan` : 'No active plan';
+    const accountInitial = user?.email?.trim().charAt(0) || '?';
+
     return (
         <div
             id="beaver-preferences"
-            className="flex-1 min-h-0 overflow-y-auto scrollbar min-w-0"
+            className="flex-1 min-h-0 min-w-0 display-flex flex-row"
         >
-          <div className="display-flex flex-col gap-2 p-4">
-            <div className="display-flex flex-row items-center gap-3 px-1">
-                <Icon icon={SettingsIcon} className="scale-16 mt-020" aria-hidden="true" focusable="false" />
-                <h1 id="beaver-preferences-title" className="text-2xl font-semibold  font-color-primary" style={{ marginBlock: "0rem" }}>
-                    Settings
-                </h1>
-                {/* <Button variant="outline" rightIcon={CancelIcon} onClick={() => togglePreferencePage((prev) => !prev)} className="mt-1">Close</Button> */}
-            </div>
+            {/* ===== SIDEBAR: title, section tabs, account ===== */}
+            <div className="beaver-prefs-sidebar display-flex flex-col flex-shrink-0 min-h-0 border-right-quinary">
+                <div className="display-flex flex-row items-center gap-2" style={{ padding: '16px 16px 12px' }}>
+                    <Icon icon={SettingsIcon} className="scale-12" aria-hidden="true" focusable="false" />
+                    <h1 id="beaver-preferences-title" className="text-lg font-semibold font-color-primary" style={{ marginBlock: 0 }}>
+                        Settings
+                    </h1>
+                </div>
 
+                <div
+                    role="tablist"
+                    aria-labelledby="beaver-preferences-title"
+                    aria-orientation="vertical"
+                    className="display-flex flex-col gap-05 flex-1 min-h-0 overflow-y-auto scrollbar"
+                    style={{ padding: '0 10px' }}
+                    onKeyDown={handleTabKeyDown}
+                >
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab.id}
+                            type="button"
+                            onClick={() => setActiveTab(tab.id)}
+                            id={`beaver-preferences-tab-${tab.id}`}
+                            role="tab"
+                            aria-selected={tab.id === effectiveActiveTab}
+                            aria-controls="beaver-preferences-panel"
+                            tabIndex={tab.id === effectiveActiveTab ? 0 : -1}
+                            className="beaver-prefs-nav-item text-base"
+                        >
+                            <Icon icon={tab.icon} aria-hidden="true" focusable="false" />
+                            <span className="truncate">{tab.label}</span>
+                        </button>
+                    ))}
+                </div>
 
-            <div
-                role="tablist"
-                aria-label="Settings sections"
-                className="display-flex flex-row items-center mb-3 mt-2"
-                style={{ borderRadius: '6px', overflow: 'hidden', border: '1px solid var(--fill-quarternary)', width: 'fit-content' }}
-                onKeyDown={handleTabKeyDown}
-            >
-                {tabs.map((tab, index) => (
-                    <button
-                        key={tab.id}
-                        type="button"
-                        onClick={() => setActiveTab(tab.id)}
-                        id={`beaver-preferences-tab-${tab.id}`}
-                        role="tab"
-                        aria-selected={tab.id === effectiveActiveTab}
-                        aria-controls="beaver-preferences-panel"
-                        tabIndex={tab.id === effectiveActiveTab ? 0 : -1}
-                        className="text-base"
-                        style={{
-                            borderLeft: index > 0 ? '1px solid var(--fill-quarternary)' : 'none',
-                            borderTop: 'none',
-                            borderBottom: 'none',
-                            borderRight: 'none',
-                            borderRadius: 0,
-                            background: tab.id === effectiveActiveTab ? 'var(--fill-quinary)' : 'transparent',
-                            color: tab.id === effectiveActiveTab ? 'var(--fill-primary)' : 'var(--fill-secondary)',
-                            padding: '6px 12px',
-                            minHeight: '20px',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            lineHeight: 1.2,
-                            gap: '4px',
-                            whiteSpace: 'nowrap',
-                            transition: 'background-color 0.15s ease, color 0.15s ease'
-                        }}
-                    >
-                        <Icon
-                            icon={tab.icon as React.ComponentType<React.SVGProps<SVGSVGElement>>}
-                            className="scale-95 -ml-05"
-                        />
-                        {tab.label}
-                    </button>
-                ))}
-            </div>
-
-            <div
-                role="tabpanel"
-                id="beaver-preferences-panel"
-                aria-labelledby={`beaver-preferences-tab-${effectiveActiveTab}`}
-            >
-            {/* ===== GENERAL TAB ===== */}
-            {effectiveActiveTab === 'general' && (
-                <>
+                {/* Account stays visible whichever section is open. */}
+                <div className="display-flex flex-col gap-2 border-top-quinary" style={{ padding: '12px 14px' }}>
                     {user ? (
                         <>
-                            <SettingsGroup>
-                                <SettingsRow
-                                    title="Manage Account"
-                                    description={<>Signed in as {user.email} ({hasCreditPlan ? `${formatPlanName(creditPlan.plan ?? undefined)} plan` : 'No active plan'})</>}
-                                    control={
-                                        <Button
-                                            variant="outline"
-                                            icon={UserIcon}
-                                            onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/login')}
-                                            style={{ padding: '4px 6px' }}
-                                        >
-                                            Open
-                                        </Button>
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Sign Out"
-                                    description="End your current session"
-                                    hasBorder
-                                    control={
-                                        <Button variant="outline" icon={LogoutIcon} onClick={logout} style={{ padding: '4px 6px' }}>
-                                            Logout
-                                        </Button>
-                                    }
-                                />
-                            </SettingsGroup>
-
-                            <SectionLabel>Preferences</SectionLabel>
-                            <SettingsGroup>
-                                <SettingsRow
-                                    title="Keyboard Shortcut"
-                                    description={<>Sidebar: {sidebarShortcutLabel} &middot; Window: {windowShortcutLabel} &middot; Changes require restart</>}
-                                    control={
-                                        <select
-                                            id="keyboard-shortcut"
-                                            value={keyboardShortcut}
-                                            onChange={handleKeyboardShortcutChange}
-                                            className="py-1 px-2 border preference-input text-sm"
-                                            style={{ width: '40px', margin: 0 }}
-                                            onClick={(e) => e.stopPropagation()}
-                                        >
-                                            {'DGHJKMRVX'.split('').map((letter) => (
-                                                <option key={letter} value={letter}>{letter}</option>
-                                            ))}
-                                        </select>
-                                    }
-                                />
-                                <SettingsRow
-                                    title={`Citation Format: ${citationFormat ? 'Numeric' : 'Author-Year'}`}
-                                    description="Choose between numeric [1] or author-year (Smith, 2023) citations"
-                                    onClick={handleCitationFormatToggle}
-                                    hasBorder
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={citationFormat}
-                                            onChange={handleCitationFormatToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Keep Cited Passages Highlighted"
-                                    description="When enabled, Beaver marks cited passages with temporary Zotero annotations that disappear on your next click. When disabled, Beaver briefly flashes the passage instead."
-                                    onClick={handleTemporaryCitationAnnotationsToggle}
-                                    hasBorder
-                                    tooltip="When disabled, citations use Zotero's transient PDF position highlight instead."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={useTemporaryCitationAnnotations}
-                                            onChange={handleTemporaryCitationAnnotationsToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Add Selected Items to New Threads"
-                                    description="Automatically attach selected items to new thread"
-                                    onClick={handleAddSelectedOnNewThreadToggle}
-                                    hasBorder
-                                    tooltip="When enabled, any items you have selected in Zotero will be automatically added as sources when you start a new conversation thread."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={addSelectedOnNewThread}
-                                            onChange={handleAddSelectedOnNewThreadToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Add Selected Items When Opening"
-                                    description="Automatically attach selected items when opening Beaver"
-                                    onClick={handleAddSelectedOnOpenToggle}
-                                    hasBorder
-                                    tooltip="When enabled, any items you have selected in Zotero will be automatically added as sources when you open Beaver."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={addSelectedOnOpen}
-                                            onChange={handleAddSelectedOnOpenToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Add Provenance Note to Imported Items"
-                                    description="Add a child note with a conversation link to Beaver conversation"
-                                    onClick={handleAddProvenanceNoteToggle}
-                                    hasBorder
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={addProvenanceNote}
-                                            onChange={handleAddProvenanceNoteToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Announce Responses for Screen Readers"
-                                    description="Move focus to screen-reader text when Beaver starts and finishes generating a response"
-                                    onClick={handleFocusResponseForScreenReadersToggle}
-                                    hasBorder
-                                    tooltip="When enabled, focus moves from the chat input to screen-reader-only status text while Beaver generates, then to a screen-reader-only copy of the completed response."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={focusResponseForScreenReaders}
-                                            onChange={handleFocusResponseForScreenReadersToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Preview Note Edits in Editor"
-                                    description={diffPreviewSupported
-                                        ? "Show proposed note edits inline in the Zotero note editor"
-                                        : "Requires Zotero 8 — unavailable on this version"}
-                                    onClick={diffPreviewSupported ? handleShowDiffPreviewToggle : undefined}
-                                    hasBorder
-                                    tooltip="When enabled, edit_note proposals appear as a colored diff directly in the note editor with Apply / Reject controls. When disabled, approvals fall back to the sidebar preview. Turn off if a Zotero update causes the in-editor preview to misbehave."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={showDiffPreview && diffPreviewSupported}
-                                            disabled={!diffPreviewSupported}
-                                            onChange={handleShowDiffPreviewToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: diffPreviewSupported ? 'pointer' : 'not-allowed', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Help Improve Beaver"
-                                    description="Share anonymized prompts to help improve Beaver"
-                                    onClick={handleConsentToggle}
-                                    hasBorder
-                                    tooltip="When enabled, we use your prompts, queries, and AI responses to improve Beaver's features and performance. We automatically remove personal information and never share your PDFs, documents, or other files."
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={consentToShare}
-                                            onChange={handleConsentToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                                <SettingsRow
-                                    title="Email Notifications"
-                                    description="Receive email updates about Beaver"
-                                    onClick={handleEmailToggle}
-                                    hasBorder
-                                    control={
-                                        <input
-                                            type="checkbox"
-                                            checked={emailNotifications}
-                                            onChange={handleEmailToggle}
-                                            onClick={(e) => e.stopPropagation()}
-                                            style={{ cursor: 'pointer', margin: 0 }}
-                                        />
-                                    }
-                                />
-                            </SettingsGroup>
-
-                            <div className="display-flex flex-row gap-1 items-start mt-3" style={{ paddingLeft: '2px' }}>
-                                <button
-                                    type="button"
-                                    onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/terms')}
-                                    className="text-link-muted text-sm"
+                            <div className="display-flex flex-row items-center gap-2 min-w-0">
+                                <div className="beaver-prefs-avatar" aria-hidden="true">{accountInitial}</div>
+                                <div className="display-flex flex-col min-w-0">
+                                    <div className="text-sm font-color-primary font-medium truncate" title={user.email}>
+                                        {user.email}
+                                    </div>
+                                    <div className="text-xs font-color-secondary truncate">{planLabel}</div>
+                                </div>
+                            </div>
+                            <div className="display-flex flex-row items-center gap-2">
+                                <Button
+                                    variant="outline"
+                                    rightIcon={ArrowUpRightIcon}
+                                    onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/login')}
+                                    style={{ padding: '3px 6px' }}
+                                    title="Manage your account in the browser"
                                 >
-                                    Terms of Service
-                                </button>
-                                <div className="font-color-secondary">|</div>
-                                <button
-                                    type="button"
-                                    onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/privacy-policy')}
-                                    className="text-link-muted text-sm"
+                                    Manage
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    icon={LogoutIcon}
+                                    onClick={logout}
+                                    style={{ padding: '3px 6px' }}
+                                    title="End your current session"
                                 >
-                                    Privacy Policy
-                                </button>
+                                    Sign out
+                                </Button>
                             </div>
                         </>
                     ) : (
-                        <SettingsGroup className="mt-2">
-                            <SettingsRow
-                                title="Account"
-                                description="You are not signed in."
-                            />
-                        </SettingsGroup>
+                        <div className="display-flex flex-row items-center gap-2 min-w-0">
+                            <div className="beaver-prefs-avatar" aria-hidden="true">
+                                <Icon icon={UserIcon} className="scale-90" />
+                            </div>
+                            <div className="text-sm font-color-secondary">Not signed in</div>
+                        </div>
                     )}
-                </>
-            )}
-
-            {/* ===== SYNC TAB ===== */}
-            {effectiveActiveTab === 'sync' && (
-                <>
-                    <SectionLabel>Libraries</SectionLabel>
-                    <ExcludedLibrariesList />
-
-                    <SectionLabel>Search Index</SectionLabel>
-                    <SettingsGroup>
-                        <SettingsRow
-                            title="Search Index"
-                            description={
-                                <>
-                                    Check that the local search index matches your Zotero libraries.
-                                    This usually happens automatically, but you can run a manual check if search results look out of date.
-                                    {embeddingIndexState.failedItems > 0 && (
-                                        <span className="display-flex font-color-yellow mt-1">
-                                            {embeddingIndexState.failedItems} items failed to index
-                                        </span>
-                                    )}
-                                    {embeddingIndexState.status === 'error' && embeddingIndexState.error && (
-                                        <span className="display-flex font-color-red mt-1">
-                                            Error: {embeddingIndexState.error}
-                                        </span>
-                                    )}
-                                </>
-                            }
-                            control={
-                                <Button
-                                    variant="outline"
-                                    rightIcon={!isEmbeddingIndexing ? rebuildIndexButtonProps.icon : undefined}
-                                    iconClassName={rebuildIndexButtonProps.iconClassName}
-                                    onClick={handleRebuildSearchIndex}
-                                    disabled={rebuildIndexButtonProps.disabled}
-                                    loading={isEmbeddingIndexing}
-                                    style={{ padding: '4px 6px' }}
-                                >
-                                    {rebuildIndexButtonProps.text}
-                                </Button>
-                            }
-                        />
-                        {isEmbeddingIndexing && embeddingIndexState.phase === 'initial' && embeddingIndexState.totalItems > 0 && (
-                            <EmbeddingIndexProgress />
-                        )}
-                    </SettingsGroup>
-                </>
-            )}
-
-            {/* ===== PERMISSIONS TAB ===== */}
-            {effectiveActiveTab === 'permissions' && (
-                <PermissionsSection />
-            )}
-
-            {/* ===== PLAN & USAGE TAB ===== */}
-            {effectiveActiveTab === 'billing' && (
-                <BillingSection />
-            )}
-
-            {/* ===== MODELS & API KEYS TAB ===== */}
-            {effectiveActiveTab === 'models' && (
-                <ApiKeysSection />
-            )}
-
-            {/* ===== ACTIONS TAB ===== */}
-            {effectiveActiveTab === 'actions' && (
-                <ActionsPreferenceSection />
-            )}
-
-            {/* ===== ADVANCED TAB ===== */}
-            {effectiveActiveTab === 'advanced' && (
-                <AdvancedSection />
-            )}
+                    <div className="display-flex flex-row items-center gap-1" style={{ paddingLeft: '2px' }}>
+                        <button
+                            type="button"
+                            onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/terms')}
+                            className="text-link-muted text-xs"
+                        >
+                            Terms of Service
+                        </button>
+                        <span className="font-color-tertiary text-xs" aria-hidden="true">·</span>
+                        <button
+                            type="button"
+                            onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/privacy-policy')}
+                            className="text-link-muted text-xs"
+                        >
+                            Privacy Policy
+                        </button>
+                    </div>
+                </div>
             </div>
 
-            {/* Spacer at the bottom */}
-            {/* <div style={{ height: "20px" }} /> */}
-          </div>
+            {/* ===== CONTENT: the selected section ===== */}
+            <div className="beaver-prefs-content flex-1 min-h-0 min-w-0 overflow-y-auto scrollbar">
+                <div
+                    role="tabpanel"
+                    id="beaver-preferences-panel"
+                    aria-labelledby={`beaver-preferences-tab-${effectiveActiveTab}`}
+                    className="beaver-prefs-page display-flex flex-col"
+                >
+                {!activeTabDefinition.ownsHeader && (
+                    <PageHeader title={activeTabDefinition.label} />
+                )}
+
+                {/* ===== GENERAL TAB ===== */}
+                {effectiveActiveTab === 'general' && (
+                    <>
+                        <SectionLabel>Sidebar</SectionLabel>
+                        <SettingsGroup>
+                            <SettingsRow
+                                title="Keyboard Shortcut"
+                                description={<>Sidebar: {sidebarShortcutLabel} &middot; Window: {windowShortcutLabel} &middot; Changes require restart</>}
+                                control={
+                                    <select
+                                        id="keyboard-shortcut"
+                                        value={keyboardShortcut}
+                                        onChange={handleKeyboardShortcutChange}
+                                        className="py-1 px-2 border preference-input text-sm"
+                                        style={{ width: '40px', margin: 0 }}
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        {'DGHJKMRVX'.split('').map((letter) => (
+                                            <option key={letter} value={letter}>{letter}</option>
+                                        ))}
+                                    </select>
+                                }
+                            />
+                            <SettingsRow
+                                title="Add Selected Items to New Threads"
+                                description="Automatically attach selected items to new thread"
+                                onClick={handleAddSelectedOnNewThreadToggle}
+                                hasBorder
+                                tooltip="When enabled, any items you have selected in Zotero will be automatically added as sources when you start a new conversation thread."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={addSelectedOnNewThread}
+                                        onChange={handleAddSelectedOnNewThreadToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                            <SettingsRow
+                                title="Add Selected Items When Opening"
+                                description="Automatically attach selected items when opening Beaver"
+                                onClick={handleAddSelectedOnOpenToggle}
+                                hasBorder
+                                tooltip="When enabled, any items you have selected in Zotero will be automatically added as sources when you open Beaver."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={addSelectedOnOpen}
+                                        onChange={handleAddSelectedOnOpenToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                        </SettingsGroup>
+
+                        <SectionLabel>Citations</SectionLabel>
+                        <SettingsGroup>
+                            <SettingsRow
+                                title={`Citation Format: ${citationFormat ? 'Numeric' : 'Author-Year'}`}
+                                description="Choose between numeric [1] or author-year (Smith, 2023) citations"
+                                onClick={handleCitationFormatToggle}
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={citationFormat}
+                                        onChange={handleCitationFormatToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                            <SettingsRow
+                                title="Keep Cited Passages Highlighted"
+                                description="When enabled, Beaver marks cited passages with temporary Zotero annotations that disappear on your next click. When disabled, Beaver briefly flashes the passage instead."
+                                onClick={handleTemporaryCitationAnnotationsToggle}
+                                hasBorder
+                                tooltip="When disabled, citations use Zotero's transient PDF position highlight instead."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={useTemporaryCitationAnnotations}
+                                        onChange={handleTemporaryCitationAnnotationsToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                        </SettingsGroup>
+
+                        <SectionLabel>Notes</SectionLabel>
+                        <SettingsGroup>
+                            <SettingsRow
+                                title="Add Provenance Note to Imported Items"
+                                description="Add a child note with a conversation link to Beaver conversation"
+                                onClick={handleAddProvenanceNoteToggle}
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={addProvenanceNote}
+                                        onChange={handleAddProvenanceNoteToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                            <SettingsRow
+                                title="Preview Note Edits in Editor"
+                                description={diffPreviewSupported
+                                    ? "Show proposed note edits inline in the Zotero note editor"
+                                    : "Requires Zotero 8 — unavailable on this version"}
+                                onClick={diffPreviewSupported ? handleShowDiffPreviewToggle : undefined}
+                                hasBorder
+                                tooltip="When enabled, edit_note proposals appear as a colored diff directly in the note editor with Apply / Reject controls. When disabled, approvals fall back to the sidebar preview. Turn off if a Zotero update causes the in-editor preview to misbehave."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={showDiffPreview && diffPreviewSupported}
+                                        disabled={!diffPreviewSupported}
+                                        onChange={handleShowDiffPreviewToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: diffPreviewSupported ? 'pointer' : 'not-allowed', margin: 0 }}
+                                    />
+                                }
+                            />
+                        </SettingsGroup>
+
+                        <SectionLabel>Accessibility</SectionLabel>
+                        <SettingsGroup>
+                            <SettingsRow
+                                title="Announce Responses for Screen Readers"
+                                description="Move focus to screen-reader text when Beaver starts and finishes generating a response"
+                                onClick={handleFocusResponseForScreenReadersToggle}
+                                tooltip="When enabled, focus moves from the chat input to screen-reader-only status text while Beaver generates, then to a screen-reader-only copy of the completed response."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={focusResponseForScreenReaders}
+                                        onChange={handleFocusResponseForScreenReadersToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                        </SettingsGroup>
+
+                        {/* These two preferences live on the account, so they are only
+                            offered while signed in. */}
+                        {user && (
+                            <>
+                                <SectionLabel>Privacy</SectionLabel>
+                                <SettingsGroup>
+                                    <SettingsRow
+                                        title="Help Improve Beaver"
+                                        description="Share anonymized prompts to help improve Beaver"
+                                        onClick={handleConsentToggle}
+                                        tooltip="When enabled, we use your prompts, queries, and AI responses to improve Beaver's features and performance. We automatically remove personal information and never share your PDFs, documents, or other files."
+                                        control={
+                                            <input
+                                                type="checkbox"
+                                                checked={consentToShare}
+                                                onChange={handleConsentToggle}
+                                                onClick={(e) => e.stopPropagation()}
+                                                style={{ cursor: 'pointer', margin: 0 }}
+                                            />
+                                        }
+                                    />
+                                    <SettingsRow
+                                        title="Email Notifications"
+                                        description="Receive email updates about Beaver"
+                                        onClick={handleEmailToggle}
+                                        hasBorder
+                                        control={
+                                            <input
+                                                type="checkbox"
+                                                checked={emailNotifications}
+                                                onChange={handleEmailToggle}
+                                                onClick={(e) => e.stopPropagation()}
+                                                style={{ cursor: 'pointer', margin: 0 }}
+                                            />
+                                        }
+                                    />
+                                </SettingsGroup>
+                            </>
+                        )}
+                    </>
+                )}
+
+                {/* ===== SEARCH TAB ===== */}
+                {effectiveActiveTab === 'sync' && (
+                    <>
+                        <SectionLabel>Libraries</SectionLabel>
+                        <ExcludedLibrariesList />
+
+                        <SectionLabel>Search Index</SectionLabel>
+                        <SettingsGroup>
+                            <SettingsRow
+                                title="Search Index"
+                                description={
+                                    <>
+                                        Check that the local search index matches your Zotero libraries.
+                                        This usually happens automatically, but you can run a manual check if search results look out of date.
+                                        {embeddingIndexState.failedItems > 0 && (
+                                            <span className="display-flex font-color-yellow mt-1">
+                                                {embeddingIndexState.failedItems} items failed to index
+                                            </span>
+                                        )}
+                                        {embeddingIndexState.status === 'error' && embeddingIndexState.error && (
+                                            <span className="display-flex font-color-red mt-1">
+                                                Error: {embeddingIndexState.error}
+                                            </span>
+                                        )}
+                                    </>
+                                }
+                                control={
+                                    <Button
+                                        variant="outline"
+                                        rightIcon={!isEmbeddingIndexing ? rebuildIndexButtonProps.icon : undefined}
+                                        iconClassName={rebuildIndexButtonProps.iconClassName}
+                                        onClick={handleRebuildSearchIndex}
+                                        disabled={rebuildIndexButtonProps.disabled}
+                                        loading={isEmbeddingIndexing}
+                                        style={{ padding: '4px 6px' }}
+                                    >
+                                        {rebuildIndexButtonProps.text}
+                                    </Button>
+                                }
+                            />
+                            {isEmbeddingIndexing && embeddingIndexState.phase === 'initial' && embeddingIndexState.totalItems > 0 && (
+                                <EmbeddingIndexProgress />
+                            )}
+                        </SettingsGroup>
+                    </>
+                )}
+
+                {/* ===== PERMISSIONS TAB ===== */}
+                {effectiveActiveTab === 'permissions' && (
+                    <PermissionsSection />
+                )}
+
+                {/* ===== PLAN & USAGE TAB ===== */}
+                {effectiveActiveTab === 'billing' && (
+                    <BillingSection />
+                )}
+
+                {/* ===== API KEYS TAB ===== */}
+                {effectiveActiveTab === 'models' && (
+                    <ApiKeysSection />
+                )}
+
+                {/* ===== ACTIONS TAB ===== */}
+                {effectiveActiveTab === 'actions' && (
+                    <ActionsPreferenceSection />
+                )}
+
+                {/* ===== ADVANCED TAB ===== */}
+                {effectiveActiveTab === 'advanced' && (
+                    <AdvancedSection />
+                )}
+                </div>
+            </div>
         </div>
     );
 };

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -292,48 +292,50 @@ const PreferencePage: React.FC = () => {
                     ))}
                 </div>
 
-                {/* Account stays visible whichever section is open; it doubles as
-                    the shortcut to the Plan & Usage page. */}
-                <div className="display-flex flex-col gap-2 border-top-quinary" style={{ padding: '10px 10px 12px' }}>
+                {/* Sign out sits with the navigation, below the tabs, so the
+                    account block underneath stays a single, quiet control. */}
+                {user && (
+                    <div style={{ padding: '8px 10px' }}>
+                        <button
+                            type="button"
+                            className="beaver-prefs-nav-item"
+                            onClick={logout}
+                            title="End your current session"
+                        >
+                            <Icon icon={LogoutIcon} aria-hidden="true" focusable="false" />
+                            <span className="truncate">Sign out</span>
+                        </button>
+                    </div>
+                )}
+
+                {/* Account stays visible whichever section is open; clicking it
+                    opens the Plan & Usage page. */}
+                <div className="display-flex flex-col border-top-quinary" style={{ padding: '10px 10px 10px' }}>
                     {user ? (
-                        <>
-                            <button
-                                type="button"
-                                className="beaver-prefs-account"
-                                onClick={() => setActiveTab('billing')}
-                                title={`${user.email} — open Plan & Usage`}
-                                aria-label={`Account ${user.email}, ${planLabel}. Open Plan & Usage`}
-                                aria-current={effectiveActiveTab === 'billing' ? 'page' : undefined}
-                            >
-                                <div className="beaver-prefs-avatar" aria-hidden="true">{accountInitial}</div>
-                                <div className="display-flex flex-col min-w-0" aria-hidden="true">
-                                    <div className="text-base font-color-primary font-medium truncate">
-                                        {user.email}
-                                    </div>
-                                    <div className="text-sm font-color-secondary truncate">{planLabel}</div>
+                        <button
+                            type="button"
+                            className="beaver-prefs-account"
+                            onClick={() => setActiveTab('billing')}
+                            title={`${user.email} — open Plan & Usage`}
+                            aria-label={`Account ${user.email}, ${planLabel}. Open Plan & Usage`}
+                        >
+                            <div className="beaver-prefs-avatar" aria-hidden="true">{accountInitial}</div>
+                            <div className="display-flex flex-col min-w-0" aria-hidden="true">
+                                <div className="text-base font-color-primary font-medium truncate">
+                                    {user.email}
                                 </div>
-                            </button>
-                            <div className="display-flex flex-row items-center" style={{ paddingLeft: '4px' }}>
-                                <Button
-                                    variant="outline"
-                                    icon={LogoutIcon}
-                                    onClick={logout}
-                                    style={{ padding: '3px 6px' }}
-                                    title="End your current session"
-                                >
-                                    Sign out
-                                </Button>
+                                <div className="text-sm font-color-secondary truncate">{planLabel}</div>
                             </div>
-                        </>
+                        </button>
                     ) : (
-                        <div className="display-flex flex-row items-center gap-2 min-w-0" style={{ padding: '4px' }}>
+                        <div className="display-flex flex-row items-center gap-2 min-w-0" style={{ padding: '6px 8px' }}>
                             <div className="beaver-prefs-avatar" aria-hidden="true">
                                 <Icon icon={UserIcon} />
                             </div>
                             <div className="text-base font-color-secondary">Not signed in</div>
                         </div>
                     )}
-                    <div className="display-flex flex-row items-center gap-1" style={{ paddingLeft: '6px' }}>
+                    <div className="beaver-prefs-legal display-flex flex-row items-center gap-1">
                         <button
                             type="button"
                             onClick={() => Zotero.launchURL(process.env.WEBAPP_BASE_URL + '/terms')}

--- a/react/components/preferences/components/SettingsElements.tsx
+++ b/react/components/preferences/components/SettingsElements.tsx
@@ -18,9 +18,24 @@ export const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children
     </div>
 );
 
-export const SectionHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <div role="heading" aria-level={2} className="text-xl font-color-primary font-bold" style={{ marginTop: '8px', marginBottom: '6px', paddingLeft: '4px' }}>
-        {children}
+/**
+ * Title row at the top of a settings page. `actions` sits on the right of the
+ * title (e.g. the Actions page's Import / Add buttons); `children` render as a
+ * lead paragraph under it.
+ */
+export const PageHeader: React.FC<{ title: string; actions?: React.ReactNode; children?: React.ReactNode }> = ({ title, actions, children }) => (
+    <div className="display-flex flex-col gap-1" style={{ marginBottom: '12px' }}>
+        <div className="display-flex flex-row items-center justify-between gap-4" style={{ minHeight: '30px' }}>
+            <h1 className="text-2xl font-semibold font-color-primary" style={{ marginBlock: 0, paddingLeft: '2px' }}>
+                {title}
+            </h1>
+            {actions}
+        </div>
+        {children && (
+            <div className="font-color-secondary text-base" style={{ paddingLeft: '2px' }}>
+                {children}
+            </div>
+        )}
     </div>
 );
 

--- a/scripts/worktree/worktree-zotero.sh
+++ b/scripts/worktree/worktree-zotero.sh
@@ -110,7 +110,7 @@ def pref(key):
 data = {
     "WT_DATADIR": pref("extensions.zotero.dataDir"),
     "WT_HTTP": pref("extensions.zotero.httpServer.port"),
-    "W": pref("extensions.zotero.extensions.mcp-rdp.port"),
+    "WT_RDP": pref("extensions.zotero.extensions.mcp-rdp.port"),
 }
 for k, v in data.items():
     if v:

--- a/scripts/worktree/worktree-zotero.sh
+++ b/scripts/worktree/worktree-zotero.sh
@@ -110,7 +110,7 @@ def pref(key):
 data = {
     "WT_DATADIR": pref("extensions.zotero.dataDir"),
     "WT_HTTP": pref("extensions.zotero.httpServer.port"),
-    "WT_RDP": pref("extensions.zotero.extensions.mcp-rdp.port"),
+    "W": pref("extensions.zotero.extensions.mcp-rdp.port"),
 }
 for k, v in data.items():
     if v:
@@ -697,7 +697,7 @@ cmd_reload() {
     echo
     if [[ -n "$pids" ]]; then
       if port_listening "$WT_RDP"; then
-        echo "Triggering zotero_plugin_reload over RDP $WT_RDP…"
+        echo "Triggering zotero_plugin_reload over RDP ${WT_RDP}…"
         rdp_exec zotero_plugin_reload '{}' || die "plugin reload failed"
         echo "Forced one reload. Ordinary saves already hot-reload."
       else


### PR DESCRIPTION
## Summary

- Redesign the Beaver Settings window with a vertical sidebar and content-based preference sections.
- Improve preference navigation with vertical keyboard controls, selected states, and account actions.
- Update settings page headers, sizing, spacing, and styling for the new layout.
- Correct the worktree Zotero script variable name and RDP echo output.
- Align package metadata with version 0.24.0 and remove obsolete client feature text and tests.

## Testing

- Not run.