### PR TITLE
feat(run-status-popup): add closed-sidebar run status card

### DIFF
--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -186,6 +186,298 @@
     pointer-events: auto;
 }
 
+/* Run status popup: the open thread's run, in the corner of the main window
+ * while the sidebar is closed (react/components/runStatusPopup). Sits inside
+ * #beaver-pane-floating-popup, under any message popups. */
+.beaver-run-status-popup {
+    position: relative;
+    align-self: flex-end;
+    width: 324px;
+    max-width: 100%;
+    margin: 0 4px 12px 0;
+    /* Room above the card for the layers that stand for other threads. */
+    padding-top: calc(var(--beaver-run-status-stack, 0) * 6px);
+}
+
+.beaver-run-status-popup[data-stack-depth="1"] { --beaver-run-status-stack: 1; }
+.beaver-run-status-popup[data-stack-depth="2"] { --beaver-run-status-stack: 2; }
+
+/* One sliver per further thread, narrower and higher the further back it is. */
+.beaver-run-status-popup__layer {
+    position: absolute;
+    top: calc((var(--beaver-run-status-stack, 0) - var(--beaver-stack-depth)) * 6px);
+    left: calc(var(--beaver-stack-depth) * 10px);
+    right: calc(var(--beaver-stack-depth) * 10px);
+    height: 16px;
+    border: 1px solid var(--beaver-border-strong);
+    border-bottom: 0;
+    border-radius: 12px 12px 0 0;
+    background: var(--beaver-surface-overlay);
+    opacity: calc(1 - var(--beaver-stack-depth) * 0.3);
+}
+
+.beaver-run-status-popup__card {
+    position: relative;
+    box-sizing: border-box;
+    overflow: hidden;
+    border: 1px solid var(--beaver-border-strong);
+    border-radius: 12px;
+    background: var(--beaver-surface-overlay);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 3px rgba(0, 0, 0, 0.08);
+    cursor: pointer;
+    transition: border-color 120ms ease;
+}
+
+.beaver-run-status-popup__card--settled {
+    transition: border-color 120ms ease, height 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.beaver-run-status-popup__card:hover {
+    border-color: var(--fill-tertiary);
+}
+
+.beaver-run-status-popup__card:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 1px;
+}
+
+.beaver-run-status-popup__content {
+    display: flex;
+    flex-direction: column;
+    padding: 10px 12px 10px 12px;
+    gap: 8px;
+}
+
+.beaver-run-status-popup__header {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 10px;
+    min-width: 0;
+}
+
+/* The pulse and the icons share one slot so the title column lines up across states. */
+.beaver-run-status-popup__leading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+}
+
+.beaver-run-status-popup__text {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: 2px;
+}
+
+.beaver-run-status-popup__trailing {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    /* Pull the dismiss button flush with the padding, as on the version card. */
+    margin: -4px -6px -4px 0;
+}
+
+/* The close button only appears while the pointer or focus is on the card. */
+.beaver-run-status-popup__dismiss {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.beaver-run-status-popup__card:hover .beaver-run-status-popup__dismiss,
+.beaver-run-status-popup__card:focus-within .beaver-run-status-popup__dismiss {
+    opacity: 1;
+}
+
+.beaver-run-status-popup__title {
+    font-size: 0.95rem;
+    font-weight: 500;
+    line-height: 20px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.beaver-run-status-popup__detail {
+    font-size: 0.875rem;
+    line-height: 18px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* The shimmer paints its gradient across the whole box; keep the box to the text. */
+.beaver-run-status-popup__detail > .shimmer-text {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: top;
+}
+
+.beaver-run-status-popup__body {
+    font-size: 0.875rem;
+    line-height: 1.35;
+    padding-left: 30px;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.beaver-run-status-popup__footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    padding-top: 2px;
+}
+
+.beaver-run-status-popup .beaver-run-status-popup__footer > button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+/* The permission menu gives way first: its label truncates before a
+ * decision button wraps. */
+.beaver-run-status-popup__permission {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.beaver-run-status-popup__permission > *,
+.beaver-run-status-popup .beaver-run-status-popup__permission button {
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.beaver-run-status-popup .beaver-run-status-popup__permission button > * {
+    min-width: 0;
+}
+
+.beaver-run-status-popup__rows {
+    display: flex;
+    flex-direction: column;
+    margin-left: 30px;
+    border: 1px solid var(--beaver-border-subtle);
+    border-radius: 8px;
+    background: var(--beaver-fill-subtle);
+    overflow: hidden;
+}
+
+/* Doubled selector: the pane-wide `[id^="beaver-pane-"] button { all: revert }`
+ * reset outranks a single class. */
+.beaver-run-status-popup .beaver-run-status-popup__row {
+    appearance: none;
+    -moz-appearance: none;
+    margin: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 5px 8px;
+    font-size: 0.875rem;
+    line-height: 18px;
+    cursor: pointer;
+}
+
+.beaver-run-status-popup__row + .beaver-run-status-popup__row {
+    border-top: 1px solid var(--beaver-border-subtle);
+}
+
+.beaver-run-status-popup__row:hover {
+    background: var(--beaver-fill-hover);
+}
+
+.beaver-run-status-popup__row:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -2px;
+}
+
+.beaver-run-status-popup__row-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* A fixed label keeps its width; the trail beside it truncates first. */
+.beaver-run-status-popup__row-text--fixed {
+    flex: 0 0 auto;
+}
+
+.beaver-run-status-popup__row-trail {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.beaver-run-status-popup__row-arrow {
+    flex: 0 0 auto;
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.beaver-run-status-popup__row:hover .beaver-run-status-popup__row-arrow {
+    opacity: 1;
+}
+
+/* A working run: a dot with a ring that keeps expanding out of it and fading. */
+.beaver-run-pulse {
+    position: relative;
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+}
+
+.beaver-run-pulse__dot {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+}
+
+.beaver-run-pulse__ring {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1.5px solid var(--accent-blue);
+    opacity: 0;
+    transform: scale(0.35);
+    animation: beaverRunPulseRing 2.2s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
+}
+
+.beaver-run-pulse__ring:nth-child(2) {
+    animation-delay: 1.1s;
+}
+
+@keyframes beaverRunPulseRing {
+    0% { transform: scale(0.35); opacity: 0.85; }
+    70% { transform: scale(1); opacity: 0; }
+    100% { transform: scale(1); opacity: 0; }
+}
+
 /* Toolbar Button */
 #zotero-beaver-tb-chat-toggle {
     list-style-image: url("chrome://beaver/content/icons/magic-wand.svg");

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -337,6 +337,20 @@
     overflow: hidden;
 }
 
+/* The shared question card, drawn inside the popup: the popup is the frame,
+ * so the card gives up its own. */
+.beaver-run-status-popup__question {
+    cursor: default;
+}
+
+.beaver-run-status-popup__question > .user-message-display {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
 .beaver-run-status-popup__footer {
     display: flex;
     flex-direction: row;

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -462,6 +462,26 @@
     opacity: 1;
 }
 
+/* The onboarding tip's visual: the real card's top-left corner, run off the
+ * tip's right edge and faded out toward the right and the bottom. */
+.beaver-run-status-tip__preview {
+    height: 78px;
+    overflow: hidden;
+    /* Room for the card's shadow on the left and top. */
+    padding: 6px 0 0 6px;
+    margin-left: -6px;
+    mask-image: linear-gradient(to bottom, black 55%, transparent 100%);
+}
+
+.beaver-run-status-tip__preview-clip {
+    mask-image: linear-gradient(to right, black 60%, transparent 100%);
+}
+
+.beaver-run-status-tip__preview-card {
+    width: 324px;
+    cursor: default;
+}
+
 /* A working run: a dot with a ring that keeps expanding out of it and fading. */
 .beaver-run-pulse {
     position: relative;

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -310,13 +310,21 @@
     text-overflow: ellipsis;
 }
 
-/* The shimmer paints its gradient across the whole box; keep the box to the text. */
-.beaver-run-status-popup__detail > .shimmer-text {
-    display: inline-block;
-    max-width: 100%;
+/* The shimmering status line: the text clips, and the component appends a
+ * plain ellipsis beside it. Gecko does not paint `text-overflow`'s own marker
+ * through the shimmer's transparent text fill. */
+.beaver-run-status-popup__status {
+    display: flex;
+    flex-direction: row;
+    min-width: 0;
+}
+
+.beaver-run-status-popup__status-text {
+    display: block;
+    flex: 0 1 auto;
+    min-width: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: top;
+    white-space: nowrap;
 }
 
 .beaver-run-status-popup__body {
@@ -444,16 +452,16 @@
 .beaver-run-pulse {
     position: relative;
     display: inline-block;
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
 }
 
 .beaver-run-pulse__dot {
     position: absolute;
-    top: 5px;
-    left: 5px;
-    width: 6px;
-    height: 6px;
+    top: 6px;
+    left: 6px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background: var(--accent-blue);
 }
@@ -462,9 +470,9 @@
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    border: 1.5px solid var(--accent-blue);
+    border: 2px solid var(--accent-blue);
     opacity: 0;
-    transform: scale(0.35);
+    transform: scale(0.4);
     animation: beaverRunPulseRing 2.2s cubic-bezier(0.2, 0.6, 0.4, 1) infinite;
 }
 
@@ -473,9 +481,9 @@
 }
 
 @keyframes beaverRunPulseRing {
-    0% { transform: scale(0.35); opacity: 0.85; }
-    70% { transform: scale(1); opacity: 0; }
-    100% { transform: scale(1); opacity: 0; }
+    0% { transform: scale(0.4); opacity: 1; }
+    75% { transform: scale(1.05); opacity: 0; }
+    100% { transform: scale(1.05); opacity: 0; }
 }
 
 /* Toolbar Button */

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -113,6 +113,10 @@ pref("onboardingWelcomeShown", false);
 pref("onboardingReaderTipShown", false);
 pref("onboardingReaderTipShownV2", false);
 pref("onboardingNoteTipShown", false);
+
+// One-time feature tips: JSON { shown: { [tipId]: isoDate }, lastShownAt: isoDate }
+// (see react/utils/featureTipPrefs.ts)
+pref("featureTips", "{}");
 pref("onboardingCitationTipShown", false);
 pref("onboardingWelcomeShownAt", "");
 pref("versionUpdatePopupShownAt", "");

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -59,6 +59,9 @@ pref("enableSystemNotifications", true);
 // Show an OS-native system notification when a response is complete and Beaver is not visible
 pref("enableResponseCompleteNotifications", true);
 
+// Show the run status popup in the corner of the main window while the sidebar is closed
+pref("enableRunStatusPopup", true);
+
 // Deferred tool preferences: maps tool group to preference (always_ask, always_apply, continue_without_applying)
 // Defaults are defined in react/atoms/deferredToolPreferences.ts and merged at load time.
 // This pref only stores user overrides.

--- a/packages/agent-ui/src/chat/AskUserQuestionCard.tsx
+++ b/packages/agent-ui/src/chat/AskUserQuestionCard.tsx
@@ -33,8 +33,11 @@ export interface AskUserQuestionCardProps {
     pendingQuestion: PendingQuestion;
     /** The user's answers for every question of the request. */
     onSubmit: (answers: AskUserQuestionAnswer[]) => void;
-    /** Abandon the run rather than answer it. */
-    onStop: () => void;
+    /**
+     * Abandon the run rather than answer it. Omitted by a surface that has no
+     * business stopping the run — the corner popup — and the button with it.
+     */
+    onStop?: () => void;
 }
 
 /**
@@ -295,17 +298,19 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({
 
                 {/* Footer: Stop ... Skip Next/Submit */}
                 <div className="display-flex flex-row items-center pt-2 gap-2">
-                    <Tooltip content="Stop the agent run" showArrow singleLine>
-                        <Button
-                            variant="outline"
-                            rightIcon={StopStrokeIcon}
-                            ariaLabel="Stop generating"
-                            style={{ padding: '2px 5px' }}
-                            onClick={onStop}
-                        >
-                            Stop
-                        </Button>
-                    </Tooltip>
+                    {onStop && (
+                        <Tooltip content="Stop the agent run" showArrow singleLine>
+                            <Button
+                                variant="outline"
+                                rightIcon={StopStrokeIcon}
+                                ariaLabel="Stop generating"
+                                style={{ padding: '2px 5px' }}
+                                onClick={onStop}
+                            >
+                                Stop
+                            </Button>
+                        </Tooltip>
+                    )}
                     <div className="flex-1" />
                     <Button
                         variant="ghost"

--- a/packages/agent-ui/src/icons/BubbleChatQuestionIcon.tsx
+++ b/packages/agent-ui/src/icons/BubbleChatQuestionIcon.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+type BubbleChatQuestionIconProps = React.SVGProps<SVGSVGElement>;
+
+const BubbleChatQuestionIcon: React.FC<BubbleChatQuestionIconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" color="currentColor" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <path d="M21.5 12C21.5 17.2467 17.2467 21.5 12 21.5C10.3719 21.5 8.8394 21.0904 7.5 20.3687C5.63177 19.362 4.37462 20.2979 3.26592 20.4658C3.09774 20.4913 2.93024 20.4302 2.80997 20.31C2.62741 20.1274 2.59266 19.8451 2.6935 19.6074C3.12865 18.5818 3.5282 16.6382 2.98341 15C2.6698 14.057 2.5 13.0483 2.5 12C2.5 6.75329 6.75329 2.5 12 2.5C17.2467 2.5 21.5 6.75329 21.5 12Z"></path>
+        <path d="M9.5 9.5C9.5 8.11929 10.6193 7 12 7C13.3807 7 14.5 8.11929 14.5 9.5C14.5 10.3569 14.0689 11.1131 13.4117 11.5636C12.7283 12.0319 12 12.6716 12 13.5"></path>
+        <path d="M12.125 16.75H12M12.25 16.75C12.25 16.8881 12.1381 17 12 17C11.8619 17 11.75 16.8881 11.75 16.75C11.75 16.6119 11.8619 16.5 12 16.5C12.1381 16.5 12.25 16.6119 12.25 16.75Z"></path>
+    </svg>
+);
+
+export default BubbleChatQuestionIcon;

--- a/packages/agent-ui/src/icons/index.tsx
+++ b/packages/agent-ui/src/icons/index.tsx
@@ -49,6 +49,7 @@ export { default as ArrowRightIcon } from './ArrowRightIcon';
 export { default as RepeatIcon } from './RepeatIcon';
 export { default as GlobalSearchIcon } from './GlobalSearchIcon';
 export { default as CopyIcon } from './CopyIcon';
+export { default as BubbleChatQuestionIcon } from './BubbleChatQuestionIcon';
 export { default as TickIcon } from './TickIcon';
 export { default as ShareIcon } from './ShareIcon';
 export { default as Share05Icon } from './Share05Icon';

--- a/packages/agent-ui/tsconfig.json
+++ b/packages/agent-ui/tsconfig.json
@@ -97,6 +97,7 @@
     "./src/icons/CircleIcon.tsx",
     "./src/icons/ClockIcon.tsx",
     "./src/icons/CopyIcon.tsx",
+    "./src/icons/BubbleChatQuestionIcon.tsx",
     "./src/icons/DatabaseIcon.tsx",
     "./src/icons/DeleteIcon.tsx",
     "./src/icons/DocumentValidationIcon.tsx",

--- a/react/atoms/featureTips.ts
+++ b/react/atoms/featureTips.ts
@@ -1,0 +1,80 @@
+/**
+ * Showing a feature tip: whether now is a good moment, and where it goes.
+ */
+import { atom } from 'jotai';
+import { logger } from '@beaver/agent-core/platform/logger';
+import { getPref } from '../../src/utils/prefs';
+import { FEATURE_TIPS, type FeatureTipId } from '../constants/featureTips';
+import { popupMessagesAtom } from './ui';
+import { addPopupMessageAtom, removePopupMessageAtom } from '../utils/popupMessageUtils';
+import {
+    addFloatingPopupMessageAtom,
+    floatingPopupMessagesAtom,
+    removeFloatingPopupMessageAtom,
+} from './floatingPopup';
+import {
+    hasSeenFeatureTip,
+    isWithinFeatureTipGap,
+    markFeatureTipShown,
+    readFeatureTipState,
+    writeFeatureTipState,
+} from '../utils/featureTipPrefs';
+
+export const featureTipMessageId = (tipId: FeatureTipId): string => `feature-tip:${tipId}`;
+
+export interface ShowFeatureTipOptions {
+    /** Skip the seen check and the pacing; for previews. */
+    force?: boolean;
+    /** Override where the tip goes; for previews. */
+    inPanel?: boolean;
+}
+
+/**
+ * Shows a tip if the moment is right, and records that it was shown.
+ *
+ * A tip is shown once, never while another popup of either kind is up, and
+ * never within the gap of the previous tip, the release notes, or the welcome
+ * card — the user is being told one thing at a time. Returns whether it was
+ * shown; the trigger uses that to stop asking.
+ */
+export const showFeatureTipAtom = atom(
+    null,
+    (get, set, tipId: FeatureTipId, options: ShowFeatureTipOptions = {}): boolean => {
+        const definition = FEATURE_TIPS[tipId];
+        if (!definition) return false;
+
+        if (!options.force) {
+            const state = readFeatureTipState();
+            if (hasSeenFeatureTip(state, tipId)) return false;
+            if (isWithinFeatureTipGap(state, Date.now(), [
+                getPref('versionUpdatePopupShownAt'),
+                getPref('onboardingWelcomeShownAt'),
+            ])) {
+                logger(`showFeatureTipAtom: Holding "${tipId}" (another tip was shown recently)`);
+                return false;
+            }
+            if (get(floatingPopupMessagesAtom).length > 0 || get(popupMessagesAtom).length > 0) {
+                logger(`showFeatureTipAtom: Holding "${tipId}" (another popup is showing)`);
+                return false;
+            }
+            writeFeatureTipState(markFeatureTipShown(state, tipId, Date.now()));
+        }
+
+        const inPanel = options.inPanel ?? definition.inPanel;
+        logger(`showFeatureTipAtom: Showing "${tipId}" ${inPanel ? 'in the panel' : 'floating'}`);
+        set(inPanel ? addPopupMessageAtom : addFloatingPopupMessageAtom, {
+            id: featureTipMessageId(tipId),
+            type: 'feature_tip',
+            tipId,
+            expire: false,
+            cancelable: false,
+        });
+        return true;
+    },
+);
+
+/** Retires a tip wherever it was shown. */
+export const dismissFeatureTipAtom = atom(null, (_get, set, tipId: FeatureTipId) => {
+    set(removePopupMessageAtom, featureTipMessageId(tipId));
+    set(removeFloatingPopupMessageAtom, featureTipMessageId(tipId));
+});

--- a/react/atoms/runStatusPopup.ts
+++ b/react/atoms/runStatusPopup.ts
@@ -1,0 +1,103 @@
+import { atom } from 'jotai';
+import { getPref, setPref } from '../../src/utils/prefs';
+
+/**
+ * The run whose completion the closed-sidebar status popup is reporting.
+ *
+ * A run that finishes while the sidebar is closed has nowhere to announce
+ * itself, so the popup keeps a completed card up for it. The record is stamped
+ * when the run turns terminal with the sidebar closed, and cleared when the
+ * user dismisses the card, opens Beaver, or starts another run — the sidebar
+ * then carries the answer, and a card that outlived it would report a result
+ * the user has already seen.
+ */
+export interface RunStatusPopupCompletion {
+    runId: string;
+    /** When the run turned terminal, in epoch ms. */
+    completedAt: number;
+}
+
+export const runStatusPopupCompletionAtom = atom<RunStatusPopupCompletion | null>(null);
+
+/**
+ * A card the dev endpoint asked the popup to draw instead of the live state.
+ *
+ * Every state the popup can reach depends on a run being in exactly that state,
+ * which is slow to reproduce and bills credits. The preview lets each be drawn
+ * on demand; its controls only clear the preview. Serializable on purpose — it
+ * arrives over HTTP.
+ */
+export type RunStatusPopupPreview =
+    | { kind: 'running'; threadName?: string; statusLine?: string; stackDepth?: number }
+    | {
+        kind: 'approval';
+        threadName?: string;
+        label?: string;
+        count?: number;
+        /** Draw the run-permission menu; off for a confirm-only card. */
+        showPermissionMenu?: boolean;
+        /** Tool the single action's icon is drawn for, e.g. `create_note`. */
+        actionType?: string;
+        approveLabel?: string;
+        rejectLabel?: string;
+        stackDepth?: number;
+    }
+    | {
+        kind: 'credit';
+        threadName?: string;
+        title?: string;
+        message?: string;
+        approveLabel?: string;
+        declineLabel?: string;
+        stackDepth?: number;
+    }
+    | { kind: 'batch'; threadName?: string; title?: string; scope?: string; stackDepth?: number }
+    | { kind: 'question'; threadName?: string; title?: string; stackDepth?: number }
+    | {
+        kind: 'completed';
+        threadName?: string;
+        outcome?: 'completed' | 'error' | 'canceled';
+        /** The run error type, for the title an `error` outcome carries. */
+        errorType?: string;
+        artifacts?: string[];
+        /** The changes-card trail, e.g. "2 applied, 1 pending". */
+        changes?: string;
+        stackDepth?: number;
+    };
+
+export const runStatusPopupPreviewAtom = atom<RunStatusPopupPreview | null>(null);
+
+/**
+ * Show the popup even while the sidebar is open. Dev-only, for inspecting the
+ * card beside the surface it stands in for.
+ */
+export const runStatusPopupForceVisibleAtom = atom(false);
+
+/**
+ * Cards the user has closed. Keyed by what the card was about — a run's
+ * working state, one set of approvals, one confirmation — so closing the
+ * working card does not also hide the decision the same run asks for a
+ * moment later. Cleared when another run takes the thread over.
+ */
+export const runStatusPopupDismissedAtom = atom<ReadonlySet<string>>(new Set<string>());
+
+export const dismissRunStatusPopupCardAtom = atom(null, (get, set, signature: string) => {
+    const next = new Set(get(runStatusPopupDismissedAtom));
+    next.add(signature);
+    set(runStatusPopupDismissedAtom, next);
+});
+
+/**
+ * The `enableRunStatusPopup` preference, mirrored so the popup follows a
+ * change made in the preferences window without a reload. Read lazily: the
+ * preference store is not there when this module loads.
+ */
+const runStatusPopupEnabledOverrideAtom = atom<boolean | null>(null);
+
+export const runStatusPopupEnabledAtom = atom(
+    (get) => get(runStatusPopupEnabledOverrideAtom) ?? getPref('enableRunStatusPopup') !== false,
+    (_get, set, enabled: boolean) => {
+        setPref('enableRunStatusPopup', enabled);
+        set(runStatusPopupEnabledOverrideAtom, enabled);
+    },
+);

--- a/react/components/FloatingPopupRoot.tsx
+++ b/react/components/FloatingPopupRoot.tsx
@@ -1,12 +1,14 @@
 import React, { useRef } from 'react';
 import FloatingPopupContainer from './ui/popup/FloatingPopupContainer';
+import RunStatusPopup from './runStatusPopup/RunStatusPopup';
 
 const FloatingPopupRoot: React.FC = () => {
     const containerRef = useRef<HTMLDivElement>(null);
 
     return (
-        <div ref={containerRef}>
+        <div ref={containerRef} className="display-flex flex-col">
             <FloatingPopupContainer />
+            <RunStatusPopup />
         </div>
     );
 };

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -5,6 +5,7 @@ import { getPref, setPref } from '../../../src/utils/prefs';
 import { UserIcon, LogoutIcon, RepeatIcon, SettingsIcon, Icon, SearchIcon, LockIcon, KeyIcon, ZapIcon, ToolsIcon, DollarCircleIcon } from '../icons/icons';
 import Button from "@beaver/agent-ui/primitives/Button";
 import { useSetAtom } from 'jotai';
+import { runStatusPopupEnabledAtom } from '../../atoms/runStatusPopup';
 import { profileWithPlanAtom, creditPlanAtom, hasCreditPlanAtom } from "../../atoms/profile";
 import { activePreferencePageTabAtom, PreferencePageTab } from "../../atoms/ui";
 import { logger } from "@beaver/agent-core/platform/logger";
@@ -41,6 +42,7 @@ const PreferencePage: React.FC = () => {
     });
     const [addSelectedOnNewThread, setAddSelectedOnNewThread] = useState(() => getPref('addSelectedItemsOnNewThread'));
     const [addSelectedOnOpen, setAddSelectedOnOpen] = useState(() => getPref('addSelectedItemsOnOpen'));
+    const [runStatusPopupEnabled, setRunStatusPopupEnabled] = useAtom(runStatusPopupEnabledAtom);
     const [addProvenanceNote, setAddProvenanceNote] = useState(() => getPref('addBeaverProvenanceNote'));
     const [focusResponseForScreenReaders, setFocusResponseForScreenReaders] = useState(() => getPref('focusResponseForScreenReaders'));
     const [showDiffPreview, setShowDiffPreview] = useState(() => getPref('showDiffPreviewInNoteEditor') !== false);
@@ -147,6 +149,10 @@ const PreferencePage: React.FC = () => {
         setPref("addSelectedItemsOnOpen", newValue);
         setAddSelectedOnOpen(newValue);
     }, [addSelectedOnOpen]);
+
+    const handleRunStatusPopupToggle = useCallback(() => {
+        setRunStatusPopupEnabled(!runStatusPopupEnabled);
+    }, [runStatusPopupEnabled, setRunStatusPopupEnabled]);
 
     const handleAddProvenanceNoteToggle = useCallback(() => {
         const newValue = !addProvenanceNote;
@@ -417,6 +423,22 @@ const PreferencePage: React.FC = () => {
                                         type="checkbox"
                                         checked={addSelectedOnOpen}
                                         onChange={handleAddSelectedOnOpenToggle}
+                                        onClick={(e) => e.stopPropagation()}
+                                        style={{ cursor: 'pointer', margin: 0 }}
+                                    />
+                                }
+                            />
+                            <SettingsRow
+                                title="Run Status Popup"
+                                description="Show what Beaver is doing in the corner of the window while the sidebar is closed"
+                                onClick={handleRunStatusPopupToggle}
+                                hasBorder
+                                tooltip="When enabled, a small card in the bottom-right corner of the Zotero window shows the current run's progress, lets you approve pending changes, and reports when a response is ready."
+                                control={
+                                    <input
+                                        type="checkbox"
+                                        checked={runStatusPopupEnabled}
+                                        onChange={handleRunStatusPopupToggle}
                                         onClick={(e) => e.stopPropagation()}
                                         style={{ cursor: 'pointer', margin: 0 }}
                                     />

--- a/react/components/runStatusPopup/RunPulse.tsx
+++ b/react/components/runStatusPopup/RunPulse.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * The mark for a run that is working: a dot with a soft ring that keeps
+ * expanding out of it and fading, like a ping. Sized to an icon, so the same
+ * slot holds an icon once the run has something more specific to say.
+ */
+const RunPulse: React.FC<{ className?: string }> = ({ className = '' }) => (
+    <span className={`beaver-run-pulse ${className}`} aria-hidden="true">
+        <span className="beaver-run-pulse__ring" />
+        <span className="beaver-run-pulse__ring" />
+        <span className="beaver-run-pulse__dot" />
+    </span>
+);
+
+export default RunPulse;

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -12,7 +12,6 @@ import {
     Icon,
     LayersIcon,
     LibraryIcon,
-    NoteIcon,
 } from '../icons/icons';
 import Button from '@beaver/agent-ui/primitives/Button';
 import IconButton from '@beaver/agent-ui/primitives/IconButton';
@@ -138,7 +137,7 @@ const CreditView: React.FC<{ card: CreditCard }> = ({ card }) => (
     <>
         <Header
             card={card}
-            leading={<Mark icon={DollarCircleIcon} className="font-color-orange" />}
+            leading={<Mark icon={DollarCircleIcon} className="font-color-secondary" />}
             detail={<span title={card.title}>{card.title}</span>}
             detailClassName="font-color-primary"
         />
@@ -226,10 +225,13 @@ const CompletedView: React.FC<{ card: CompletedCard }> = ({ card }) => {
                             type="button"
                             className="beaver-run-status-popup__row"
                             onClick={artifact.open ?? card.onOpen}
-                            title={artifact.title}
+                            title={artifact.title ?? artifact.label}
                         >
-                            <Icon icon={NoteIcon} className="font-color-secondary" />
-                            <span className="beaver-run-status-popup__row-text font-color-primary">{artifact.title}</span>
+                            <Icon icon={getAgentActionToolIcon(artifact.actionType)} className="font-color-secondary" />
+                            <span className="beaver-run-status-popup__row-text">
+                                <span className="font-color-primary font-medium">{artifact.label}</span>
+                                {artifact.title && <span className="font-color-secondary"> {artifact.title}</span>}
+                            </span>
                             <Icon icon={ArrowUpRightIcon} className="font-color-tertiary beaver-run-status-popup__row-arrow" />
                         </button>
                     ))}
@@ -241,7 +243,7 @@ const CompletedView: React.FC<{ card: CompletedCard }> = ({ card }) => {
                         </button>
                     )}
                     {card.changes !== null && (
-                        <button type="button" className="beaver-run-status-popup__row" onClick={card.onOpen}>
+                        <button type="button" className="beaver-run-status-popup__row" onClick={card.onReviewChanges}>
                             <Icon icon={LibraryIcon} className="font-color-secondary" />
                             <span className="beaver-run-status-popup__row-text beaver-run-status-popup__row-text--fixed font-color-primary">Review library changes</span>
                             {card.changes && (

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -1,0 +1,377 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import { isSidebarVisibleAtom } from '../../atoms/ui';
+import { runStatusPopupForceVisibleAtom } from '../../atoms/runStatusPopup';
+import {
+    AlertIcon,
+    ArrowUpRightIcon,
+    CancelIcon,
+    CheckmarkCircleIcon,
+    DollarCircleIcon,
+    HelpCircleIcon,
+    Icon,
+    LayersIcon,
+    LibraryIcon,
+    NoteIcon,
+} from '../icons/icons';
+import Button from '@beaver/agent-ui/primitives/Button';
+import IconButton from '@beaver/agent-ui/primitives/IconButton';
+import RunPermissionButton from '../ui/buttons/RunPermissionButton';
+import { getAgentActionToolIcon } from '../../host/zotero/components/agentActionViewHelpers';
+import RunPulse from './RunPulse';
+import { useRunStatusPopupCard } from './useRunStatusPopupCard';
+import type {
+    ApprovalCard,
+    BatchCard,
+    CompletedCard,
+    CreditCard,
+    QuestionCard,
+    RunningCard,
+    RunStatusPopupCard,
+} from './runStatusPopupModel';
+
+/** The compact control sizing the card's footer buttons share. */
+const FOOTER_BUTTON_STYLE: React.CSSProperties = { padding: '2px 10px', fontSize: '0.875rem', whiteSpace: 'nowrap' };
+
+/** Every state's mark shares one footprint, the pulse included. */
+const MARK_SIZE = 16;
+
+const Mark: React.FC<{ icon: React.FC<React.SVGProps<SVGSVGElement>>; className?: string }> = ({ icon, className = '' }) => (
+    <Icon icon={icon} size={MARK_SIZE} className={className} />
+);
+
+/**
+ * Whether a click on the card should open Beaver. Buttons, menus and the
+ * artifact rows carry their own actions, so a click that lands on one of
+ * them — or inside a menu they opened — is theirs.
+ */
+function isCardBackgroundClick(event: React.MouseEvent<HTMLElement>): boolean {
+    const target = event.target as Element | null;
+    return !target?.closest('button, a, [role="menu"], [role="menuitem"], [role="menuitemradio"]');
+}
+
+const Header: React.FC<{
+    card: RunStatusPopupCard;
+    leading: React.ReactNode;
+    /** The second line; null for a card whose title is the whole story. */
+    detail: React.ReactNode;
+    detailClassName?: string;
+}> = ({ card, leading, detail, detailClassName = 'font-color-secondary' }) => (
+    <div className="beaver-run-status-popup__header">
+        <div className="beaver-run-status-popup__leading">{leading}</div>
+        <div className="beaver-run-status-popup__text">
+            <div className="beaver-run-status-popup__title font-color-primary" title={card.threadName}>
+                {card.threadName}
+            </div>
+            {detail !== null && (
+                <div className={`beaver-run-status-popup__detail ${detailClassName}`}>{detail}</div>
+            )}
+        </div>
+        {/* Shown on hover so the card stays quiet; closing is remembered for
+            this card only (see the hook), so the run's next request still
+            gets through. */}
+        <div className="beaver-run-status-popup__trailing beaver-run-status-popup__dismiss">
+            <IconButton
+                icon={CancelIcon}
+                variant="ghost-secondary"
+                onClick={card.onDismiss}
+                ariaLabel="Close"
+            />
+        </div>
+    </div>
+);
+
+const RunningView: React.FC<{ card: RunningCard }> = ({ card }) => (
+    <Header
+        card={card}
+        leading={<RunPulse />}
+        detail={<span className="shimmer-text" title={card.statusLine}>{card.statusLine}</span>}
+    />
+);
+
+const ApprovalView: React.FC<{ card: ApprovalCard }> = ({ card }) => (
+    <>
+        <Header
+            card={card}
+            leading={(
+                <Mark
+                    icon={card.actionType ? getAgentActionToolIcon(card.actionType) : LibraryIcon}
+                    className="font-color-secondary"
+                />
+            )}
+            detail={<span title={card.label}>{card.label}</span>}
+            detailClassName="font-color-primary"
+        />
+        <div className="beaver-run-status-popup__footer">
+            {card.permission && (
+                <div className="beaver-run-status-popup__permission">
+                    <RunPermissionButton
+                        mode={card.permission.mode}
+                        onChange={card.permission.onChange}
+                        pendingCoveredCount={card.permission.pendingCoveredCount}
+                        disabled={card.decideDisabled}
+                    />
+                </div>
+            )}
+            <div className="flex-1" />
+            <Button
+                variant="outline"
+                style={FOOTER_BUTTON_STYLE}
+                onClick={() => card.onDecide(false)}
+                disabled={card.decideDisabled}
+            >
+                {card.rejectLabel}
+            </Button>
+            <Button
+                variant="solid"
+                style={FOOTER_BUTTON_STYLE}
+                onClick={() => card.onDecide(true)}
+                disabled={card.decideDisabled}
+            >
+                {card.approveLabel}
+            </Button>
+        </div>
+    </>
+);
+
+const CreditView: React.FC<{ card: CreditCard }> = ({ card }) => (
+    <>
+        <Header
+            card={card}
+            leading={<Mark icon={DollarCircleIcon} className="font-color-orange" />}
+            detail={<span title={card.title}>{card.title}</span>}
+            detailClassName="font-color-primary"
+        />
+        <div className="beaver-run-status-popup__body font-color-secondary">{card.message}</div>
+        <div className="beaver-run-status-popup__footer">
+            <div className="flex-1" />
+            <Button
+                variant="outline"
+                style={FOOTER_BUTTON_STYLE}
+                onClick={() => card.onDecide(false)}
+                disabled={card.decideDisabled}
+            >
+                {card.declineLabel}
+            </Button>
+            <Button
+                variant="solid"
+                style={FOOTER_BUTTON_STYLE}
+                onClick={() => card.onDecide(true)}
+                disabled={card.decideDisabled}
+            >
+                {card.approveLabel}
+            </Button>
+        </div>
+    </>
+);
+
+const BatchView: React.FC<{ card: BatchCard }> = ({ card }) => (
+    <>
+        <Header
+            card={card}
+            leading={<Mark icon={LayersIcon} className="font-color-secondary" />}
+            detail={<span title={card.title}>{card.title}</span>}
+            detailClassName="font-color-primary"
+        />
+        {card.scope && <div className="beaver-run-status-popup__body font-color-secondary">{card.scope}</div>}
+        <div className="beaver-run-status-popup__footer">
+            <span className="font-color-tertiary text-sm">Approve in Beaver</span>
+            <div className="flex-1" />
+            <Button variant="solid" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={card.onOpen}>
+                Review
+            </Button>
+        </div>
+    </>
+);
+
+const QuestionView: React.FC<{ card: QuestionCard }> = ({ card }) => (
+    <>
+        <Header
+            card={card}
+            leading={<Mark icon={HelpCircleIcon} className="font-color-secondary" />}
+            detail={<span title={card.title}>{card.title}</span>}
+            detailClassName="font-color-primary"
+        />
+        <div className="beaver-run-status-popup__footer">
+            <div className="flex-1" />
+            <Button variant="solid" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={card.onOpen}>
+                Answer
+            </Button>
+        </div>
+    </>
+);
+
+/** The error outcome wears the run error display's icon; a clean finish, a check. */
+const COMPLETED_MARK: Record<CompletedCard['outcome'], { icon: React.FC<React.SVGProps<SVGSVGElement>>; className: string }> = {
+    completed: { icon: CheckmarkCircleIcon, className: 'font-color-green' },
+    error: { icon: AlertIcon, className: 'font-color-red' },
+    canceled: { icon: AlertIcon, className: 'font-color-secondary' },
+};
+
+const CompletedView: React.FC<{ card: CompletedCard }> = ({ card }) => {
+    const mark = COMPLETED_MARK[card.outcome];
+    const hasRows = card.artifacts.length > 0 || card.changes !== null;
+    return (
+        <>
+            <Header
+                card={card}
+                leading={<Mark icon={mark.icon} className={mark.className} />}
+                detail={card.detail}
+            />
+            {hasRows && (
+                <div className="beaver-run-status-popup__rows">
+                    {card.artifacts.map((artifact) => (
+                        <button
+                            key={artifact.key}
+                            type="button"
+                            className="beaver-run-status-popup__row"
+                            onClick={artifact.open ?? card.onOpen}
+                            title={artifact.title}
+                        >
+                            <Icon icon={NoteIcon} className="font-color-secondary" />
+                            <span className="beaver-run-status-popup__row-text font-color-primary">{artifact.title}</span>
+                            <Icon icon={ArrowUpRightIcon} className="font-color-tertiary beaver-run-status-popup__row-arrow" />
+                        </button>
+                    ))}
+                    {card.hiddenArtifactCount > 0 && (
+                        <button type="button" className="beaver-run-status-popup__row" onClick={card.onOpen}>
+                            <span className="beaver-run-status-popup__row-text font-color-secondary">
+                                {`+${card.hiddenArtifactCount} more`}
+                            </span>
+                        </button>
+                    )}
+                    {card.changes !== null && (
+                        <button type="button" className="beaver-run-status-popup__row" onClick={card.onOpen}>
+                            <Icon icon={LibraryIcon} className="font-color-secondary" />
+                            <span className="beaver-run-status-popup__row-text beaver-run-status-popup__row-text--fixed font-color-primary">Review library changes</span>
+                            {card.changes && (
+                                <span className="beaver-run-status-popup__row-trail font-color-tertiary" title={card.changes}>
+                                    {card.changes}
+                                </span>
+                            )}
+                        </button>
+                    )}
+                </div>
+            )}
+            <div className="beaver-run-status-popup__footer">
+                <div className="flex-1" />
+                <Button variant="outline" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={card.onOpen}>
+                    Open Beaver
+                </Button>
+            </div>
+        </>
+    );
+};
+
+const CardView: React.FC<{ card: RunStatusPopupCard }> = ({ card }) => {
+    switch (card.kind) {
+        case 'running': return <RunningView card={card} />;
+        case 'approval': return <ApprovalView card={card} />;
+        case 'credit': return <CreditView card={card} />;
+        case 'batch': return <BatchView card={card} />;
+        case 'question': return <QuestionView card={card} />;
+        case 'completed': return <CompletedView card={card} />;
+    }
+};
+
+/**
+ * The card's frame, sized to its content through a measured height so a
+ * change of state grows or shrinks it smoothly rather than snapping. The
+ * first paint is not animated: a card appearing should not unfold from zero.
+ */
+const AnimatedCard: React.FC<{ card: RunStatusPopupCard; children: React.ReactNode }> = ({ card, children }) => {
+    const innerRef = useRef<HTMLDivElement>(null);
+    const [height, setHeight] = useState<number | null>(null);
+    const [settled, setSettled] = useState(false);
+
+    const measure = useCallback(() => {
+        const inner = innerRef.current;
+        if (inner) setHeight(inner.getBoundingClientRect().height);
+    }, []);
+
+    // Measured in the same frame the new state is laid out, so the transition
+    // starts at once; the observer below covers the content changing on its
+    // own afterwards (a tool label's item name arriving).
+    useLayoutEffect(measure, [card, measure]);
+
+    useLayoutEffect(() => {
+        const inner = innerRef.current;
+        const win = inner?.ownerDocument.defaultView;
+        if (!inner || !win) return;
+        // Second frame: the first measurement is drawn without a transition,
+        // and every change after it is animated.
+        const frame = win.requestAnimationFrame(() => setSettled(true));
+        const observer = new win.ResizeObserver(measure);
+        observer.observe(inner);
+        return () => {
+            win.cancelAnimationFrame(frame);
+            observer.disconnect();
+        };
+    }, [measure]);
+
+    const handleClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
+        if (isCardBackgroundClick(event)) card.onOpen();
+    }, [card]);
+
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
+        if (event.target !== event.currentTarget) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            card.onOpen();
+        }
+    }, [card]);
+
+    return (
+        <div
+            className={`beaver-run-status-popup__card beaver-run-status-popup__card--${card.kind} ${settled ? 'beaver-run-status-popup__card--settled' : ''}`}
+            style={{ height: height ?? undefined }}
+            role="button"
+            tabIndex={0}
+            aria-label={`Open Beaver: ${card.threadName}`}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
+        >
+            <div ref={innerRef} className="beaver-run-status-popup__content">
+                {children}
+            </div>
+        </div>
+    );
+};
+
+/**
+ * The status of the open thread's run, drawn in the corner of the main window
+ * while the sidebar is closed: what the run is doing, the decision it is
+ * waiting on with the controls to make it, or what it finished with.
+ *
+ * Always mounted, so the completion tracking in the hook sees a run finish
+ * whether or not a card is up; it draws nothing while the sidebar is open.
+ */
+const RunStatusPopup: React.FC = () => {
+    const card = useRunStatusPopupCard();
+    const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
+    const forceVisible = useAtomValue(runStatusPopupForceVisibleAtom);
+
+    if (!card || (isSidebarVisible && !forceVisible)) return null;
+
+    // Layers behind the front card stand for the other threads still
+    // running. The count is capped by the model; each layer is a sliver.
+    const layers = Array.from({ length: card.stackDepth }, (_, index) => index + 1);
+
+    return (
+        <div className="beaver-run-status-popup" data-stack-depth={card.stackDepth}>
+            {layers.map((depth) => (
+                <div
+                    key={depth}
+                    className="beaver-run-status-popup__layer"
+                    style={{ '--beaver-stack-depth': depth } as React.CSSProperties}
+                    aria-hidden="true"
+                />
+            ))}
+            <AnimatedCard card={card}>
+                <CardView card={card} />
+            </AnimatedCard>
+        </div>
+    );
+};
+
+export default RunStatusPopup;

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -47,6 +47,7 @@ import {
 import Button from '@beaver/agent-ui/primitives/Button';
 import IconButton from '@beaver/agent-ui/primitives/IconButton';
 import RunPermissionButton from '../ui/buttons/RunPermissionButton';
+import AskUserQuestionCard from '@beaver/agent-ui/chat/AskUserQuestionCard';
 import { getAgentActionToolIcon } from '../../host/zotero/components/agentActionViewHelpers';
 import RunPulse from './RunPulse';
 import { useRunStatusPopupCard } from './useRunStatusPopupCard';
@@ -77,7 +78,9 @@ const Mark: React.FC<{ icon: React.FC<React.SVGProps<SVGSVGElement>>; className?
  */
 function isCardBackgroundClick(event: React.MouseEvent<HTMLElement>): boolean {
     const target = event.target as Element | null;
-    return !target?.closest('button, a, [role="menu"], [role="menuitem"], [role="menuitemradio"]');
+    return !target?.closest(
+        'button, a, input, textarea, label, [role="menu"], [role="menuitem"], [role="menuitemradio"], [data-run-status-popup-interactive]',
+    );
 }
 
 const Header: React.FC<{
@@ -214,19 +217,23 @@ const BatchView: React.FC<{ card: BatchCard }> = ({ card }) => (
     </>
 );
 
+/**
+ * The question is answered right here, with the same card the composer shows
+ * for it. Without Stop: a corner popup is not the place to abandon a run.
+ */
 const QuestionView: React.FC<{ card: QuestionCard }> = ({ card }) => (
     <>
         <Header
             card={card}
             leading={<Mark icon={HelpCircleIcon} className="font-color-secondary" />}
-            detail={<span title={card.title}>{card.title}</span>}
-            detailClassName="font-color-primary"
+            detail={null}
         />
-        <div className="beaver-run-status-popup__footer">
-            <div className="flex-1" />
-            <Button variant="solid" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={card.onOpen}>
-                Answer
-            </Button>
+        <div className="beaver-run-status-popup__question" data-run-status-popup-interactive>
+            <AskUserQuestionCard
+                key={card.question.questionId}
+                pendingQuestion={card.question}
+                onSubmit={card.onSubmit}
+            />
         </div>
     </>
 );

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -1,4 +1,35 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * The shimmering status line, cut with a visible ellipsis.
+ *
+ * Drawn by hand because the shimmer paints its text through a transparent
+ * fill, and Gecko paints `text-overflow`'s marker the same way — the line
+ * looked cut off. The text itself is clipped, and a plain "…" in the line's
+ * own color follows it whenever the text does not fit.
+ */
+const StatusLine: React.FC<{ text: string }> = ({ text }) => {
+    const textRef = useRef<HTMLSpanElement>(null);
+    const [clipped, setClipped] = useState(false);
+
+    useLayoutEffect(() => {
+        const el = textRef.current;
+        const win = el?.ownerDocument.defaultView;
+        if (!el || !win) return;
+        const measure = () => setClipped(el.scrollWidth > el.clientWidth + 1);
+        measure();
+        const observer = new win.ResizeObserver(measure);
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [text]);
+
+    return (
+        <span className="beaver-run-status-popup__status" title={text}>
+            <span ref={textRef} className="shimmer-text beaver-run-status-popup__status-text">{text}</span>
+            {clipped && <span aria-hidden="true">…</span>}
+        </span>
+    );
+};
 import { useAtomValue } from 'jotai';
 import { isSidebarVisibleAtom } from '../../atoms/ui';
 import { runStatusPopupForceVisibleAtom } from '../../atoms/runStatusPopup';
@@ -84,7 +115,7 @@ const RunningView: React.FC<{ card: RunningCard }> = ({ card }) => (
     <Header
         card={card}
         leading={<RunPulse />}
-        detail={<span className="shimmer-text" title={card.statusLine}>{card.statusLine}</span>}
+        detail={<StatusLine text={card.statusLine} />}
     />
 );
 

--- a/react/components/runStatusPopup/runStatusPopupModel.ts
+++ b/react/components/runStatusPopup/runStatusPopupModel.ts
@@ -22,7 +22,12 @@ const MAX_PROMPT_TITLE_CHARS = 60;
 
 export interface RunStatusArtifact {
     key: string;
-    title: string;
+    /** The action type that produced it, for its icon. */
+    actionType: string;
+    /** What was made, in the sidebar's words: "Created Note". */
+    label: string;
+    /** The artifact's own name; null when the action has none. */
+    title: string | null;
     /** Opens the artifact itself; absent when it has not been written yet. */
     open?: () => void;
 }
@@ -99,6 +104,8 @@ export interface CompletedCard extends RunStatusCardBase {
     hiddenArtifactCount: number;
     /** The changes card's trail ("2 applied, 1 pending"), or null with no changes. */
     changes: string | null;
+    /** Opens Beaver with the answer's changes card expanded. */
+    onReviewChanges: () => void;
 }
 
 export type RunStatusPopupCard =

--- a/react/components/runStatusPopup/runStatusPopupModel.ts
+++ b/react/components/runStatusPopup/runStatusPopupModel.ts
@@ -1,0 +1,236 @@
+/**
+ * What the closed-sidebar status popup says, derived from run state.
+ *
+ * Pure: the hook next door subscribes to the store and calls these; nothing
+ * here reads an atom, touches the DOM, or knows how a card is drawn.
+ */
+import type { AgentRun, ToolCallPart } from '@beaver/agent-core/agents/types';
+import { isAutoLoadingToolCall, isThinkingInProgress } from '@beaver/agent-core/agents/messageVisibility';
+import { getToolCallStatus, type ToolResult } from '@beaver/agent-core/run-state/atoms';
+import type { PendingApproval } from '@beaver/agent-ui/host';
+import type { RunPermissionMode } from '../ui/buttons/RunPermissionButton';
+import { getActionLabel } from '../../host/zotero/components/agentActionViewHelpers';
+
+/** How many threads the popup will layer behind the front card, at most. */
+export const MAX_STACK_DEPTH = 2;
+
+/** Artifacts listed on a completed card before the rest is left to the sidebar. */
+export const MAX_COMPLETED_ARTIFACTS = 3;
+
+/** Longest thread name drawn before the prompt is cut, when no name exists yet. */
+const MAX_PROMPT_TITLE_CHARS = 60;
+
+export interface RunStatusArtifact {
+    key: string;
+    title: string;
+    /** Opens the artifact itself; absent when it has not been written yet. */
+    open?: () => void;
+}
+
+interface RunStatusCardBase {
+    threadName: string;
+    /** Further running threads layered behind this card, capped by MAX_STACK_DEPTH. */
+    stackDepth: number;
+    /** Opens Beaver on this thread. The whole card is the target. */
+    onOpen: () => void;
+    /**
+     * Closes this card. It stays closed for exactly what it was about — see
+     * `runStatusPopupDismissedAtom` — and the next thing the run has to say
+     * gets a card of its own.
+     */
+    onDismiss: () => void;
+}
+
+export interface RunningCard extends RunStatusCardBase {
+    kind: 'running';
+    /** What the run is doing now: "Thinking", "Generating", or a tool-call label. */
+    statusLine: string;
+}
+
+export interface ApprovalCard extends RunStatusCardBase {
+    kind: 'approval';
+    /** One action's label and title, or the aggregate for several. */
+    label: string;
+    count: number;
+    /** The one pending action's type, for its tool icon; null for several. */
+    actionType: string | null;
+    /** The run-scoped permission control; null for a confirm-only card. */
+    permission: {
+        mode: RunPermissionMode;
+        pendingCoveredCount: number;
+        onChange: (mode: RunPermissionMode) => void;
+    } | null;
+    approveLabel: string;
+    rejectLabel: string;
+    onDecide: (approved: boolean) => void;
+    /** A decision is already on its way; the next click must wait. */
+    decideDisabled: boolean;
+}
+
+export interface CreditCard extends RunStatusCardBase {
+    kind: 'credit';
+    title: string;
+    message: string;
+    approveLabel: string;
+    declineLabel: string;
+    onDecide: (approved: boolean) => void;
+    decideDisabled: boolean;
+}
+
+export interface BatchCard extends RunStatusCardBase {
+    kind: 'batch';
+    title: string;
+    /** The population, e.g. "184 items in Methods". Empty when unknown. */
+    scope: string;
+}
+
+export interface QuestionCard extends RunStatusCardBase {
+    kind: 'question';
+    title: string;
+}
+
+export interface CompletedCard extends RunStatusCardBase {
+    kind: 'completed';
+    outcome: 'completed' | 'error' | 'canceled';
+    /** What went wrong, in the run error display's words; null for a clean finish. */
+    detail: string | null;
+    artifacts: RunStatusArtifact[];
+    /** How many artifacts the card left out, for the "+N more" line. */
+    hiddenArtifactCount: number;
+    /** The changes card's trail ("2 applied, 1 pending"), or null with no changes. */
+    changes: string | null;
+}
+
+export type RunStatusPopupCard =
+    | RunningCard
+    | ApprovalCard
+    | CreditCard
+    | BatchCard
+    | QuestionCard
+    | CompletedCard;
+
+export type RunStatusPopupKind = RunStatusPopupCard['kind'];
+
+/** What a live run is doing right now, for the running card's second line. */
+export type RunActivity =
+    | { kind: 'thinking' }
+    | { kind: 'generating' }
+    | { kind: 'tool'; part: ToolCallPart };
+
+/**
+ * The visible activity in a run: a tool call still waiting on its result, or
+ * failing that, whether the newest response is reasoning or writing.
+ *
+ * A tool call wins because it is the most specific thing the popup can say,
+ * and because the model says nothing while one runs. Auto-loading calls are
+ * plumbing the sidebar hides, and `return_suggestions` is the answer's
+ * follow-up chips, so neither reads as activity. The newest of several
+ * parallel calls is the one named, since it is the one that started last.
+ *
+ * With no tool running, the newest response decides: reasoning with nothing
+ * else yet is "thinking", a text part is "generating", and anything else —
+ * including a run that has produced nothing at all, or whose newest message is
+ * a tool return the model has yet to answer — is the wait before the next
+ * token, which reads as thinking too.
+ */
+/** Plumbing the sidebar hides, and the answer's follow-up chips: neither is activity. */
+function isIgnoredToolCall(part: ToolCallPart): boolean {
+    return isAutoLoadingToolCall(part) || part.tool_name === 'return_suggestions';
+}
+
+export function deriveRunActivity(
+    run: AgentRun,
+    toolResults: ReadonlyMap<string, ToolResult>,
+): RunActivity {
+    let inProgress: ToolCallPart | null = null;
+    for (const message of run.model_messages) {
+        if (message.kind !== 'response') continue;
+        for (const part of message.parts) {
+            if (part.part_kind !== 'tool-call' || isIgnoredToolCall(part)) continue;
+            if (getToolCallStatus(part.tool_call_id, toolResults, run.status) === 'in_progress') {
+                inProgress = part;
+            }
+        }
+    }
+    if (inProgress) return { kind: 'tool', part: inProgress };
+
+    const newest = run.model_messages[run.model_messages.length - 1];
+    if (!newest || newest.kind !== 'response') return { kind: 'thinking' };
+    if (isThinkingInProgress(newest)) return { kind: 'thinking' };
+    for (let i = newest.parts.length - 1; i >= 0; i--) {
+        const part = newest.parts[i];
+        if (part.part_kind === 'text') return part.content.trim() ? { kind: 'generating' } : { kind: 'thinking' };
+        if (part.part_kind === 'thinking') return { kind: 'thinking' };
+        // A completed tool call: the model is between steps. The calls the
+        // in-progress scan ignores are ignored here too — the suggestion chips
+        // come after the answer's text, and must not hide it.
+        if (part.part_kind === 'tool-call' && !isIgnoredToolCall(part)) return { kind: 'thinking' };
+    }
+    return { kind: 'thinking' };
+}
+
+/**
+ * The name the card carries for a thread. The backend names a thread after
+ * its first run; until then the prompt itself is the best title there is.
+ */
+export function threadDisplayName(threadName: string | null | undefined, run: AgentRun | null | undefined): string {
+    const named = threadName?.trim();
+    if (named) return named;
+    const prompt = run?.user_prompt?.content?.replace(/\s+/g, ' ').trim() ?? '';
+    if (!prompt) return 'New chat';
+    return prompt.length > MAX_PROMPT_TITLE_CHARS
+        ? `${prompt.slice(0, MAX_PROMPT_TITLE_CHARS - 1).trimEnd()}…`
+        : prompt;
+}
+
+/** Cost and off-device confirmations: no library write, so no permission grant covers them. */
+export function isConfirmActionType(actionType: string): boolean {
+    return actionType === 'confirm_extraction' || actionType === 'confirm_external_search';
+}
+
+export interface PendingApprovalSummary {
+    label: string;
+    count: number;
+    /** Every pending request is a confirmation rather than a library change. */
+    confirmOnly: boolean;
+}
+
+/**
+ * One line for the approvals a run is waiting on.
+ *
+ * A single request reads like its in-stream card: the action label, then the
+ * title of what it touches when the caller has resolved one. Several collapse
+ * into a count with the labels that make it up, each with its own tally, so
+ * "3 changes · Edit ×2, Create Note" says what the Approve All button covers.
+ */
+export function describePendingApprovals(
+    approvals: readonly PendingApproval[],
+    singleTitle: string | null,
+): PendingApprovalSummary {
+    const confirmOnly = approvals.length > 0 && approvals.every((a) => isConfirmActionType(a.actionType));
+    if (approvals.length === 1) {
+        const [approval] = approvals;
+        const label = getActionLabel(approval.actionType, approval.actionData);
+        // A confirmation's title already says what is being confirmed
+        // ("Confirm 12 Item Batch Processing"); a verb in front of it would
+        // only repeat it.
+        return {
+            label: !singleTitle ? label : confirmOnly ? singleTitle : `${label} · ${singleTitle}`,
+            count: 1,
+            confirmOnly,
+        };
+    }
+
+    const tallies = new Map<string, number>();
+    for (const approval of approvals) {
+        const label = getActionLabel(approval.actionType, approval.actionData);
+        tallies.set(label, (tallies.get(label) ?? 0) + 1);
+    }
+    const parts = [...tallies.entries()].map(([label, n]) => (n > 1 ? `${label} ×${n}` : label));
+    const noun = confirmOnly ? 'confirmations' : 'changes';
+    return {
+        label: `${approvals.length} ${noun} · ${parts.join(', ')}`,
+        count: approvals.length,
+        confirmOnly,
+    };
+}

--- a/react/components/runStatusPopup/runStatusPopupModel.ts
+++ b/react/components/runStatusPopup/runStatusPopupModel.ts
@@ -8,6 +8,8 @@ import type { AgentRun, ToolCallPart } from '@beaver/agent-core/agents/types';
 import { isAutoLoadingToolCall, isThinkingInProgress } from '@beaver/agent-core/agents/messageVisibility';
 import { getToolCallStatus, type ToolResult } from '@beaver/agent-core/run-state/atoms';
 import type { PendingApproval } from '@beaver/agent-ui/host';
+import type { PendingQuestion } from '@beaver/agent-core/run-state/pendingQuestions';
+import type { AskUserQuestionAnswer } from '@beaver/agent-core/protocol/agentProtocol';
 import type { RunPermissionMode } from '../ui/buttons/RunPermissionButton';
 import { getActionLabel } from '../../host/zotero/components/agentActionViewHelpers';
 
@@ -91,7 +93,9 @@ export interface BatchCard extends RunStatusCardBase {
 
 export interface QuestionCard extends RunStatusCardBase {
     kind: 'question';
-    title: string;
+    /** The request itself; the card draws the shared question UI for it. */
+    question: PendingQuestion;
+    onSubmit: (answers: AskUserQuestionAnswer[]) => void;
 }
 
 export interface CompletedCard extends RunStatusCardBase {

--- a/react/components/runStatusPopup/useRunStatusPopupCard.ts
+++ b/react/components/runStatusPopup/useRunStatusPopupCard.ts
@@ -24,7 +24,8 @@ import {
     pendingCreditConfirmationsAtom,
     type PendingCreditConfirmation,
 } from '@beaver/agent-core/run-state/pendingCreditConfirmations';
-import { pendingQuestionsAtom } from '@beaver/agent-core/run-state/pendingQuestions';
+import { pendingQuestionsAtom, type PendingQuestion } from '@beaver/agent-core/run-state/pendingQuestions';
+import type { AskUserQuestionAnswer } from '@beaver/agent-core/protocol/agentProtocol';
 import type { PendingApproval } from '@beaver/agent-ui/host';
 import { pendingApprovalsAtom } from '../../agents/agentActions';
 import {
@@ -33,6 +34,7 @@ import {
     autoReplacementPendingRunIdsAtom,
     beginApprovalVerdictAtom,
     releaseApprovalVerdictAtom,
+    sendAskUserQuestionResponseAtom,
     sendCreditConfirmationResponseAtom,
     setRunPermissionModeAtom,
 } from '../../atoms/agentRunAtoms';
@@ -263,6 +265,17 @@ function useApprovalControls(runId: string | null, approvals: readonly PendingAp
     return { mode, pendingCoveredCount, onDecide, onPermissionChange, decideDisabled: isVerdictInFlight };
 }
 
+/** The question card's answers, sent the way the composer panel sends them. */
+function useQuestionControls(question: PendingQuestion | null) {
+    const sendResponse = useSetAtom(sendAskUserQuestionResponseAtom);
+    const questionId = question?.questionId ?? null;
+    const toolcallId = question?.toolcallId ?? null;
+    return useCallback((answers: AskUserQuestionAnswer[]) => {
+        if (!questionId || !toolcallId) return;
+        sendResponse({ questionId, toolcallId, answers, cancelled: false });
+    }, [questionId, toolcallId, sendResponse]);
+}
+
 /** The credit card's decision, one-shot per confirmation like the composer panel's. */
 function useCreditControls(confirmation: PendingCreditConfirmation | null) {
     const sendResponse = useSetAtom(sendCreditConfirmationResponseAtom);
@@ -381,6 +394,7 @@ function useLiveCard(): RunStatusPopupCard | null {
     const singleTitle = useSingleApprovalTitle(approvals.length === 1 ? approvals[0] : null);
     const approvalControls = useApprovalControls(liveRun?.id ?? null, approvals);
     const creditControls = useCreditControls(credit);
+    const onSubmitQuestion = useQuestionControls(question);
     const completed = useCompletedDetails(isLive ? null : completion?.runId ?? null);
     const setPanelState = useSetAtom(setAnnotationPanelStateAtom);
     // The changes card keys its expansion by the answer's last run, so the
@@ -457,7 +471,7 @@ function useLiveCard(): RunStatusPopupCard | null {
             };
         }
         if (question) {
-            return { ...base, kind: 'question', title: question.title?.trim() || 'Beaver has a question for you' };
+            return { ...base, kind: 'question', question, onSubmit: onSubmitQuestion };
         }
         return { ...base, kind: 'running', statusLine: isAutoRetrying ? 'Retrying' : statusLine };
     }
@@ -540,7 +554,27 @@ function usePreviewCard(preview: RunStatusPopupPreview | null): RunStatusPopupCa
                 scope: preview.scope ?? '568 items in Methods and its subcollections',
             };
         case 'question':
-            return { ...base, kind: 'question', title: preview.title ?? 'Beaver has a question for you' };
+            return {
+                ...base,
+                kind: 'question',
+                question: {
+                    questionId: 'preview-question',
+                    toolcallId: 'preview-toolcall',
+                    title: preview.title ?? 'Scope',
+                    questions: [{
+                        id: 'q0',
+                        header: 'Time range',
+                        question: 'Which years should the literature review cover?',
+                        options: [
+                            { id: 'q0-o1', label: 'Last 5 years', description: 'Recent work only' },
+                            { id: 'q0-o2', label: 'Last 20 years' },
+                            { id: 'q0-o3', label: 'Everything' },
+                        ],
+                        allow_custom: true,
+                    }],
+                },
+                onSubmit: clear,
+            };
         case 'completed':
             return {
                 ...base,

--- a/react/components/runStatusPopup/useRunStatusPopupCard.ts
+++ b/react/components/runStatusPopup/useRunStatusPopupCard.ts
@@ -42,6 +42,7 @@ import {
     runApprovalPolicyAtom,
 } from '../../atoms/runApprovalPolicy';
 import { isSidebarVisibleAtom } from '../../atoms/ui';
+import { setAnnotationPanelStateAtom } from '../../atoms/messageUIState';
 import {
     dismissRunStatusPopupCardAtom,
     runStatusPopupCompletionAtom,
@@ -275,10 +276,15 @@ function useCreditControls(confirmation: PendingCreditConfirmation | null) {
     return { onDecide, decideDisabled: confirmationId !== null && decidedId === confirmationId };
 }
 
-function artifactTitle(row: ReviewRow): string {
+/** The row's label and title, worded as the sidebar's artifacts list words them. */
+function describeArtifact(row: ReviewRow): { label: string; title: string | null } {
     const [first] = row.actions;
-    return getActionTitle(row.actionType, first.proposed_data, null, row.actions)
-        ?? getActionLabel(row.actionType, first.proposed_data, true);
+    const isInEffect = row.actions.some((action) => action.status === 'applied'
+        || (action.status === 'error' && action.result_data != null));
+    return {
+        label: getActionLabel(row.actionType, first.proposed_data, isInEffect),
+        title: getActionTitle(row.actionType, first.proposed_data, null, row.actions),
+    };
 }
 
 function artifactOpener(row: ReviewRow): (() => void) | undefined {
@@ -318,7 +324,8 @@ function useCompletedDetails(runId: string | null): CompletedDetails {
             run,
             artifacts: shown.map((row) => ({
                 key: getReviewRowKey(row),
-                title: artifactTitle(row),
+                actionType: row.actionType,
+                ...describeArtifact(row),
                 open: artifactOpener(row),
             })),
             hiddenArtifactCount: artifactRows.length - shown.length,
@@ -375,6 +382,16 @@ function useLiveCard(): RunStatusPopupCard | null {
     const approvalControls = useApprovalControls(liveRun?.id ?? null, approvals);
     const creditControls = useCreditControls(credit);
     const completed = useCompletedDetails(isLive ? null : completion?.runId ?? null);
+    const setPanelState = useSetAtom(setAnnotationPanelStateAtom);
+    // The changes card keys its expansion by the answer's last run, so the
+    // card is open by the time the sidebar draws it.
+    const completedRunId = completed.run?.id ?? null;
+    const onReviewChanges = useCallback(() => {
+        if (completedRunId) {
+            setPanelState({ key: `${completedRunId}:changes`, updates: { resultsVisible: true } });
+        }
+        openBeaver();
+    }, [completedRunId, setPanelState]);
 
     if (!enabled) return null;
 
@@ -462,6 +479,7 @@ function useLiveCard(): RunStatusPopupCard | null {
             artifacts: completed.artifacts,
             hiddenArtifactCount: completed.hiddenArtifactCount,
             changes: completed.changes,
+            onReviewChanges,
         };
     }
 
@@ -533,11 +551,14 @@ function usePreviewCard(preview: RunStatusPopupPreview | null): RunStatusPopupCa
                     : preview.outcome === 'canceled' ? 'Response was interrupted' : null,
                 artifacts: (preview.artifacts ?? ['Summary: Smith 2014']).map((title, index) => ({
                     key: `preview-${index}`,
+                    actionType: 'create_note',
+                    label: 'Created Note',
                     title,
                     open: clear,
                 })),
                 hiddenArtifactCount: 0,
                 changes: preview.changes === undefined ? '2 applied, 1 pending' : preview.changes,
+                onReviewChanges: openBeaver,
             };
     }
 }

--- a/react/components/runStatusPopup/useRunStatusPopupCard.ts
+++ b/react/components/runStatusPopup/useRunStatusPopupCard.ts
@@ -1,0 +1,551 @@
+/**
+ * The card the closed-sidebar status popup shows for the open thread, derived
+ * from live run state — or from the dev preview when one is set.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import type { AgentRun, ToolCallPart } from '@beaver/agent-core/agents/types';
+import { isRunActive } from '@beaver/agent-core/agents/types';
+import {
+    activeRunAtom,
+    allRunsAtom,
+    currentThreadNameAtom,
+    lastRunSummaryAtom,
+    resumeChainAtom,
+    toolResultsMapAtom,
+    wsReconnectingAtom,
+    wsRetryAtom,
+} from '@beaver/agent-core/run-state/atoms';
+import { getToolCallLabel, type ToolCallLabelEnrich } from '@beaver/agent-core/run-state/toolLabels';
+import { runStatusText } from '@beaver/agent-core/run-state/runStatusCopy';
+import { getRunErrorTitle } from '@beaver/agent-core/run-state/runErrorCopy';
+import { pendingBatchApprovalsAtom } from '@beaver/agent-core/run-state/pendingBatchApprovals';
+import {
+    pendingCreditConfirmationsAtom,
+    type PendingCreditConfirmation,
+} from '@beaver/agent-core/run-state/pendingCreditConfirmations';
+import { pendingQuestionsAtom } from '@beaver/agent-core/run-state/pendingQuestions';
+import type { PendingApproval } from '@beaver/agent-ui/host';
+import { pendingApprovalsAtom } from '../../agents/agentActions';
+import {
+    answerPendingApprovalsAtom,
+    approvalVerdictInFlightAtom,
+    autoReplacementPendingRunIdsAtom,
+    beginApprovalVerdictAtom,
+    releaseApprovalVerdictAtom,
+    sendCreditConfirmationResponseAtom,
+    setRunPermissionModeAtom,
+} from '../../atoms/agentRunAtoms';
+import {
+    getPendingApprovalIdsCoveredByFullAccess,
+    isFullAccessGrantedForRun,
+    runApprovalPolicyAtom,
+} from '../../atoms/runApprovalPolicy';
+import { isSidebarVisibleAtom } from '../../atoms/ui';
+import {
+    dismissRunStatusPopupCardAtom,
+    runStatusPopupCompletionAtom,
+    runStatusPopupDismissedAtom,
+    runStatusPopupEnabledAtom,
+    runStatusPopupPreviewAtom,
+    type RunStatusPopupPreview,
+} from '../../atoms/runStatusPopup';
+import { eventManager } from '../../events/eventManager';
+import { resolveToolCallLabelEnrich } from '../../utils/toolCallLabelEnrich';
+import { openNoteByKey } from '../../utils/sourceUtils';
+import { resolveItemReference, resolveLibraryRef } from '../../../src/utils/libraryIdentity';
+import { shortItemTitle } from '../../../src/utils/zoteroUtils';
+import { dismissActiveEditNotePreview } from '../../host/zotero/editNotePreviewLifecycle';
+import { getActionLabel, getActionTitle } from '../../host/zotero/components/agentActionViewHelpers';
+import {
+    getChangesCardHeading,
+    getOpenNoteTarget,
+    getReviewRowKey,
+    type ReviewRow,
+} from '../../host/zotero/components/reviewChangeRows';
+import { useArtifactRows, useChangesRows } from '../../host/zotero/components/reviewChanges/useRunActionRows';
+import type { RunPermissionMode } from '../ui/buttons/RunPermissionButton';
+import {
+    deriveRunActivity,
+    describePendingApprovals,
+    MAX_COMPLETED_ARTIFACTS,
+    MAX_STACK_DEPTH,
+    threadDisplayName,
+    type RunStatusArtifact,
+    type RunStatusPopupCard,
+} from './runStatusPopupModel';
+
+const EMPTY_RUN_IDS: string[] = [];
+
+/** Opens Beaver on the thread the card describes — today always the open one. */
+function openBeaver(): void {
+    eventManager.dispatch('toggleChat', { forceOpen: true });
+}
+
+/**
+ * Records a run that finished while the sidebar was closed, so the completed
+ * card can report it, and forgets it as soon as the sidebar is open or
+ * another run has taken the thread over.
+ */
+function useCompletionTracking(): void {
+    const summary = useAtomValue(lastRunSummaryAtom);
+    const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
+    const setCompletion = useSetAtom(runStatusPopupCompletionAtom);
+    const previousRef = useRef(summary);
+
+    useEffect(() => {
+        const previous = previousRef.current;
+        previousRef.current = summary;
+        if (!summary) {
+            setCompletion(null);
+            return;
+        }
+        if (previous && previous.id !== summary.id) {
+            // Another run replaced the one the card was about, or the thread
+            // changed under it. Either way the record is stale.
+            setCompletion(null);
+        }
+        const wasLive = previous?.id === summary.id && isRunActive(previous);
+        if (wasLive && !isRunActive(summary) && !isSidebarVisible) {
+            setCompletion({ runId: summary.id, completedAt: Date.now() });
+        }
+    }, [summary, isSidebarVisible, setCompletion]);
+
+    useEffect(() => {
+        if (isSidebarVisible) setCompletion(null);
+    }, [isSidebarVisible, setCompletion]);
+}
+
+/**
+ * Host-resolved names for the running tool call's label, resolved the way the
+ * in-stream tool-call row resolves them. Null until they arrive, or for a call
+ * whose label needs none.
+ */
+function useToolCallLabelEnrich(part: ToolCallPart | null): ToolCallLabelEnrich | null {
+    const [resolved, setResolved] = useState<{ id: string; enrich: ToolCallLabelEnrich | null }>({ id: '', enrich: null });
+    const toolCallId = part?.tool_call_id ?? null;
+    useEffect(() => {
+        if (!part || !toolCallId) return;
+        let cancelled = false;
+        void resolveToolCallLabelEnrich(part, null).then((enrich) => {
+            if (!cancelled) setResolved({ id: toolCallId, enrich });
+        });
+        return () => { cancelled = true; };
+        // The args are settled once the call has been issued, so its id is
+        // the whole identity.
+    }, [toolCallId]);
+    return toolCallId && resolved.id === toolCallId ? resolved.enrich : null;
+}
+
+/** The running card's second line: what the run is doing, or the wait it is in. */
+function useRunStatusLine(run: AgentRun | null): string {
+    const toolResults = useAtomValue(toolResultsMapAtom);
+    const retry = useAtomValue(wsRetryAtom);
+    const reconnect = useAtomValue(wsReconnectingAtom);
+    const activity = run ? deriveRunActivity(run, toolResults) : null;
+    const toolPart = activity?.kind === 'tool' ? activity.part : null;
+    const enrich = useToolCallLabelEnrich(toolPart);
+
+    let idleLabel = 'Thinking';
+    if (activity?.kind === 'generating') idleLabel = 'Generating';
+    if (toolPart) idleLabel = getToolCallLabel(toolPart, 'in_progress', { enrich });
+    // Live, but holding for a decision made on a card the popup does not draw.
+    if (run?.status === 'awaiting_deferred') idleLabel = 'Waiting for your review';
+
+    return runStatusText({
+        reconnect,
+        backendRetry: retry && run && retry.runId === run.id ? retry : null,
+        idleLabel,
+    });
+}
+
+const ITEM_TITLE_ACTION_TYPES = new Set([
+    'edit_metadata',
+    'edit_item',
+    'edit_note',
+    'edit_note_batch',
+    'create_highlight_annotations',
+    'create_note_annotations',
+]);
+
+/**
+ * The title of what a single pending approval touches — the item's short
+ * bibliographic name for the tools that edit one, else whatever the action
+ * data names (a note title, a collection). Null while the item resolves.
+ */
+function useSingleApprovalTitle(approval: PendingApproval | null): string | null {
+    const [itemTitle, setItemTitle] = useState<{ actionId: string; title: string | null }>({ actionId: '', title: null });
+    const actionId = approval?.actionId ?? null;
+    const needsItem = !!approval && ITEM_TITLE_ACTION_TYPES.has(approval.actionType);
+
+    useEffect(() => {
+        if (!approval || !actionId || !needsItem) return;
+        const data = approval.actionData ?? {};
+        const zoteroKey: string | undefined = data.resolved_ref?.zotero_key ?? data.zotero_key;
+        const libraryId: number | undefined = data.resolved_ref?.library_id ?? data.library_id;
+        const libraryRef: string | undefined = data.resolved_ref?.library_ref ?? data.library_ref;
+        if (!zoteroKey || (!libraryId && !libraryRef)) return;
+        let cancelled = false;
+        void (async () => {
+            const resolved = await resolveItemReference({ library_ref: libraryRef, library_id: libraryId, zotero_key: zoteroKey });
+            if (resolved.status !== 'found') return;
+            const title = await shortItemTitle(resolved.item);
+            if (!cancelled) setItemTitle({ actionId, title });
+        })();
+        return () => { cancelled = true; };
+    }, [actionId, needsItem]);
+
+    if (!approval) return null;
+    const resolvedTitle = itemTitle.actionId === approval.actionId ? itemTitle.title : null;
+    return getActionTitle(approval.actionType, approval.actionData, resolvedTitle, undefined);
+}
+
+interface ApprovalControls {
+    mode: RunPermissionMode;
+    pendingCoveredCount: number;
+    onDecide: (approved: boolean) => void;
+    onPermissionChange: (mode: RunPermissionMode) => void;
+    decideDisabled: boolean;
+}
+
+/**
+ * The approval card's controls, bound the way the composer binds its own
+ * Approve All: one verdict in flight at a time, the note diff preview torn
+ * down before the answer goes out, and a full-access grant that answers every
+ * covered card at once.
+ */
+function useApprovalControls(runId: string | null, approvals: readonly PendingApproval[]): ApprovalControls {
+    const policy = useAtomValue(runApprovalPolicyAtom);
+    const isVerdictInFlight = useAtomValue(approvalVerdictInFlightAtom);
+    const beginVerdict = useSetAtom(beginApprovalVerdictAtom);
+    const releaseVerdict = useSetAtom(releaseApprovalVerdictAtom);
+    const answerPendingApprovals = useSetAtom(answerPendingApprovalsAtom);
+    const setRunPermissionMode = useSetAtom(setRunPermissionModeAtom);
+
+    const mode: RunPermissionMode = isFullAccessGrantedForRun(policy, runId) ? 'full_access' : 'ask';
+    const pendingCoveredCount = useMemo(
+        () => getPendingApprovalIdsCoveredByFullAccess(approvals).length,
+        [approvals],
+    );
+
+    const onDecide = useCallback((approved: boolean) => {
+        if (approvals.length === 0) return;
+        if (!beginVerdict()) return;
+        // Taken now: an approval arriving while the preview is torn down was
+        // not on the card the user answered.
+        const actionIds = approvals.map((approval) => approval.actionId);
+        void (async () => {
+            try {
+                await dismissActiveEditNotePreview();
+                answerPendingApprovals({ actionIds, approved });
+            } finally {
+                releaseVerdict();
+            }
+        })();
+    }, [approvals, beginVerdict, releaseVerdict, answerPendingApprovals]);
+
+    const onPermissionChange = useCallback(async (next: RunPermissionMode) => {
+        if (!runId) return;
+        if (next !== 'full_access') {
+            setRunPermissionMode({ runId, fullAccess: false });
+            return;
+        }
+        // The grant is applied even when the teardown fails, as on the
+        // in-stream card: the user has decided.
+        try {
+            await dismissActiveEditNotePreview();
+        } finally {
+            setRunPermissionMode({ runId, fullAccess: true });
+        }
+    }, [runId, setRunPermissionMode]);
+
+    return { mode, pendingCoveredCount, onDecide, onPermissionChange, decideDisabled: isVerdictInFlight };
+}
+
+/** The credit card's decision, one-shot per confirmation like the composer panel's. */
+function useCreditControls(confirmation: PendingCreditConfirmation | null) {
+    const sendResponse = useSetAtom(sendCreditConfirmationResponseAtom);
+    const [decidedId, setDecidedId] = useState<string | null>(null);
+    const confirmationId = confirmation?.confirmationId ?? null;
+    const onDecide = useCallback((approved: boolean) => {
+        if (!confirmationId || decidedId === confirmationId) return;
+        setDecidedId(confirmationId);
+        sendResponse({ confirmationId, approved });
+    }, [confirmationId, decidedId, sendResponse]);
+    return { onDecide, decideDisabled: confirmationId !== null && decidedId === confirmationId };
+}
+
+function artifactTitle(row: ReviewRow): string {
+    const [first] = row.actions;
+    return getActionTitle(row.actionType, first.proposed_data, null, row.actions)
+        ?? getActionLabel(row.actionType, first.proposed_data, true);
+}
+
+function artifactOpener(row: ReviewRow): (() => void) | undefined {
+    const target = getOpenNoteTarget(row);
+    if (!target) return undefined;
+    return () => {
+        const libraryId = resolveLibraryRef(target);
+        if (libraryId) void openNoteByKey(libraryId, target.zotero_key);
+    };
+}
+
+interface CompletedDetails {
+    run: AgentRun | null;
+    artifacts: RunStatusArtifact[];
+    hiddenArtifactCount: number;
+    changes: string | null;
+}
+
+/**
+ * What a finished answer produced and changed, from the same rows the
+ * sidebar's artifacts list and changes card are built from. An answer that
+ * was continued spans its whole resume chain, as those surfaces do.
+ */
+function useCompletedDetails(runId: string | null): CompletedDetails {
+    const chain = useAtomValue(useMemo(() => resumeChainAtom(runId ?? ''), [runId]));
+    const runIds = useMemo(
+        () => (chain.length > 0 ? chain.map((run) => run.id) : EMPTY_RUN_IDS),
+        [chain],
+    );
+    const artifactRows = useArtifactRows(runIds);
+    const changesRows = useChangesRows(runIds);
+
+    return useMemo(() => {
+        const run = chain.length > 0 ? chain[chain.length - 1] : null;
+        const shown = artifactRows.slice(0, MAX_COMPLETED_ARTIFACTS);
+        return {
+            run,
+            artifacts: shown.map((row) => ({
+                key: getReviewRowKey(row),
+                title: artifactTitle(row),
+                open: artifactOpener(row),
+            })),
+            hiddenArtifactCount: artifactRows.length - shown.length,
+            changes: changesRows.length > 0 ? (getChangesCardHeading(changesRows).trail ?? '') : null,
+        };
+    }, [chain, artifactRows, changesRows]);
+}
+
+/**
+ * Forgets the cards the user closed once another run takes the thread over:
+ * a closed card is closed for its run, and the next run gets its own.
+ */
+function useDismissalReset(activeRunId: string | null): void {
+    const setDismissed = useSetAtom(runStatusPopupDismissedAtom);
+    const previousRef = useRef(activeRunId);
+    useEffect(() => {
+        if (previousRef.current !== activeRunId) {
+            previousRef.current = activeRunId;
+            setDismissed(new Set());
+        }
+    }, [activeRunId, setDismissed]);
+}
+
+function useLiveCard(): RunStatusPopupCard | null {
+    useCompletionTracking();
+
+    const enabled = useAtomValue(runStatusPopupEnabledAtom);
+    const dismissed = useAtomValue(runStatusPopupDismissedAtom);
+    const dismiss = useSetAtom(dismissRunStatusPopupCardAtom);
+    const autoReplacementPendingRunIds = useAtomValue(autoReplacementPendingRunIdsAtom);
+    const activeRun = useAtomValue(activeRunAtom);
+    useDismissalReset(activeRun?.id ?? null);
+    const threadName = useAtomValue(currentThreadNameAtom);
+    const pendingApprovals = useAtomValue(pendingApprovalsAtom);
+    const batchApprovals = useAtomValue(pendingBatchApprovalsAtom);
+    const creditConfirmations = useAtomValue(pendingCreditConfirmationsAtom);
+    const questions = useAtomValue(pendingQuestionsAtom);
+    const completion = useAtomValue(runStatusPopupCompletionAtom);
+    const setCompletion = useSetAtom(runStatusPopupCompletionAtom);
+
+    // A failed run the client is already replacing is not finished, and its
+    // error is about to be undone: the sidebar shows it as retrying, and so
+    // does the card.
+    const isAutoRetrying = !!activeRun && autoReplacementPendingRunIds.has(activeRun.id);
+    const isLive = isRunActive(activeRun) || isAutoRetrying;
+    const liveRun = isLive ? activeRun : null;
+    const approvals = useMemo(() => [...pendingApprovals.values()], [pendingApprovals]);
+    const batch = batchApprovals.values().next().value ?? null;
+    const credit = creditConfirmations.values().next().value ?? null;
+    const question = questions.values().next().value ?? null;
+
+    const statusLine = useRunStatusLine(liveRun);
+    const singleTitle = useSingleApprovalTitle(approvals.length === 1 ? approvals[0] : null);
+    const approvalControls = useApprovalControls(liveRun?.id ?? null, approvals);
+    const creditControls = useCreditControls(credit);
+    const completed = useCompletedDetails(isLive ? null : completion?.runId ?? null);
+
+    if (!enabled) return null;
+
+    // What the card is about, so closing it hides exactly that: the working
+    // state of this run, this set of approvals, this confirmation. Anything
+    // else the run has to say afterwards gets a fresh card.
+    const signature = liveRun
+        ? approvals.length > 0
+            ? `approval:${approvals.map((approval) => approval.actionId).sort().join(',')}`
+            : batch ? `batch:${batch.approvalId}`
+                : credit ? `credit:${credit.confirmationId}`
+                    : question ? `question:${question.questionId}`
+                        : `running:${liveRun.id}`
+        : completion ? `completed:${completion.runId}` : null;
+    if (signature && dismissed.has(signature)) return null;
+    const onDismiss = () => {
+        if (signature) dismiss(signature);
+        if (!liveRun) setCompletion(null);
+    };
+
+    if (liveRun) {
+        const base = { threadName: threadDisplayName(threadName, liveRun), stackDepth: 0, onOpen: openBeaver, onDismiss };
+        if (approvals.length > 0) {
+            const summary = describePendingApprovals(approvals, singleTitle);
+            const plural = summary.count > 1;
+            return {
+                ...base,
+                kind: 'approval',
+                label: summary.label,
+                count: summary.count,
+                actionType: approvals.length === 1 ? approvals[0].actionType : null,
+                permission: summary.confirmOnly
+                    ? null
+                    : {
+                        mode: approvalControls.mode,
+                        pendingCoveredCount: approvalControls.pendingCoveredCount,
+                        onChange: approvalControls.onPermissionChange,
+                    },
+                approveLabel: summary.confirmOnly ? (plural ? 'Confirm All' : 'Confirm') : (plural ? 'Approve All' : 'Approve'),
+                rejectLabel: plural ? 'Reject All' : 'Reject',
+                onDecide: approvalControls.onDecide,
+                decideDisabled: approvalControls.decideDisabled,
+            };
+        }
+        if (batch) {
+            return {
+                ...base,
+                kind: 'batch',
+                title: batch.title,
+                scope: [batch.scopePrimary, batch.scopeSecondary].filter(Boolean).join(' '),
+            };
+        }
+        if (credit) {
+            return {
+                ...base,
+                kind: 'credit',
+                title: credit.title,
+                message: credit.message,
+                approveLabel: credit.approveLabel,
+                declineLabel: credit.declineLabel,
+                onDecide: creditControls.onDecide,
+                decideDisabled: creditControls.decideDisabled,
+            };
+        }
+        if (question) {
+            return { ...base, kind: 'question', title: question.title?.trim() || 'Beaver has a question for you' };
+        }
+        return { ...base, kind: 'running', statusLine: isAutoRetrying ? 'Retrying' : statusLine };
+    }
+
+    if (completion && completed.run) {
+        const run = completed.run;
+        const outcome = run.status === 'error' ? 'error' : run.status === 'canceled' ? 'canceled' : 'completed';
+        return {
+            threadName: threadDisplayName(threadName, run),
+            stackDepth: 0,
+            onOpen: openBeaver,
+            onDismiss,
+            kind: 'completed',
+            outcome,
+            // The same title the run error display puts on its header.
+            detail: outcome === 'error'
+                ? getRunErrorTitle(run.error?.type)
+                : outcome === 'canceled' ? 'Response was interrupted' : null,
+            artifacts: completed.artifacts,
+            hiddenArtifactCount: completed.hiddenArtifactCount,
+            changes: completed.changes,
+        };
+    }
+
+    return null;
+}
+
+/** A card built from the dev preview; its decisions only clear the preview. */
+function usePreviewCard(preview: RunStatusPopupPreview | null): RunStatusPopupCard | null {
+    const setPreview = useSetAtom(runStatusPopupPreviewAtom);
+    const [mode, setMode] = useState<RunPermissionMode>('ask');
+    const clear = useCallback(() => setPreview(null), [setPreview]);
+    useEffect(() => { setMode('ask'); }, [preview]);
+
+    if (!preview) return null;
+    const base = {
+        threadName: preview.threadName ?? 'Summarize Legewie et al. 2024 on neighborhood effects',
+        stackDepth: Math.min(Math.max(preview.stackDepth ?? 0, 0), MAX_STACK_DEPTH),
+        onOpen: openBeaver,
+        onDismiss: clear,
+    };
+    switch (preview.kind) {
+        case 'running':
+            return { ...base, kind: 'running', statusLine: preview.statusLine ?? 'Reading Smith 2020, p. 5-10' };
+        case 'approval': {
+            const count = preview.count ?? 1;
+            const plural = count > 1;
+            return {
+                ...base,
+                kind: 'approval',
+                label: preview.label ?? 'Edit · Smith 2014',
+                count,
+                actionType: count === 1 ? preview.actionType ?? 'edit_metadata' : null,
+                permission: preview.showPermissionMenu === false
+                    ? null
+                    : { mode, pendingCoveredCount: count, onChange: setMode },
+                approveLabel: preview.approveLabel ?? (plural ? 'Approve All' : 'Approve'),
+                rejectLabel: preview.rejectLabel ?? (plural ? 'Reject All' : 'Reject'),
+                onDecide: clear,
+                decideDisabled: false,
+            };
+        }
+        case 'credit':
+            return {
+                ...base,
+                kind: 'credit',
+                title: preview.title ?? 'Continue past 50 credits?',
+                message: preview.message ?? 'This response has used 50 credits. Continuing may use up to 30 more.',
+                approveLabel: preview.approveLabel ?? 'Continue',
+                declineLabel: preview.declineLabel ?? 'Wrap up',
+                onDecide: clear,
+                decideDisabled: false,
+            };
+        case 'batch':
+            return {
+                ...base,
+                kind: 'batch',
+                title: preview.title ?? 'Summarize each paper into a note',
+                scope: preview.scope ?? '568 items in Methods and its subcollections',
+            };
+        case 'question':
+            return { ...base, kind: 'question', title: preview.title ?? 'Beaver has a question for you' };
+        case 'completed':
+            return {
+                ...base,
+                kind: 'completed',
+                outcome: preview.outcome ?? 'completed',
+                detail: preview.outcome === 'error'
+                    ? getRunErrorTitle(preview.errorType)
+                    : preview.outcome === 'canceled' ? 'Response was interrupted' : null,
+                artifacts: (preview.artifacts ?? ['Summary: Smith 2014']).map((title, index) => ({
+                    key: `preview-${index}`,
+                    title,
+                    open: clear,
+                })),
+                hiddenArtifactCount: 0,
+                changes: preview.changes === undefined ? '2 applied, 1 pending' : preview.changes,
+            };
+    }
+}
+
+/** The card to draw, or null when the popup has nothing to say. */
+export function useRunStatusPopupCard(): RunStatusPopupCard | null {
+    const preview = useAtomValue(runStatusPopupPreviewAtom);
+    const live = useLiveCard();
+    const previewCard = usePreviewCard(preview);
+    return preview ? previewCard : live;
+}

--- a/react/components/ui/popup/FeatureTipContent.tsx
+++ b/react/components/ui/popup/FeatureTipContent.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { CancelIcon, Icon } from '../../icons/icons';
+import IconButton from '@beaver/agent-ui/primitives/IconButton';
+import Button from '@beaver/agent-ui/primitives/Button';
+import { FEATURE_TIPS, type FeatureTipId } from '../../../constants/featureTips';
+
+interface FeatureTipContentProps {
+    tipId: FeatureTipId;
+    onDismiss: () => void;
+}
+
+/**
+ * A feature tip, in the panel or floating: icon and title, a line of text,
+ * the tip's showcase if it has one, and its buttons. The definition supplies
+ * the parts; this is the frame they share.
+ */
+const FeatureTipContent: React.FC<FeatureTipContentProps> = ({ tipId, onDismiss }) => {
+    const tip = FEATURE_TIPS[tipId];
+    if (!tip) return null;
+    const { Showcase, Actions } = tip;
+
+    return (
+        <div className="display-flex flex-col gap-3 w-full">
+            <div className="display-flex flex-row items-center justify-between w-full gap-2">
+                <div className="display-flex flex-row gap-2 items-center min-w-0">
+                    <Icon icon={tip.icon} size={18} className="font-color-secondary" />
+                    <span className="font-color-primary text-lg font-medium truncate">{tip.title}</span>
+                </div>
+                <IconButton icon={CancelIcon} variant="ghost-secondary" onClick={onDismiss} ariaLabel="Dismiss" />
+            </div>
+
+            <div className="font-color-secondary text-base">{tip.text}</div>
+
+            {Showcase && <Showcase />}
+
+            <div className="display-flex flex-row items-center justify-end gap-2 w-full">
+                {Actions
+                    ? <Actions dismiss={onDismiss} />
+                    : (
+                        <Button variant="outline" onClick={onDismiss} style={{ padding: '3px 10px' }}>
+                            Got it
+                        </Button>
+                    )}
+            </div>
+        </div>
+    );
+};
+
+export default FeatureTipContent;

--- a/react/components/ui/popup/PopupMessageItem.tsx
+++ b/react/components/ui/popup/PopupMessageItem.tsx
@@ -9,6 +9,7 @@ import VersionUpdateMessageContent from './VersionUpdateMessageContent';
 import WelcomeOnboardingContent from './WelcomeOnboardingContent';
 import ReaderTipContent from './ReaderTipContent';
 import NoteTipContent from './NoteTipContent';
+import FeatureTipContent from './FeatureTipContent';
 import { CitationTipContent } from '../../sources/CitationTipContent';
 import Button from "@beaver/agent-ui/primitives/Button";
 import PopupMessageHeader from './PopupMessageHeader';
@@ -118,8 +119,8 @@ const PopupMessageItem: React.FC<PopupMessageItemProps> = ({ message, onRemove, 
                     display-flex flex-col items-start gap-2
                 `}
             >
-                {/* Floating version_update/welcome_onboarding/reader_tip render their own headers */}
-                {!(isFloating && (message.type === 'version_update' || message.type === 'welcome_onboarding' || message.type === 'reader_tip' || message.type === 'note_tip')) && (
+                {/* Floating version_update/welcome_onboarding/reader_tip render their own headers; a feature tip always does */}
+                {!(isFloating && (message.type === 'version_update' || message.type === 'welcome_onboarding' || message.type === 'reader_tip' || message.type === 'note_tip')) && message.type !== 'feature_tip' && (
                     <PopupMessageHeader
                         icon={message.icon || getDefaultIcon()}
                         rightIcon={message.rightIcon}
@@ -194,6 +195,10 @@ const PopupMessageItem: React.FC<PopupMessageItemProps> = ({ message, onRemove, 
 
                 {message.type === 'note_tip' && (
                     <NoteTipContent onDismiss={handleDismiss} />
+                )}
+
+                {message.type === 'feature_tip' && message.tipId && (
+                    <FeatureTipContent tipId={message.tipId} onDismiss={handleDismiss} />
                 )}
 
                 {message.type === 'citation_tip' && (

--- a/react/components/ui/popup/featureTips/RunStatusTipShowcase.tsx
+++ b/react/components/ui/popup/featureTips/RunStatusTipShowcase.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useAtomValue } from 'jotai';
+import Button from '@beaver/agent-ui/primitives/Button';
+import { eventManager } from '../../../../events/eventManager';
+import { isSidebarVisibleAtom } from '../../../../atoms/ui';
+import RunPulse from '../../../runStatusPopup/RunPulse';
+import type { FeatureTipActionsProps } from '../../../../constants/featureTips';
+
+/**
+ * The corner card's top-left, built from the card's own classes so it stays
+ * true to the real thing, cut off and faded where the tip runs out of room.
+ */
+const RunStatusTipShowcase: React.FC = () => (
+    <div className="beaver-run-status-tip__preview" aria-hidden="true">
+        <div className="beaver-run-status-tip__preview-clip">
+            <div className="beaver-run-status-popup__card beaver-run-status-tip__preview-card">
+                <div className="beaver-run-status-popup__content">
+                    <div className="beaver-run-status-popup__header">
+                        <div className="beaver-run-status-popup__leading"><RunPulse /></div>
+                        <div className="beaver-run-status-popup__text">
+                            <div className="beaver-run-status-popup__title font-color-primary">
+                                Summarizing the neighborhood effects literature
+                            </div>
+                            <div className="beaver-run-status-popup__detail font-color-secondary">
+                                <span className="shimmer-text">Reading Sampson 2012, p. 31-48</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="beaver-run-status-popup__footer">
+                        <div className="flex-1" />
+                        <Button variant="outline" style={{ padding: '2px 10px', fontSize: '0.875rem' }} tabIndex={-1}>
+                            Reject
+                        </Button>
+                        <Button variant="solid" style={{ padding: '2px 10px', fontSize: '0.875rem' }} tabIndex={-1}>
+                            Approve
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+/** "Got it", and — while the sidebar is open — the offer to try it right now. */
+export const RunStatusTipActions: React.FC<FeatureTipActionsProps> = ({ dismiss }) => {
+    const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
+    const handleCloseSidebar = () => {
+        if (isSidebarVisible) eventManager.dispatch('toggleChat', {});
+        dismiss();
+    };
+    return (
+        <>
+            <Button variant="ghost-secondary" onClick={dismiss} style={{ padding: '3px 8px' }}>
+                Got it
+            </Button>
+            {isSidebarVisible && (
+                <Button variant="solid" onClick={handleCloseSidebar} style={{ padding: '3px 10px' }}>
+                    Close sidebar
+                </Button>
+            )}
+        </>
+    );
+};
+
+export default RunStatusTipShowcase;

--- a/react/constants/featureTips.tsx
+++ b/react/constants/featureTips.tsx
@@ -1,0 +1,49 @@
+/**
+ * The one-time feature tips: what each says, how it looks, and where it goes.
+ *
+ * A tip is a registry entry here plus a trigger (see `useRunStatusTip`) that
+ * asks `showFeatureTipAtom` for it at the right moment. Showing, pacing and
+ * rendering are shared — see `react/atoms/featureTips.ts` and
+ * `FeatureTipContent` — so a new tip is an entry, a trigger, and at most a
+ * showcase of its own.
+ */
+import React from 'react';
+import { BubbleChatQuestionIcon } from '../components/icons/icons';
+import RunStatusTipShowcase, { RunStatusTipActions } from '../components/ui/popup/featureTips/RunStatusTipShowcase';
+
+export type FeatureTipId = 'run-status-popup';
+
+export interface FeatureTipActionsProps {
+    /** Retires the tip. */
+    dismiss: () => void;
+}
+
+export interface FeatureTipDefinition {
+    id: FeatureTipId;
+    /** One line, the feature's promise. Truncates, so keep it short. */
+    title: string;
+    /** One or two sentences under it. */
+    text: string;
+    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    /**
+     * Inside the sidebar, above the composer, like in-panel release notes;
+     * otherwise the floating card in the main window's corner.
+     */
+    inPanel: boolean;
+    /** A visual between the text and the buttons — a taste of the feature. */
+    Showcase?: React.ComponentType;
+    /** The button row. Defaults to a single "Got it". */
+    Actions?: React.ComponentType<FeatureTipActionsProps>;
+}
+
+export const FEATURE_TIPS: Record<FeatureTipId, FeatureTipDefinition> = {
+    'run-status-popup': {
+        id: 'run-status-popup',
+        title: 'Beaver keeps going when closed',
+        text: 'Close the sidebar while Beaver works. A small card in the corner keeps you posted and lets you approve changes.',
+        icon: BubbleChatQuestionIcon,
+        inPanel: true,
+        Showcase: RunStatusTipShowcase,
+        Actions: RunStatusTipActions,
+    },
+};

--- a/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
+++ b/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
@@ -7,12 +7,15 @@
  * the preview card, `{ clear: true }` removes it, and `{ forceVisible: true }`
  * keeps the popup on screen while the sidebar is open. The preview's own
  * controls only clear the preview. Every field but `kind` is optional and
- * falls back to sample copy — see `RunStatusPopupPreview`.
+ * falls back to sample copy — see `RunStatusPopupPreview`. `{ tip: true }`
+ * shows the one-time onboarding tip about the popup (`tipInPanel` overrides
+ * where it goes); `{ tip: false }` removes it.
  *
  * Wired to its path in `useHttpEndpoints.ts`.
  */
 
 import { store } from '../../store';
+import { dismissFeatureTipAtom, showFeatureTipAtom } from '../../atoms/featureTips';
 import {
     runStatusPopupCompletionAtom,
     runStatusPopupForceVisibleAtom,
@@ -31,6 +34,14 @@ export async function handleTestRunStatusPopupHttpRequest(request: any): Promise
     }
     if (typeof request?.forceVisible === 'boolean') {
         store.set(runStatusPopupForceVisibleAtom, request.forceVisible);
+    }
+    if (request?.tip === true) {
+        store.set(showFeatureTipAtom, 'run-status-popup', {
+            force: true,
+            inPanel: typeof request.tipInPanel === 'boolean' ? request.tipInPanel : undefined,
+        });
+    } else if (request?.tip === false) {
+        store.set(dismissFeatureTipAtom, 'run-status-popup');
     }
     if (request?.clearCompletion) {
         store.set(runStatusPopupCompletionAtom, null);

--- a/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
+++ b/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
@@ -1,0 +1,50 @@
+/**
+ * Dev-only HTTP handler for the closed-sidebar run status popup
+ * (`react/components/runStatusPopup`).
+ *
+ * `/beaver/test/run-status-popup` draws any of the popup's states on demand,
+ * without a run in that state: `{ preview: { kind: 'approval', ... } }` sets
+ * the preview card, `{ clear: true }` removes it, and `{ forceVisible: true }`
+ * keeps the popup on screen while the sidebar is open. The preview's own
+ * controls only clear the preview. Every field but `kind` is optional and
+ * falls back to sample copy — see `RunStatusPopupPreview`.
+ *
+ * Wired to its path in `useHttpEndpoints.ts`.
+ */
+
+import { store } from '../../store';
+import {
+    runStatusPopupCompletionAtom,
+    runStatusPopupForceVisibleAtom,
+    runStatusPopupPreviewAtom,
+    type RunStatusPopupPreview,
+} from '../../atoms/runStatusPopup';
+
+const PREVIEW_KINDS = new Set<RunStatusPopupPreview['kind']>([
+    'running', 'approval', 'credit', 'batch', 'question', 'completed',
+]);
+
+export async function handleTestRunStatusPopupHttpRequest(request: any): Promise<any> {
+    if (request?.clear) {
+        store.set(runStatusPopupPreviewAtom, null);
+        store.set(runStatusPopupForceVisibleAtom, false);
+    }
+    if (typeof request?.forceVisible === 'boolean') {
+        store.set(runStatusPopupForceVisibleAtom, request.forceVisible);
+    }
+    if (request?.clearCompletion) {
+        store.set(runStatusPopupCompletionAtom, null);
+    }
+    if (request?.preview) {
+        const preview = request.preview as RunStatusPopupPreview;
+        if (!PREVIEW_KINDS.has(preview.kind)) {
+            throw new Error(`Unknown preview kind: ${String(preview.kind)}`);
+        }
+        store.set(runStatusPopupPreviewAtom, preview);
+    }
+    return {
+        preview: store.get(runStatusPopupPreviewAtom),
+        forceVisible: store.get(runStatusPopupForceVisibleAtom),
+        completion: store.get(runStatusPopupCompletionAtom),
+    };
+}

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -178,6 +178,7 @@ import {
     handleTestBeaverWindowHttpRequest,
     handleTestSelectTabHttpRequest,
 } from './httpHandlers/testApplicationStateHandlers';
+import { handleTestRunStatusPopupHttpRequest } from './httpHandlers/testRunStatusPopupHandlers';
 import type {
     WSZoteroDataRequest,
     WSExternalReferenceCheckRequest,
@@ -366,6 +367,7 @@ const ENDPOINT_PATHS = [
     '/beaver/test/beaver-window',
     '/beaver/test/beaver-sidebar',
     '/beaver/test/select-tab',
+    '/beaver/test/run-status-popup',
 ] as const;
 
 /**
@@ -1341,6 +1343,9 @@ function registerEndpoints(): boolean {
 
         Zotero.Server.Endpoints['/beaver/test/select-tab'] =
             createEndpoint(handleTestSelectTabHttpRequest);
+
+        Zotero.Server.Endpoints['/beaver/test/run-status-popup'] =
+            createEndpoint(handleTestRunStatusPopupHttpRequest);
     }
 
     logger(`useHttpEndpoints: Registered ${ENDPOINT_PATHS.length} HTTP endpoints`, 3);

--- a/react/hooks/useRunStatusTip.ts
+++ b/react/hooks/useRunStatusTip.ts
@@ -1,0 +1,33 @@
+/**
+ * Asks for the run-status tip the first time a run is live while the sidebar
+ * is open: that is the moment the user could close the sidebar and see the
+ * corner card, and the tip offers to. A run that starts with the sidebar
+ * already closed needs no tip — the card itself is on screen. Whether now is
+ * a good moment is `showFeatureTipAtom`'s call.
+ */
+import { useEffect, useRef } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { isStreamingAtom } from '@beaver/agent-core/run-state/atoms';
+import { isSidebarVisibleAtom } from '../atoms/ui';
+import { runStatusPopupEnabledAtom } from '../atoms/runStatusPopup';
+import { showFeatureTipAtom } from '../atoms/featureTips';
+
+/** Long enough for the run to have started producing something on screen. */
+const TIP_DELAY_MS = 1500;
+
+export function useRunStatusTip(): void {
+    const isStreaming = useAtomValue(isStreamingAtom);
+    const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
+    const popupEnabled = useAtomValue(runStatusPopupEnabledAtom);
+    const showFeatureTip = useSetAtom(showFeatureTipAtom);
+    const shownThisSessionRef = useRef(false);
+
+    useEffect(() => {
+        if (shownThisSessionRef.current) return;
+        if (!isStreaming || !isSidebarVisible || !popupEnabled) return;
+        const timer = setTimeout(() => {
+            if (showFeatureTip('run-status-popup')) shownThisSessionRef.current = true;
+        }, TIP_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, [isStreaming, isSidebarVisible, popupEnabled, showFeatureTip]);
+}

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -31,6 +31,7 @@ import { useReaderAnnotationActionHandler } from './hooks/useReaderAnnotationAct
 import { useReaderVisualizerActionHandler } from './hooks/useReaderVisualizerActionHandler';
 import { useOnboardingPopups } from './hooks/useOnboardingPopups';
 import { useInterruptedThreadPopup } from './hooks/useInterruptedThreadPopup';
+import { useRunStatusTip } from './hooks/useRunStatusTip';
 import { useBackgroundWorkerStatus } from './hooks/useBackgroundWorkerStatus';
 import { useSyncSuppression } from './hooks/useSyncSuppression';
 import { BeaverTemporaryAnnotations } from './utils/annotationUtils';
@@ -197,6 +198,9 @@ const GlobalContextInitializer = () => {
 
     // Offer to reopen a chat that was cut off when Beaver last shut down
     useInterruptedThreadPopup();
+
+    // One-time tip that the corner card follows a run while the sidebar is closed
+    useRunStatusTip();
 
     // Mirror background extraction activity into the shared Jotai store
     useBackgroundWorkerStatus();

--- a/react/types/popupMessage.ts
+++ b/react/types/popupMessage.ts
@@ -1,10 +1,11 @@
 import { FileStatusSummary } from "./fileStatus";
 import { FeatureStep } from "../constants/versionUpdateMessages";
 import { ButtonVariant } from "@beaver/agent-ui/primitives/Button";
+import type { FeatureTipId } from "../constants/featureTips";
 
 export const POPUP_MESSAGE_DURATION = 4000; // 4 seconds
 
-export type PopupMessageType = 'info' | 'warning' | 'error' | 'plan_change' | 'indexing_complete' | 'version_update' | 'items_summary' | 'welcome_onboarding' | 'reader_tip' | 'note_tip' | 'citation_tip';
+export type PopupMessageType = 'info' | 'warning' | 'error' | 'plan_change' | 'indexing_complete' | 'version_update' | 'items_summary' | 'welcome_onboarding' | 'reader_tip' | 'note_tip' | 'citation_tip' | 'feature_tip';
 
 export interface PopupMessageFeature {
     title: string;
@@ -21,6 +22,8 @@ export interface PopupMessageButton {
 
 export interface PopupMessage {
     id: string;
+    /** Which tip a `feature_tip` message shows — see `react/constants/featureTips.tsx`. */
+    tipId?: FeatureTipId;
     cancelable?: boolean; // Defaults to true
     type: PopupMessageType;
     /** Release version shown by version update messages. */

--- a/react/utils/featureTipPrefs.ts
+++ b/react/utils/featureTipPrefs.ts
@@ -1,0 +1,82 @@
+/**
+ * What the user has already been told, for the one-time feature tips.
+ *
+ * One JSON preference for every tip, keyed by tip id, so adding a tip is a
+ * registry entry rather than a new preference — and so the tips can be paced
+ * against each other: the newest one shown is what the gap between tips is
+ * measured from. The pure functions take the state; the two wrappers at the
+ * bottom read and write the preference.
+ */
+import { getPref, setPref } from '../../src/utils/prefs';
+
+export interface FeatureTipState {
+    /** When each tip was shown, by tip id, as ISO timestamps. */
+    shown: Record<string, string>;
+    /** When the newest tip of any kind was shown. */
+    lastShownAt?: string;
+}
+
+/** The gap kept between two feature tips, whichever they are. */
+export const FEATURE_TIP_GAP_MS = 4 * 60 * 60 * 1000;
+
+const EMPTY_STATE: FeatureTipState = { shown: {} };
+
+export function parseFeatureTipState(raw: unknown): FeatureTipState {
+    if (typeof raw !== 'string' || !raw.trim()) return { shown: {} };
+    try {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return { shown: {} };
+        const shown = parsed.shown && typeof parsed.shown === 'object' ? parsed.shown : {};
+        const state: FeatureTipState = { shown: {} };
+        for (const [id, at] of Object.entries(shown)) {
+            if (typeof at === 'string') state.shown[id] = at;
+        }
+        if (typeof parsed.lastShownAt === 'string') state.lastShownAt = parsed.lastShownAt;
+        return state;
+    } catch {
+        return { shown: {} };
+    }
+}
+
+export function hasSeenFeatureTip(state: FeatureTipState, tipId: string): boolean {
+    return tipId in state.shown;
+}
+
+/**
+ * Whether a tip shown now would come too soon after the last one.
+ *
+ * `otherShownAt` lets the caller count popups that are not feature tips but
+ * compete for the same attention — the release notes, the welcome card — so a
+ * tip does not land right after one of those either.
+ */
+export function isWithinFeatureTipGap(
+    state: FeatureTipState,
+    now: number,
+    otherShownAt: readonly (string | null | undefined)[] = [],
+    gapMs = FEATURE_TIP_GAP_MS,
+): boolean {
+    const stamps = [state.lastShownAt, ...otherShownAt];
+    for (const stamp of stamps) {
+        if (!stamp) continue;
+        const at = new Date(stamp).getTime();
+        if (!Number.isNaN(at) && now - at < gapMs) return true;
+    }
+    return false;
+}
+
+export function markFeatureTipShown(state: FeatureTipState, tipId: string, now: number): FeatureTipState {
+    const at = new Date(now).toISOString();
+    return { shown: { ...state.shown, [tipId]: at }, lastShownAt: at };
+}
+
+export function readFeatureTipState(): FeatureTipState {
+    try {
+        return parseFeatureTipState(getPref('featureTips'));
+    } catch {
+        return EMPTY_STATE;
+    }
+}
+
+export function writeFeatureTipState(state: FeatureTipState): void {
+    setPref('featureTips', JSON.stringify(state));
+}

--- a/src/services/systemNotifications.ts
+++ b/src/services/systemNotifications.ts
@@ -21,9 +21,9 @@
  * All are gated on whether the user can currently see the Beaver UI. Three
  * visibility scenarios are handled (see getBeaverVisibility):
  *   A) Beaver UI is on screen and focused  -> no notification (user sees it).
- *   B) A Zotero window is focused but Beaver is not visible -> system
- *      notification for now. This is the intended seam for a future in-app
- *      Zotero notification; replace the SCENARIO_B branch when that exists.
+ *   B) A Zotero window is focused but Beaver is not visible -> no
+ *      notification: the run status popup in the main window's corner
+ *      (react/components/runStatusPopup) reports the event there.
  *   C) Zotero is in the background -> system notification (only way to reach
  *      the user).
  *
@@ -121,10 +121,12 @@ function shouldNotifySystem(): boolean {
             // Scenario A: the pending UI is already on screen — nothing to do.
             return false;
         case "zotero-focused":
-            // SCENARIO B: Zotero is focused but Beaver is not visible.
-            // TODO: when an in-app Zotero notification exists, route this case
-            // there instead of falling through to a system notification.
-            return true;
+            // Scenario B: Zotero is focused but Beaver is not visible. The run
+            // status popup in the main window's corner
+            // (react/components/runStatusPopup) already shows the pending
+            // decision or the finished response there, with its controls, so
+            // an OS notification on top of it would say the same thing twice.
+            return false;
         case "zotero-unfocused":
             // Scenario C: Zotero is in the background.
             return true;
@@ -371,9 +373,9 @@ export function notifyRunComplete(): void {
         return;
     }
 
-    // Scenario A: the response is already on screen — nothing to do. Scenarios
-    // B and C (Beaver hidden, or Zotero in the background) both get notified.
-    if (getBeaverVisibility() === "beaver-visible") {
+    // Only scenario C (Zotero in the background) is notified: in A the
+    // response is on screen, and in B the run status popup reports it.
+    if (getBeaverVisibility() !== "zotero-unfocused") {
         return;
     }
 

--- a/tests/unit/components/runStatusPopup/runStatusPopupModel.test.ts
+++ b/tests/unit/components/runStatusPopup/runStatusPopupModel.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The closed-sidebar status popup's copy, derived from run state.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+
+import type { AgentRun, ModelResponse, ToolCallPart, ToolReturnPart } from '@beaver/agent-core/agents/types';
+import type { ToolResult } from '@beaver/agent-core/run-state/atoms';
+import type { PendingApproval } from '@beaver/agent-ui/host';
+import {
+    deriveRunActivity,
+    describePendingApprovals,
+    threadDisplayName,
+} from '../../../../react/components/runStatusPopup/runStatusPopupModel';
+
+function toolCall(id: string, toolName = 'read', args: Record<string, any> = {}): ToolCallPart {
+    return { part_kind: 'tool-call', tool_name: toolName, args, tool_call_id: id };
+}
+
+function toolReturn(id: string, toolName = 'read'): ToolReturnPart {
+    return { part_kind: 'tool-return', tool_name: toolName, content: {}, tool_call_id: id };
+}
+
+function response(parts: ModelResponse['parts']): ModelResponse {
+    return { kind: 'response', run_id: 'run-1', parts };
+}
+
+function run(messages: AgentRun['model_messages'], status: AgentRun['status'] = 'in_progress'): AgentRun {
+    return {
+        id: 'run-1',
+        user_id: 'user-1',
+        thread_id: 'thread-1',
+        agent_name: 'beaver',
+        user_prompt: { content: 'Summarize the neighborhood effects literature', attachments: [] } as any,
+        status,
+        model_messages: messages,
+        model_name: 'test',
+        created_at: '2026-09-06T10:00:00.000Z',
+        consent_to_share: false,
+    };
+}
+
+function results(...parts: ToolReturnPart[]): ReadonlyMap<string, ToolResult> {
+    return new Map(parts.map((part) => [part.tool_call_id, part]));
+}
+
+describe('deriveRunActivity', () => {
+    it('reads as thinking before the run has produced anything', () => {
+        expect(deriveRunActivity(run([]), results())).toEqual({ kind: 'thinking' });
+    });
+
+    it('reads as thinking while reasoning is the only thing in the response', () => {
+        const r = run([response([{ part_kind: 'thinking', content: 'Let me see' }])]);
+        expect(deriveRunActivity(r, results())).toEqual({ kind: 'thinking' });
+    });
+
+    it('reads as generating while the newest part is streamed text', () => {
+        const r = run([response([
+            { part_kind: 'thinking', content: 'Let me see' },
+            { part_kind: 'text', content: 'Neighborhood effects are' },
+        ])]);
+        expect(deriveRunActivity(r, results())).toEqual({ kind: 'generating' });
+    });
+
+    it('names a tool call that is still waiting on its result', () => {
+        const call = toolCall('tc-1', 'fulltext_search');
+        const r = run([response([{ part_kind: 'text', content: 'Searching.' }, call])]);
+        expect(deriveRunActivity(r, results())).toEqual({ kind: 'tool', part: call });
+    });
+
+    it('names the newest of several parallel calls', () => {
+        const first = toolCall('tc-1', 'read');
+        const second = toolCall('tc-2', 'read_note');
+        const r = run([response([first, second])]);
+        expect(deriveRunActivity(r, results())).toEqual({ kind: 'tool', part: second });
+    });
+
+    it('goes back to thinking once every call has returned and the model has not answered', () => {
+        const call = toolCall('tc-1');
+        const r = run([
+            response([call]),
+            { kind: 'request', run_id: 'run-1', parts: [toolReturn('tc-1')], instructions: '' },
+        ]);
+        expect(deriveRunActivity(r, results(toolReturn('tc-1')))).toEqual({ kind: 'thinking' });
+    });
+
+    it('ignores auto-loading calls and suggestion chips', () => {
+        const r = run([response([
+            { part_kind: 'text', content: 'Done.' },
+            toolCall('auto_load_1', 'load_tool_results'),
+            toolCall('tc-9', 'return_suggestions'),
+        ])]);
+        expect(deriveRunActivity(r, results())).toEqual({ kind: 'generating' });
+    });
+});
+
+describe('threadDisplayName', () => {
+    it('prefers the backend name', () => {
+        expect(threadDisplayName('Neighborhood effects', run([]))).toBe('Neighborhood effects');
+    });
+
+    it('falls back to the prompt, cut to a title length', () => {
+        const r = run([]);
+        r.user_prompt.content = 'A'.repeat(80);
+        expect(threadDisplayName(null, r)).toBe(`${'A'.repeat(59)}…`);
+        expect(threadDisplayName('  ', run([]))).toBe('Summarize the neighborhood effects literature');
+    });
+
+    it('has a name for a thread with nothing yet', () => {
+        expect(threadDisplayName(null, null)).toBe('New chat');
+    });
+});
+
+function approval(actionId: string, actionType: string, actionData: Record<string, any> = {}): PendingApproval {
+    return { actionId, toolcallId: `tc-${actionId}`, actionType: actionType as any, actionData };
+}
+
+describe('describePendingApprovals', () => {
+    it('labels one request like its card, with the title when known', () => {
+        expect(describePendingApprovals([approval('a', 'edit_metadata')], 'Smith 2014')).toEqual({
+            label: 'Edit · Smith 2014',
+            count: 1,
+            confirmOnly: false,
+        });
+        expect(describePendingApprovals([approval('a', 'create_note')], null).label).toBe('Create Note');
+    });
+
+    it('tallies several requests behind a count', () => {
+        const summary = describePendingApprovals([
+            approval('a', 'edit_metadata'),
+            approval('b', 'edit_metadata'),
+            approval('c', 'create_note'),
+        ], null);
+        expect(summary).toEqual({ label: '3 changes · Edit ×2, Create Note', count: 3, confirmOnly: false });
+    });
+
+    it('knows when every request is a confirmation rather than a change', () => {
+        expect(describePendingApprovals([approval('a', 'confirm_extraction', { attachment_count: 12 })], null)).toEqual({
+            label: 'Extract',
+            count: 1,
+            confirmOnly: true,
+        });
+        // The confirmation's title carries the whole line; no verb in front.
+        expect(describePendingApprovals(
+            [approval('a', 'confirm_extraction', { attachment_count: 12 })],
+            'Confirm 12 Item Batch Processing',
+        ).label).toBe('Confirm 12 Item Batch Processing');
+        const both = describePendingApprovals([
+            approval('a', 'confirm_extraction'),
+            approval('b', 'confirm_external_search'),
+        ], null);
+        expect(both.label).toBe('2 confirmations · Extract, Search');
+        expect(both.confirmOnly).toBe(true);
+    });
+});

--- a/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
+++ b/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
@@ -84,6 +84,7 @@ import { pendingQuestionsAtom } from '@beaver/agent-core/run-state/pendingQuesti
 import { pendingApprovalsAtom } from '../../../../react/agents/agentActions';
 import { autoReplacementPendingRunIdsAtom } from '../../../../react/atoms/agentRunAtoms';
 import { isSidebarVisibleAtom } from '../../../../react/atoms/ui';
+import { annotationPanelStateAtom } from '../../../../react/atoms/messageUIState';
 import { runStatusPopupCompletionAtom, runStatusPopupPreviewAtom } from '../../../../react/atoms/runStatusPopup';
 import { useRunStatusPopupCard } from '../../../../react/components/runStatusPopup/useRunStatusPopupCard';
 import type { RunStatusPopupCard } from '../../../../react/components/runStatusPopup/runStatusPopupModel';
@@ -303,9 +304,14 @@ describe('when a run finishes', () => {
 
         expect(latest).toMatchObject({ kind: 'completed', changes: '1 pending' });
         expect((latest as any).artifacts).toHaveLength(1);
-        expect((latest as any).artifacts[0].title).toBe('Summary: Smith 2014');
+        expect((latest as any).artifacts[0]).toMatchObject({ actionType: 'create_note', label: 'Created Note', title: 'Summary: Smith 2014' });
         (latest as any).artifacts[0].open();
         expect(mocks.openNoteByKey).toHaveBeenCalledExactlyOnceWith(1, 'ABCD1234');
+
+        // Reviewing the changes opens Beaver on the answer with its card expanded.
+        act(() => { (latest as any).onReviewChanges(); });
+        expect(store.get(annotationPanelStateAtom)['run-1:changes']).toMatchObject({ resultsVisible: true });
+        expect(mocks.dispatch).toHaveBeenCalledWith('toggleChat', { forceOpen: true });
     });
 
     it('does not report a run that finished in front of the user', () => {

--- a/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
+++ b/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
@@ -1,0 +1,413 @@
+// @vitest-environment jsdom
+
+/**
+ * Which card the closed-sidebar status popup shows for the open thread, and
+ * what its controls do.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Provider, atom, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    answerPendingApprovals: vi.fn(),
+    setRunPermissionMode: vi.fn(),
+    sendCreditConfirmation: vi.fn(),
+    dismissPreview: vi.fn(async () => {}),
+    openNoteByKey: vi.fn(),
+    artifactRows: [] as any[],
+    changesRows: [] as any[],
+    prefs: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../../src/utils/prefs', () => ({
+    getPref: (key: string) => mocks.prefs[key],
+    setPref: (key: string, value: unknown) => { mocks.prefs[key] = value; },
+}));
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+vi.mock('../../../../react/events/eventManager', () => ({
+    eventManager: { dispatch: mocks.dispatch },
+}));
+vi.mock('../../../../react/atoms/ui', async () => {
+    const { atom } = await import('jotai');
+    return { isSidebarVisibleAtom: atom(false) };
+});
+vi.mock('../../../../react/agents/agentActions', async () => {
+    const { atom } = await import('jotai');
+    return { pendingApprovalsAtom: atom(new Map()) };
+});
+vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
+    const { atom } = await import('jotai');
+    const inFlight = atom(false);
+    return {
+        autoReplacementPendingRunIdsAtom: atom(new Set<string>()),
+        approvalVerdictInFlightAtom: inFlight,
+        beginApprovalVerdictAtom: atom(null, (get, set) => {
+            if (get(inFlight)) return false;
+            set(inFlight, true);
+            return true;
+        }),
+        releaseApprovalVerdictAtom: atom(null, (_get, set) => set(inFlight, false)),
+        answerPendingApprovalsAtom: atom(null, (_get, _set, args: unknown) => mocks.answerPendingApprovals(args)),
+        setRunPermissionModeAtom: atom(null, (_get, _set, args: unknown) => mocks.setRunPermissionMode(args)),
+        sendCreditConfirmationResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendCreditConfirmation(args)),
+    };
+});
+vi.mock('../../../../react/host/zotero/editNotePreviewLifecycle', () => ({
+    dismissActiveEditNotePreview: mocks.dismissPreview,
+}));
+vi.mock('../../../../react/utils/sourceUtils', () => ({ openNoteByKey: mocks.openNoteByKey }));
+vi.mock('../../../../react/utils/toolCallLabelEnrich', () => ({
+    resolveToolCallLabelEnrich: vi.fn(async () => null),
+}));
+vi.mock('../../../../src/utils/libraryIdentity', () => ({
+    resolveItemReference: vi.fn(async () => ({ status: 'not_found' })),
+    resolveLibraryRef: (ref: { library_id?: number | null }) => ref.library_id ?? null,
+}));
+vi.mock('../../../../src/utils/zoteroUtils', () => ({ shortItemTitle: vi.fn(async () => 'Smith 2014') }));
+vi.mock('../../../../react/host/zotero/components/reviewChanges/useRunActionRows', () => ({
+    useArtifactRows: () => mocks.artifactRows,
+    useChangesRows: () => mocks.changesRows,
+}));
+
+import type { AgentRun } from '@beaver/agent-core/agents/types';
+import {
+    activeRunAtom,
+    currentThreadNameAtom,
+    threadRunsAtom,
+} from '@beaver/agent-core/run-state/atoms';
+import { pendingBatchApprovalsAtom } from '@beaver/agent-core/run-state/pendingBatchApprovals';
+import { pendingCreditConfirmationsAtom } from '@beaver/agent-core/run-state/pendingCreditConfirmations';
+import { pendingQuestionsAtom } from '@beaver/agent-core/run-state/pendingQuestions';
+import { pendingApprovalsAtom } from '../../../../react/agents/agentActions';
+import { autoReplacementPendingRunIdsAtom } from '../../../../react/atoms/agentRunAtoms';
+import { isSidebarVisibleAtom } from '../../../../react/atoms/ui';
+import { runStatusPopupCompletionAtom, runStatusPopupPreviewAtom } from '../../../../react/atoms/runStatusPopup';
+import { useRunStatusPopupCard } from '../../../../react/components/runStatusPopup/useRunStatusPopupCard';
+import type { RunStatusPopupCard } from '../../../../react/components/runStatusPopup/runStatusPopupModel';
+
+function run(overrides: Partial<AgentRun> = {}): AgentRun {
+    return {
+        id: 'run-1',
+        user_id: 'user-1',
+        thread_id: 'thread-1',
+        agent_name: 'beaver',
+        user_prompt: { content: 'Summarize the neighborhood effects literature', attachments: [] } as any,
+        status: 'in_progress',
+        model_messages: [],
+        model_name: 'test',
+        created_at: '2026-09-06T10:00:00.000Z',
+        consent_to_share: false,
+        ...overrides,
+    };
+}
+
+let store = createStore();
+let latest: RunStatusPopupCard | null = null;
+const roots: { root: Root; container: HTMLDivElement }[] = [];
+
+function mount() {
+    const Harness: React.FC = () => {
+        latest = useRunStatusPopupCard();
+        return null;
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push({ root, container });
+    act(() => {
+        root.render(React.createElement(Provider, { store }, React.createElement(Harness)));
+    });
+}
+
+function set<T>(target: any, value: T) {
+    act(() => { store.set(target, value); });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    store = createStore();
+    latest = null;
+    mocks.artifactRows = [];
+    mocks.changesRows = [];
+    mocks.prefs = {};
+});
+
+afterEach(() => {
+    act(() => { roots.forEach(({ root }) => root.unmount()); });
+    roots.forEach(({ container }) => container.remove());
+    roots.length = 0;
+});
+
+describe('with no run', () => {
+    it('shows nothing', () => {
+        mount();
+        expect(latest).toBeNull();
+    });
+});
+
+describe('while a run works', () => {
+    it('names the thread by its prompt until the backend names it', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        expect(latest).toMatchObject({ kind: 'running', threadName: 'Summarize the neighborhood effects literature', statusLine: 'Thinking' });
+
+        set(currentThreadNameAtom, 'Neighborhood effects');
+        expect(latest?.threadName).toBe('Neighborhood effects');
+    });
+
+    it('says what the run is doing', () => {
+        store.set(activeRunAtom, run({
+            model_messages: [{ kind: 'response', run_id: 'run-1', parts: [{ part_kind: 'text', content: 'The literature' }] }],
+        }));
+        mount();
+        expect(latest).toMatchObject({ kind: 'running', statusLine: 'Generating' });
+
+        set(activeRunAtom, run({
+            model_messages: [{
+                kind: 'response',
+                run_id: 'run-1',
+                parts: [{ part_kind: 'tool-call', tool_name: 'fulltext_search', args: { query: 'social capital' }, tool_call_id: 'tc-1' }],
+            }],
+        }));
+        expect(latest).toMatchObject({ kind: 'running', statusLine: expect.stringContaining('Fulltext search') });
+    });
+
+    it('opens Beaver from the card', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        latest!.onOpen();
+        expect(mocks.dispatch).toHaveBeenCalledExactlyOnceWith('toggleChat', { forceOpen: true });
+    });
+});
+
+describe('while a run waits on the user', () => {
+    const approval = (actionId: string, actionType = 'edit_metadata') => ({
+        actionId, toolcallId: `tc-${actionId}`, actionType, actionData: {},
+    });
+
+    it('offers the pending change with its controls', async () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingApprovalsAtom as any, new Map([['a', approval('a')]]));
+        mount();
+
+        expect(latest).toMatchObject({ kind: 'approval', label: 'Edit', count: 1, approveLabel: 'Approve', rejectLabel: 'Reject' });
+        expect((latest as any).permission).toMatchObject({ mode: 'ask', pendingCoveredCount: 1 });
+
+        await act(async () => { (latest as any).onDecide(true); });
+        expect(mocks.dismissPreview).toHaveBeenCalledOnce();
+        expect(mocks.answerPendingApprovals).toHaveBeenCalledExactlyOnceWith({ actionIds: ['a'], approved: true });
+    });
+
+    it('aggregates several changes behind Approve All', () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingApprovalsAtom as any, new Map([
+            ['a', approval('a')],
+            ['b', approval('b')],
+            ['c', approval('c', 'create_note')],
+        ]));
+        mount();
+        expect(latest).toMatchObject({
+            kind: 'approval',
+            label: '3 changes · Edit ×2, Create Note',
+            approveLabel: 'Approve All',
+            rejectLabel: 'Reject All',
+        });
+    });
+
+    it('offers no permission grant for a confirmation', () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingApprovalsAtom as any, new Map([['a', approval('a', 'confirm_extraction')]]));
+        mount();
+        expect(latest).toMatchObject({ kind: 'approval', permission: null, approveLabel: 'Confirm' });
+    });
+
+    it('grants full access for the run through the menu', async () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingApprovalsAtom as any, new Map([['a', approval('a')]]));
+        mount();
+        await act(async () => { await (latest as any).permission.onChange('full_access'); });
+        expect(mocks.dismissPreview).toHaveBeenCalledOnce();
+        expect(mocks.setRunPermissionMode).toHaveBeenCalledExactlyOnceWith({ runId: 'run-1', fullAccess: true });
+    });
+
+    it('ranks the blocking requests the way the composer does', () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingQuestionsAtom, new Map([['tc-q', { questionId: 'q', toolcallId: 'tc-q', title: 'Which years?', questions: [] }]]));
+        mount();
+        expect(latest).toMatchObject({ kind: 'question', title: 'Which years?' });
+
+        set(pendingCreditConfirmationsAtom, new Map([['c', {
+            confirmationId: 'c', runId: 'run-1', title: 'Continue past 50 credits?', message: 'Body',
+            approveLabel: 'Continue', declineLabel: 'Wrap up', pendingCredits: 30, projectedTotalCredits: 80,
+            threshold: 50, timeoutSeconds: 300, expiresAt: Date.now() + 300_000,
+        }]]));
+        expect(latest).toMatchObject({ kind: 'credit', title: 'Continue past 50 credits?', approveLabel: 'Continue', declineLabel: 'Wrap up' });
+
+        set(pendingBatchApprovalsAtom, new Map([['b', {
+            approvalId: 'b', runId: 'run-1', toolcallId: 'tc-b', batchId: 'batch', title: 'Summarize each paper',
+            scopePrimary: '184 items', scopeSecondary: 'in Methods', message: '', destructiveWarning: '', costWarning: '',
+            creditChip: '', creditTooltip: '', defaultMode: 'ask', approveLabel: 'Start', declineLabel: 'Cancel',
+            declineWithInstructionsLabel: 'Cancel', userInstructionsPrefill: '', readOnly: false, timeoutSeconds: 300,
+        }]]));
+        expect(latest).toMatchObject({ kind: 'batch', title: 'Summarize each paper', scope: '184 items in Methods' });
+
+        set(pendingApprovalsAtom as any, new Map([['a', approval('a')]]));
+        expect(latest?.kind).toBe('approval');
+    });
+
+    it('sends a credit decision once', () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingCreditConfirmationsAtom, new Map([['c', {
+            confirmationId: 'c', runId: 'run-1', title: 'T', message: 'M', approveLabel: 'Continue', declineLabel: 'Wrap up',
+            pendingCredits: 1, projectedTotalCredits: 2, threshold: 1, timeoutSeconds: 300, expiresAt: Date.now() + 300_000,
+        }]]));
+        mount();
+        act(() => { (latest as any).onDecide(false); });
+        act(() => { (latest as any).onDecide(true); });
+        expect(mocks.sendCreditConfirmation).toHaveBeenCalledExactlyOnceWith({ confirmationId: 'c', approved: false });
+        expect((latest as any).decideDisabled).toBe(true);
+    });
+});
+
+describe('when a run finishes', () => {
+    it('reports a run that finished while the sidebar was closed, until Beaver opens', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        expect(latest?.kind).toBe('running');
+
+        set(activeRunAtom, run({ status: 'completed' }));
+        expect(latest).toMatchObject({ kind: 'completed', outcome: 'completed', detail: null, artifacts: [], changes: null });
+
+        set(isSidebarVisibleAtom, true);
+        expect(store.get(runStatusPopupCompletionAtom)).toBeNull();
+        expect(latest).toBeNull();
+    });
+
+    it('lists what the run produced and changed', () => {
+        mocks.artifactRows = [{
+            runId: 'run-1', toolcallId: 'tc-n', actionType: 'create_note', bulkApplicable: true, resolved: true,
+            actions: [{ id: 'n', run_id: 'run-1', action_type: 'create_note', status: 'applied',
+                proposed_data: { title: 'Summary: Smith 2014' }, result_data: { library_id: 1, zotero_key: 'ABCD1234' } }],
+        }];
+        mocks.changesRows = [{
+            runId: 'run-1', toolcallId: 'tc-e', actionType: 'edit_metadata', bulkApplicable: true, resolved: false,
+            actions: [{ id: 'e', run_id: 'run-1', action_type: 'edit_metadata', status: 'pending', proposed_data: {} }],
+        }];
+        store.set(activeRunAtom, run());
+        mount();
+        set(activeRunAtom, run({ status: 'completed' }));
+
+        expect(latest).toMatchObject({ kind: 'completed', changes: '1 pending' });
+        expect((latest as any).artifacts).toHaveLength(1);
+        expect((latest as any).artifacts[0].title).toBe('Summary: Smith 2014');
+        (latest as any).artifacts[0].open();
+        expect(mocks.openNoteByKey).toHaveBeenCalledExactlyOnceWith(1, 'ABCD1234');
+    });
+
+    it('does not report a run that finished in front of the user', () => {
+        store.set(isSidebarVisibleAtom, true);
+        store.set(activeRunAtom, run());
+        mount();
+        set(activeRunAtom, run({ status: 'completed' }));
+        set(isSidebarVisibleAtom, false);
+        expect(latest).toBeNull();
+    });
+
+    it('drops the report when the user dismisses it or starts another run', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        set(activeRunAtom, run({ status: 'error', error: { type: 'usage_limit_exceeded', message: 'x' } }));
+        expect(latest).toMatchObject({ kind: 'completed', outcome: 'error', detail: expect.any(String) });
+        expect((latest as any).detail).not.toBe('An error occurred');
+
+        act(() => { (latest as any).onDismiss(); });
+        expect(latest).toBeNull();
+
+        act(() => {
+            store.set(threadRunsAtom, [run({ id: 'run-1', status: 'error' })]);
+            store.set(activeRunAtom, run({ id: 'run-2' }));
+        });
+        expect(latest?.kind).toBe('running');
+        set(activeRunAtom, run({ id: 'run-2', status: 'completed' }));
+        expect(latest?.kind).toBe('completed');
+
+        act(() => {
+            store.set(threadRunsAtom, [run({ id: 'run-1', status: 'error' }), run({ id: 'run-2', status: 'completed' })]);
+            store.set(activeRunAtom, run({ id: 'run-3' }));
+        });
+        expect(latest?.kind).toBe('running');
+        expect(latest?.threadName).toBe('Summarize the neighborhood effects literature');
+    });
+});
+
+describe('closing a card', () => {
+    it('hides the working card but not the decision the same run asks for next', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        act(() => { latest!.onDismiss(); });
+        expect(latest).toBeNull();
+
+        set(pendingApprovalsAtom as any, new Map([['a', { actionId: 'a', toolcallId: 'tc-a', actionType: 'edit_metadata', actionData: {} }]]));
+        expect(latest?.kind).toBe('approval');
+
+        act(() => { latest!.onDismiss(); });
+        expect(latest).toBeNull();
+
+        // Answered elsewhere; the run goes back to work, still closed.
+        set(pendingApprovalsAtom as any, new Map());
+        expect(latest).toBeNull();
+
+        // And its finish is a new card.
+        set(activeRunAtom, run({ status: 'completed' }));
+        expect(latest?.kind).toBe('completed');
+    });
+
+    it('shows again for the next run', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        act(() => { latest!.onDismiss(); });
+        act(() => {
+            store.set(threadRunsAtom, [run({ status: 'completed' })]);
+            store.set(activeRunAtom, run({ id: 'run-2' }));
+        });
+        expect(latest?.kind).toBe('running');
+    });
+});
+
+describe('the preference', () => {
+    it('turns the popup off entirely', () => {
+        mocks.prefs.enableRunStatusPopup = false;
+        store.set(activeRunAtom, run());
+        mount();
+        expect(latest).toBeNull();
+    });
+});
+
+describe('while the client retries a failed run', () => {
+    it('keeps the working card up, saying so', () => {
+        store.set(activeRunAtom, run());
+        mount();
+        act(() => {
+            store.set(autoReplacementPendingRunIdsAtom as any, new Set(['run-1']));
+            store.set(activeRunAtom, run({ status: 'error', error: { type: 'x', message: 'x' } }));
+        });
+        expect(latest).toMatchObject({ kind: 'running', statusLine: 'Retrying' });
+    });
+});
+
+describe('the dev preview', () => {
+    it('replaces the live card and clears itself on a decision', () => {
+        store.set(activeRunAtom, run());
+        store.set(runStatusPopupPreviewAtom, { kind: 'approval', count: 2, stackDepth: 5 });
+        mount();
+        expect(latest).toMatchObject({ kind: 'approval', approveLabel: 'Approve All', stackDepth: 2 });
+
+        act(() => { (latest as any).onDecide(true); });
+        expect(store.get(runStatusPopupPreviewAtom)).toBeNull();
+        expect(latest?.kind).toBe('running');
+    });
+});

--- a/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
+++ b/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
     answerPendingApprovals: vi.fn(),
     setRunPermissionMode: vi.fn(),
     sendCreditConfirmation: vi.fn(),
+    sendQuestionResponse: vi.fn(),
     dismissPreview: vi.fn(async () => {}),
     openNoteByKey: vi.fn(),
     artifactRows: [] as any[],
@@ -53,6 +54,7 @@ vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
         answerPendingApprovalsAtom: atom(null, (_get, _set, args: unknown) => mocks.answerPendingApprovals(args)),
         setRunPermissionModeAtom: atom(null, (_get, _set, args: unknown) => mocks.setRunPermissionMode(args)),
         sendCreditConfirmationResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendCreditConfirmation(args)),
+        sendAskUserQuestionResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendQuestionResponse(args)),
     };
 });
 vi.mock('../../../../react/host/zotero/editNotePreviewLifecycle', () => ({
@@ -239,7 +241,11 @@ describe('while a run waits on the user', () => {
         store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
         store.set(pendingQuestionsAtom, new Map([['tc-q', { questionId: 'q', toolcallId: 'tc-q', title: 'Which years?', questions: [] }]]));
         mount();
-        expect(latest).toMatchObject({ kind: 'question', title: 'Which years?' });
+        expect(latest).toMatchObject({ kind: 'question', question: { questionId: 'q', title: 'Which years?' } });
+        (latest as any).onSubmit([{ item_id: 'q0', selected_option_ids: ['q0-o1'] }]);
+        expect(mocks.sendQuestionResponse).toHaveBeenCalledExactlyOnceWith({
+            questionId: 'q', toolcallId: 'tc-q', answers: [{ item_id: 'q0', selected_option_ids: ['q0-o1'] }], cancelled: false,
+        });
 
         set(pendingCreditConfirmationsAtom, new Map([['c', {
             confirmationId: 'c', runId: 'run-1', title: 'Continue past 50 credits?', message: 'Body',

--- a/tests/unit/featureTips/featureTipPrefs.test.ts
+++ b/tests/unit/featureTips/featureTipPrefs.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The record of which feature tips the user has seen, and the pacing between them.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/utils/prefs', () => ({ getPref: vi.fn(), setPref: vi.fn() }));
+
+import {
+    FEATURE_TIP_GAP_MS,
+    hasSeenFeatureTip,
+    isWithinFeatureTipGap,
+    markFeatureTipShown,
+    parseFeatureTipState,
+} from '../../../react/utils/featureTipPrefs';
+
+const T0 = Date.UTC(2026, 8, 6, 12, 0, 0);
+
+describe('parseFeatureTipState', () => {
+    it('reads the stored record and shrugs off anything malformed', () => {
+        expect(parseFeatureTipState('{}')).toEqual({ shown: {} });
+        expect(parseFeatureTipState('')).toEqual({ shown: {} });
+        expect(parseFeatureTipState('not json')).toEqual({ shown: {} });
+        expect(parseFeatureTipState(undefined)).toEqual({ shown: {} });
+        expect(parseFeatureTipState('{"shown":{"a":"2026-01-01T00:00:00.000Z","b":5},"lastShownAt":"2026-01-01T00:00:00.000Z"}'))
+            .toEqual({ shown: { a: '2026-01-01T00:00:00.000Z' }, lastShownAt: '2026-01-01T00:00:00.000Z' });
+    });
+});
+
+describe('marking and pacing', () => {
+    it('remembers a shown tip and dates the gap from it', () => {
+        const state = markFeatureTipShown({ shown: {} }, 'run-status-popup', T0);
+        expect(hasSeenFeatureTip(state, 'run-status-popup')).toBe(true);
+        expect(hasSeenFeatureTip(state, 'other')).toBe(false);
+        expect(state.lastShownAt).toBe(new Date(T0).toISOString());
+
+        expect(isWithinFeatureTipGap(state, T0 + FEATURE_TIP_GAP_MS - 1)).toBe(true);
+        expect(isWithinFeatureTipGap(state, T0 + FEATURE_TIP_GAP_MS)).toBe(false);
+    });
+
+    it('counts other recent popups against the gap too', () => {
+        const recent = new Date(T0 - 60_000).toISOString();
+        expect(isWithinFeatureTipGap({ shown: {} }, T0, [recent])).toBe(true);
+        expect(isWithinFeatureTipGap({ shown: {} }, T0, ['', null, undefined, 'garbage'])).toBe(false);
+    });
+});

--- a/tests/unit/featureTips/showFeatureTip.test.ts
+++ b/tests/unit/featureTips/showFeatureTip.test.ts
@@ -1,0 +1,67 @@
+/**
+ * When a feature tip is shown, and where.
+ */
+import { createStore } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ prefs: {} as Record<string, unknown> }));
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: (key: string) => mocks.prefs[key],
+    setPref: (key: string, value: unknown) => { mocks.prefs[key] = value; },
+}));
+vi.mock('../../../react/constants/featureTips', () => ({
+    FEATURE_TIPS: {
+        'run-status-popup': { id: 'run-status-popup', title: 'T', text: 't', icon: () => null, inPanel: true },
+    },
+}));
+
+import { dismissFeatureTipAtom, showFeatureTipAtom } from '../../../react/atoms/featureTips';
+import { popupMessagesAtom } from '../../../react/atoms/ui';
+import { floatingPopupMessagesAtom } from '../../../react/atoms/floatingPopup';
+
+let store = createStore();
+const inPanel = () => store.get(popupMessagesAtom).map((m) => m.id);
+const floating = () => store.get(floatingPopupMessagesAtom).map((m) => m.id);
+
+beforeEach(() => {
+    store = createStore();
+    mocks.prefs = { featureTips: '{}', versionUpdatePopupShownAt: '', onboardingWelcomeShownAt: '' };
+    vi.useRealTimers();
+});
+
+describe('showFeatureTipAtom', () => {
+    it('shows the tip where its definition says, once, and records it', () => {
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(true);
+        expect(inPanel()).toEqual(['feature-tip:run-status-popup']);
+        expect(floating()).toEqual([]);
+        expect(JSON.parse(mocks.prefs.featureTips as string).shown['run-status-popup']).toEqual(expect.any(String));
+
+        store.set(dismissFeatureTipAtom, 'run-status-popup');
+        expect(inPanel()).toEqual([]);
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(false);
+    });
+
+    it('waits while another popup is up', () => {
+        store.set(floatingPopupMessagesAtom, [{ id: 'version', type: 'version_update' } as any]);
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(false);
+        expect(mocks.prefs.featureTips).toBe('{}');
+    });
+
+    it('keeps its distance from the release notes and other tips', () => {
+        mocks.prefs.versionUpdatePopupShownAt = new Date(Date.now() - 60_000).toISOString();
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(false);
+
+        mocks.prefs.versionUpdatePopupShownAt = '';
+        mocks.prefs.featureTips = JSON.stringify({ shown: { other: 'x' }, lastShownAt: new Date(Date.now() - 60_000).toISOString() });
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(false);
+    });
+
+    it('can be forced anywhere for a preview without being recorded', () => {
+        mocks.prefs.featureTips = JSON.stringify({ shown: { 'run-status-popup': 'x' } });
+        expect(store.set(showFeatureTipAtom, 'run-status-popup', { force: true, inPanel: false })).toBe(true);
+        expect(floating()).toEqual(['feature-tip:run-status-popup']);
+        expect(JSON.parse(mocks.prefs.featureTips as string).lastShownAt).toBeUndefined();
+    });
+});

--- a/tests/unit/hooks/useRunStatusTip.test.ts
+++ b/tests/unit/hooks/useRunStatusTip.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+/**
+ * The trigger for the run-status tip: a live run with the sidebar open.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ prefs: {} as Record<string, unknown>, show: vi.fn(() => true) }));
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: (key: string) => mocks.prefs[key],
+    setPref: (key: string, value: unknown) => { mocks.prefs[key] = value; },
+}));
+vi.mock('../../../react/atoms/ui', async () => {
+    const { atom } = await import('jotai');
+    return { isSidebarVisibleAtom: atom(false) };
+});
+vi.mock('../../../react/atoms/featureTips', async () => {
+    const { atom } = await import('jotai');
+    return { showFeatureTipAtom: atom(null, (_get, _set, tipId: string) => mocks.show(tipId)) };
+});
+
+import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
+import { isSidebarVisibleAtom } from '../../../react/atoms/ui';
+import { useRunStatusTip } from '../../../react/hooks/useRunStatusTip';
+
+const LIVE_RUN = { id: 'run-1', status: 'in_progress' } as any;
+let store = createStore();
+const roots: { root: Root; container: HTMLDivElement }[] = [];
+
+function mount() {
+    const Harness: React.FC = () => { useRunStatusTip(); return null; };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push({ root, container });
+    act(() => { root.render(React.createElement(Provider, { store }, React.createElement(Harness))); });
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    store = createStore();
+    mocks.prefs = {};
+    mocks.show.mockReturnValue(true);
+});
+
+afterEach(() => {
+    act(() => { roots.forEach(({ root }) => root.unmount()); });
+    roots.forEach(({ container }) => container.remove());
+    roots.length = 0;
+    vi.useRealTimers();
+});
+
+describe('useRunStatusTip', () => {
+    it('asks for the tip once a run is live with the sidebar open', () => {
+        store.set(isSidebarVisibleAtom as any, true);
+        store.set(activeRunAtom, LIVE_RUN);
+        mount();
+        expect(mocks.show).not.toHaveBeenCalled();
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(mocks.show).toHaveBeenCalledExactlyOnceWith('run-status-popup');
+    });
+
+    it('asks again next time if the moment was declined', () => {
+        mocks.show.mockReturnValue(false);
+        store.set(isSidebarVisibleAtom as any, true);
+        store.set(activeRunAtom, LIVE_RUN);
+        mount();
+        act(() => { vi.advanceTimersByTime(2000); });
+        act(() => { store.set(activeRunAtom, null); });
+        act(() => { store.set(activeRunAtom, { ...LIVE_RUN, id: 'run-2' }); });
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(mocks.show).toHaveBeenCalledTimes(2);
+    });
+
+    it('needs no tip with the sidebar closed', () => {
+        store.set(activeRunAtom, LIVE_RUN);
+        mount();
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(mocks.show).not.toHaveBeenCalled();
+    });
+
+    it('needs no tip when the popup is turned off', () => {
+        mocks.prefs.enableRunStatusPopup = false;
+        store.set(isSidebarVisibleAtom as any, true);
+        store.set(activeRunAtom, LIVE_RUN);
+        mount();
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(mocks.show).not.toHaveBeenCalled();
+    });
+});

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -64,6 +64,7 @@ declare namespace _ZoteroTypes {
       "onboardingReaderTipShown": boolean;
       "onboardingReaderTipShownV2": boolean;
       "onboardingNoteTipShown": boolean;
+      "featureTips": string;
       "onboardingCitationTipShown": boolean;
       "onboardingWelcomeShownAt": string;
       "versionUpdatePopupShownAt": string;

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -39,6 +39,7 @@ declare namespace _ZoteroTypes {
       "showDiffPreviewInNoteEditor": boolean;
       "enableSystemNotifications": boolean;
       "enableResponseCompleteNotifications": boolean;
+      "enableRunStatusPopup": boolean;
       "deferredToolPreferences": string;
       "customInstructions": string;
       "googleGenerativeAiApiKey": string;


### PR DESCRIPTION
## Summary
- Add a closed-sidebar run status popup for progress, approvals, confirmations, questions, and completed responses.
- Support stacked cards, animations, artifacts, library changes, and direct actions from the popup.
- Add a preference to enable or disable the popup.
- Add dev-only preview controls and model coverage for popup states.

## Testing
- Added unit tests for popup state modeling and card behavior.
- Added HTTP handler tests for run status popup previews.
- Not run: full repository test suite.