### PR TITLE
feat(population-request): enhance item type handling for empty-value …

### DIFF
--- a/src/services/agentDataProvider/handleResolvePopulationRequest.ts
+++ b/src/services/agentDataProvider/handleResolvePopulationRequest.ts
@@ -110,6 +110,169 @@ async function attachmentIdsForItems(itemIds: number[]): Promise<number[]> {
 }
 
 /**
+ * Item types the population search always excludes.
+ *
+ * Every filter describes a bibliographic item, so these never belong to a
+ * population — an attachment population is DERIVED from the items that matched
+ * rather than searched for. Shared with `searchableItemTypes`, so that a type
+ * the search already drops is never counted as a reason to narrow further.
+ */
+const NON_BIBLIOGRAPHIC_ITEM_TYPES = ['attachment', 'note', 'annotation'];
+
+/** Item types a population can hold: everything the search does not exclude. */
+function searchableItemTypes(): { id: number; name: string }[] {
+    return Zotero.ItemTypes.getAll()
+        .filter(itemType => !NON_BIBLIOGRAPHIC_ITEM_TYPES.includes(itemType.name));
+}
+
+/**
+ * Whether a condition asks "is this field unset".
+ *
+ * Both spellings: `addSearchCondition` rewrites `is ''` into `doesNotContain
+ * ''`, so the two reach Zotero as the same search.
+ */
+function isEmptyValueCheck(condition: ZoteroSearchCondition): boolean {
+    return (condition.operator === 'is' || condition.operator === 'doesNotContain')
+        && (condition.value === null || condition.value === undefined || condition.value === '');
+}
+
+/**
+ * Which of `itemTypes` can hold `fieldName`, as item type ids, or null when
+ * the answer is not knowable.
+ *
+ * Not a plain `isValidForType` check: Zotero maps a base field onto a
+ * type-specific name — a film's `distributor` IS `publisher` — and an item
+ * carrying the variant does hold the field a condition on the base field
+ * names. `getFieldIDFromTypeAndBase` answers for both spellings at once.
+ *
+ * Null means "do not restrict": the condition field is not an item-data field
+ * at all (`tag`, `year`, `creator`, `note`), or item-field data is not loaded
+ * yet. A cold cache must never narrow a population.
+ */
+function itemTypeIdsWithField(
+    fieldName: string,
+    itemTypes: { id: number; name: string }[],
+): number[] | null {
+    try {
+        // Item-data fields only. Every other condition field either lives in
+        // its own table or is a search-only predicate, and neither has an
+        // item-type validity to check.
+        if (!Zotero.ItemFields.getID(fieldName)) return null;
+
+        const typeIds = itemTypes
+            .filter(itemType => Zotero.ItemFields.getFieldIDFromTypeAndBase(itemType.id, fieldName))
+            .map(itemType => itemType.id);
+        // No field Zotero knows is valid for no type, so an empty answer says
+        // the lookup came back wrong rather than that the field is exotic.
+        // Refusing to narrow on it is the answer that cannot empty a
+        // population by mistake.
+        return typeIds.length > 0 ? typeIds : null;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger(`handleResolvePopulationRequest: Skipped field-validity check for '${fieldName}': ${msg}`, 1);
+        return null;
+    }
+}
+
+/** What the empty-value conditions in an ANDed list say about item types. */
+interface EmptyFieldTypeRestriction {
+    /** The types that hold EVERY one of those fields. Empty: no type does. */
+    allowedTypeIds: Set<number>;
+    /** Whether it excludes a type the search itself does not already exclude. */
+    narrows: boolean;
+    /** The fields it was read off, in the order the caller gave them. */
+    fields: string[];
+}
+
+/**
+ * The item types a population may hold, given the "this field is unset"
+ * conditions in an ANDed condition list — or null when none of them says
+ * anything about item types.
+ *
+ * An empty value compiles to "no value stored for this field", which every
+ * item of a type that HAS no such field satisfies for free: `publisher is ""`
+ * matches every blog post and presentation, and an operation that fills
+ * publishers in can do nothing with one. Under join mode 'all' every condition
+ * holds of every item, so the answer is the intersection.
+ *
+ * Only the empty-value spelling is restricted. `publisher doesNotContain
+ * "springer"` matches a blog post for the same reason, but there the caller is
+ * asking about the text of a field rather than about whether it is filled in,
+ * and that reading is the documented one.
+ */
+function emptyFieldTypeRestriction(
+    conditions: ZoteroSearchCondition[],
+): EmptyFieldTypeRestriction | null {
+    let itemTypes: { id: number; name: string }[];
+    try {
+        itemTypes = searchableItemTypes();
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger(`handleResolvePopulationRequest: Skipped field-validity check: ${msg}`, 1);
+        return null;
+    }
+
+    let allowed: number[] | null = null;
+    const fields: string[] = [];
+
+    for (const condition of conditions) {
+        if (!isEmptyValueCheck(condition)) continue;
+
+        const typeIds = itemTypeIdsWithField(condition.field, itemTypes);
+        if (typeIds === null) continue;
+
+        fields.push(condition.field);
+        // ANDed conditions all hold of every item, so each one narrows what is
+        // left rather than adding to it.
+        allowed = allowed === null ? typeIds : allowed.filter(id => typeIds.indexOf(id) !== -1);
+    }
+
+    if (allowed === null) return null;
+
+    const allowedTypeIds = new Set(allowed);
+    return {
+        allowedTypeIds,
+        // Read off the same list the allowed ids were chosen from, so the two
+        // cannot end up counted over different universes.
+        narrows: itemTypes.some(itemType => !allowedTypeIds.has(itemType.id)),
+        fields,
+    };
+}
+
+/**
+ * The subset of `itemIds` whose item type is one of `allowedTypeIds`, in the
+ * order given.
+ *
+ * Reads the type rather than filtering in SQL against the excluded ids: the
+ * excluded list can hold most of Zotero's item types, and keeping them out of
+ * the statement keeps the bound-variable count a function of the chunk alone.
+ */
+async function filterItemIdsByTypes(
+    itemIds: number[],
+    allowedTypeIds: Set<number>,
+): Promise<number[]> {
+    const kept = new Set<number>();
+
+    for (let i = 0; i < itemIds.length; i += SQL_CHUNK_SIZE) {
+        const chunk = itemIds.slice(i, i + SQL_CHUNK_SIZE);
+        const placeholders = chunk.map(() => '?').join(', ');
+        await Zotero.DB.queryAsync(
+            `SELECT itemID, itemTypeID FROM items WHERE itemID IN (${placeholders})`,
+            chunk,
+            {
+                onRow: (row: any) => {
+                    if (allowedTypeIds.has(row.getResultByIndex(1))) {
+                        kept.add(row.getResultByIndex(0));
+                    }
+                },
+            },
+        );
+    }
+
+    return itemIds.filter(id => kept.has(id));
+}
+
+/**
  * Read key/library/dateAdded for the matched ids without loading any item.
  * Chunked, so the caller must re-sort globally — a per-chunk `ORDER BY` only
  * orders within its own chunk.
@@ -502,6 +665,35 @@ export async function handleResolvePopulationRequest(
             );
         }
 
+        // What the "field is unset" conditions say about item types. A type
+        // that HAS no such field satisfies the check for free — `publisher is
+        // ""` matches every blog post — so the population is restricted to the
+        // types that can hold every field checked this way. Under join mode
+        // 'any' the conditions are ORed and an item may have matched through a
+        // different disjunct, so the restriction is not true of it and is not
+        // computed.
+        const typeRestriction = conditionsJoinMode === 'all'
+            ? emptyFieldTypeRestriction(requestedConditions)
+            : null;
+
+        // No item type has all of those fields at once. Items missing all of
+        // them exist — every item missing a field it cannot have counts — but
+        // none of them could ever hold the fields, so there is nothing an
+        // operation could fill in. Refused rather than resolved as an empty
+        // population: "no items matched" reads as a filter to loosen, while
+        // this one cannot be loosened into anything workable.
+        if (typeRestriction && typeRestriction.allowedTypeIds.size === 0) {
+            logger('handleResolvePopulationRequest: Refused empty-value conditions no item type can satisfy', 1);
+            return errorResponse(
+                request.request_id,
+                `Refused the empty-value conditions on ${typeRestriction.fields.join(', ')}: `
+                    + 'no Zotero item type has all of those fields, so every item this would select is '
+                    + 'one that cannot hold them in the first place. Check one of those fields per '
+                    + 'batch, or drop the ones that do not apply to the item types you mean.',
+                'invalid_condition',
+            );
+        }
+
         const [scope, ...extraGroups] = groups;
         if (scope) {
             search.setScope(scope, true);
@@ -514,9 +706,9 @@ export async function handleResolvePopulationRequest(
         // `conditions` against the attachment rows instead, where a field like
         // DOI is never present and the population silently becomes every
         // attachment in the library.
-        search.addCondition('itemType', 'isNot', 'attachment');
-        search.addCondition('itemType', 'isNot', 'note');
-        search.addCondition('itemType', 'isNot', 'annotation');
+        for (const itemType of NON_BIBLIOGRAPHIC_ITEM_TYPES) {
+            search.addCondition('itemType', 'isNot', itemType);
+        }
         search.addCondition('noChildren', 'true', '');
 
         let itemIds = await search.search();
@@ -530,6 +722,27 @@ export async function handleResolvePopulationRequest(
             if (itemIds.length === 0) break;
             const matched = new Set(await group.search());
             itemIds = itemIds.filter(id => matched.has(id));
+        }
+
+        // The item-type restriction, applied to the matched ids. `narrows` is
+        // false for the fields these conditions almost always ask about
+        // (`abstractNote` and `DOI` are valid for every type the search can
+        // return), and then there is nothing to read from the database.
+        //
+        // Dropping every match is a real empty population, not the refusal
+        // above: those conditions CAN be satisfied, this library just holds no
+        // item of a type that could carry the field.
+        if (typeRestriction && typeRestriction.narrows && itemIds.length > 0) {
+            const matchedCount = itemIds.length;
+            itemIds = await filterItemIdsByTypes(itemIds, typeRestriction.allowedTypeIds);
+            if (itemIds.length < matchedCount) {
+                logger(
+                    'handleResolvePopulationRequest: Dropped '
+                        + `${matchedCount - itemIds.length} item(s) of a type that cannot hold `
+                        + `${typeRestriction.fields.join(', ')}`,
+                    1,
+                );
+            }
         }
 
         // has_attachments, in SQL. This is the only filter that could

--- a/tests/helpers/zoteroSchemaSeed.ts
+++ b/tests/helpers/zoteroSchemaSeed.ts
@@ -16,11 +16,11 @@ export interface SeededItem {
     key?: string;
     itemType?: string;       // 'journalArticle', 'book', 'note', 'attachment', etc.
     title?: string;          // stored in 'title' field by default
-    titleFieldName?: 'title' | 'publicationTitle' | 'bookTitle';  // for testing mapped fields
+    titleFieldName?: 'title' | 'caseName' | 'bookTitle';  // for testing mapped fields
     doi?: string;
     isbn?: string;
     date?: string;           // stored in 'date' field
-    filingDate?: string;     // stored in mapped 'filingDate' field, for date-precedence tests
+    dateDecided?: string;    // stored in the date-mapped 'dateDecided' field, for date-precedence tests
     creators?: string[];     // last names in order
     deleted?: boolean;
 }
@@ -162,7 +162,7 @@ export async function seedZoteroItem(
     await addField('DOI', item.doi);
     await addField('ISBN', item.isbn);
     await addField('date', item.date);
-    await addField('filingDate', item.filingDate);
+    await addField('dateDecided', item.dateDecided);
 
     if (item.deleted) {
         await conn.queryAsync(`INSERT INTO deletedItems (itemID) VALUES (?)`, [itemID]);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -96,9 +96,13 @@ const TEST_FIELD_IDS: Record<string, number> = {
     DOI: 26,
     ISBN: 11,
     date: 14,
-    publicationTitle: 12,   // a title-mapped field on journalArticle
-    bookTitle: 90,          // a title-mapped field on bookSection
-    filingDate: 150,        // a date-mapped field for testing precedence
+    publicationTitle: 12,   // a base field of its own; bookTitle maps onto it
+    bookTitle: 90,          // a publicationTitle-mapped field on bookSection
+    caseName: 118,          // a title-mapped field on case
+    dateDecided: 150,       // a date-mapped field on case
+    abstractNote: 2,        // valid for every type but attachment/note/annotation
+    publisher: 21,          // a base field only some types hold
+    distributor: 116,       // a publisher-mapped field on film
 };
 
 const TEST_TYPE_IDS: Record<string, number> = {
@@ -108,7 +112,43 @@ const TEST_TYPE_IDS: Record<string, number> = {
     journalArticle: 4,
     book: 2,
     bookSection: 5,
+    film: 8,
+    blogPost: 37,
 };
+
+// Which fields each item type holds. A type-specific variant of a base field
+// is listed under the variant's own name (a film's `distributor` IS its
+// publisher), which is what getFieldIDFromTypeAndBase resolves. These follow
+// Zotero's real schema for the fields named: a test that asserts an item is
+// kept or dropped for holding a field is only worth anything if the schema it
+// asserts against is the real one.
+const TEST_TYPE_FIELDS: Record<string, string[]> = {
+    annotation: [],
+    note: [],
+    attachment: ['title'],
+    journalArticle: ['title', 'DOI', 'date', 'publicationTitle', 'abstractNote'],
+    book: ['title', 'DOI', 'ISBN', 'date', 'publisher', 'abstractNote'],
+    bookSection: ['title', 'DOI', 'ISBN', 'bookTitle', 'date', 'publisher', 'abstractNote'],
+    film: ['title', 'DOI', 'date', 'distributor', 'abstractNote'],
+    blogPost: ['title', 'DOI', 'date', 'abstractNote'],
+};
+
+// Zotero's base-field mapping: base field -> the type-specific fields that ARE
+// that field under another name. A subset of the real mapping — the entries
+// the seeded types need — but every entry is one Zotero really has, because
+// both mocked functions below answer from it and a made-up mapping would let a
+// test assert an item-type validity Zotero does not agree with.
+const TEST_BASE_FIELD_VARIANTS: Record<string, string[]> = {
+    title: ['caseName'],
+    date: ['dateDecided'],
+    publicationTitle: ['bookTitle'],
+    publisher: ['distributor'],
+};
+
+const testTypeNameFromID = (itemType: number | string): string | undefined =>
+    typeof itemType === 'number'
+        ? Object.keys(TEST_TYPE_IDS).find(name => TEST_TYPE_IDS[name] === itemType)
+        : itemType;
 
 // The {id, name} rows Zotero.ItemTypes.getAll returns, from the same map.
 const testItemTypes = () =>
@@ -185,10 +225,21 @@ function testRemoveDiacritics(s: string): string {
     },
     ItemFields: {
         getID: vi.fn((name: string) => TEST_FIELD_IDS[name] ?? 0),
-        getTypeFieldsFromBase: vi.fn((baseField: string) => {
-            if (baseField === 'title') return [TEST_FIELD_IDS.publicationTitle, TEST_FIELD_IDS.bookTitle];
-            if (baseField === 'date') return [TEST_FIELD_IDS.filingDate];
-            return [];
+        getTypeFieldsFromBase: vi.fn((baseField: string) =>
+            (TEST_BASE_FIELD_VARIANTS[baseField] ?? []).map(field => TEST_FIELD_IDS[field])),
+        // Zotero's own contract: the fieldID the type holds `baseField` under
+        // (the base field itself when the type holds it directly), false when
+        // the type has no such field, and a throw for an unknown type.
+        getFieldIDFromTypeAndBase: vi.fn((itemType: number | string, baseField: string) => {
+            const typeName = testTypeNameFromID(itemType);
+            if (!typeName || !(typeName in TEST_TYPE_FIELDS)) {
+                throw new Error(`Invalid item type '${itemType}'`);
+            }
+            const fields = TEST_TYPE_FIELDS[typeName];
+            if (fields.includes(baseField)) return TEST_FIELD_IDS[baseField];
+            const variant = (TEST_BASE_FIELD_VARIANTS[baseField] ?? [])
+                .find(field => fields.includes(field));
+            return variant ? TEST_FIELD_IDS[variant] : false;
         }),
     },
     ItemTypes: {

--- a/tests/unit/handlers/resolvePopulation.test.ts
+++ b/tests/unit/handlers/resolvePopulation.test.ts
@@ -19,6 +19,7 @@ interface ItemRow {
     key: string;
     libraryID: number;
     dateAdded: string;
+    itemTypeID: number;
 }
 
 type MockSearchInstance = {
@@ -118,12 +119,13 @@ describe('handleResolvePopulationRequest', () => {
     const callsMatching = (pattern: RegExp) => dbCalls().filter(([sql]) => pattern.test(sql));
 
     /** Seed an item row plus, optionally, the attachments hanging off it. */
-    function seedItem(itemID: number, options: { key?: string; libraryID?: number; dateAdded?: string; attachments?: number[] } = {}) {
+    function seedItem(itemID: number, options: { key?: string; libraryID?: number; dateAdded?: string; attachments?: number[]; itemType?: string } = {}) {
         itemRows.set(itemID, {
             itemID,
             key: options.key ?? `KEY${itemID}`,
             libraryID: options.libraryID ?? LIBRARY_ID,
             dateAdded: options.dateAdded ?? `2024-01-01 00:00:${String(itemID).padStart(2, '0')}`,
+            itemTypeID: (globalThis as any).Zotero.ItemTypes.getID(options.itemType ?? 'journalArticle'),
         });
         if (options.attachments) {
             attachmentsByParent.set(itemID, options.attachments);
@@ -133,6 +135,7 @@ describe('handleResolvePopulationRequest', () => {
                     key: `ATT${attachmentID}`,
                     libraryID: LIBRARY_ID,
                     dateAdded: `2024-02-01 00:00:${String(attachmentID % 100).padStart(2, '0')}`,
+                    itemTypeID: (globalThis as any).Zotero.ItemTypes.getID('attachment'),
                 });
             }
         }
@@ -233,6 +236,13 @@ describe('handleResolvePopulationRequest', () => {
                         for (const attachmentID of attachmentsByParent.get(parentID) ?? []) {
                             emit([attachmentID]);
                         }
+                    }
+                    return;
+                }
+                if (/SELECT itemID, itemTypeID FROM items WHERE itemID IN/.test(sql)) {
+                    for (const itemID of params as number[]) {
+                        const row = itemRows.get(itemID);
+                        if (row) emit([row.itemID, row.itemTypeID]);
                     }
                     return;
                 }
@@ -1712,6 +1722,249 @@ describe('handleResolvePopulationRequest', () => {
 
             expect(response.error_code).toBe('collection_not_found');
             expect(response.matched_item_count).toBeUndefined();
+        });
+    });
+
+    describe('item-type validity of empty-value conditions', () => {
+        /** The SQL reads that ask for an item's type, if the handler ran any. */
+        const typeReads = () => callsMatching(/SELECT itemID, itemTypeID FROM items/);
+
+        it('drops items of a type that cannot hold the checked field', async () => {
+            // A blog post has no publisher field at all, so it satisfies
+            // "publisher is empty" for free — and an operation that fills
+            // publishers in can do nothing with it.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+            }));
+
+            expect(response.error).toBeUndefined();
+            expect(response.item_ids).toEqual(['u-KEY1']);
+            expect(response.total_count).toBe(1);
+        });
+
+        it('keeps an item whose type holds the field under another name', async () => {
+            // A film's `distributor` IS its publisher. Restricting on the base
+            // field alone would drop it, which is the opposite of correct.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'film' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1']);
+        });
+
+        it("applies to the doesNotContain '' spelling of the same check", async () => {
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'doesNotContain', value: '' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1']);
+        });
+
+        it('intersects the types across several empty-value conditions', async () => {
+            // A book holds both fields; a film holds the publisher (as its
+            // `distributor`) but no ISBN, so ORing the two type sets instead
+            // of intersecting them would keep it.
+            searchResultIds = [1, 2, 3];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'film' });
+            seedItem(3, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [
+                    { field: 'publisher', operator: 'is', value: '' },
+                    { field: 'ISBN', operator: 'is', value: '' },
+                ],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1']);
+        });
+
+        it('refuses empty-value conditions no item type can satisfy', async () => {
+            // No type holds both an ISBN and a distributor, so nothing can be
+            // missing both. Answering "0 items" would read as a filter to
+            // loosen rather than as one no library can satisfy.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'film' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [
+                    { field: 'ISBN', operator: 'is', value: '' },
+                    { field: 'distributor', operator: 'is', value: '' },
+                ],
+            }));
+
+            expect(response.error_code).toBe('invalid_condition');
+            expect(response.error).toContain('ISBN, distributor');
+            // The refusal must not claim no item is missing both fields —
+            // every blog post in the library is.
+            expect(response.error).toContain('cannot hold them');
+            expect(response.item_ids).toEqual([]);
+            expect(response.total_count).toBe(0);
+        });
+
+        it('resolves an empty population when the library holds no eligible item', async () => {
+            // Distinct from the refusal above: the filter IS satisfiable, this
+            // library just has nothing of a type that could carry a publisher.
+            searchResultIds = [1];
+            seedItem(1, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+            }));
+
+            expect(response.error).toBeUndefined();
+            expect(response.item_ids).toEqual([]);
+            expect(response.total_count).toBe(0);
+        });
+
+        it('runs no extra query for a field every searched type holds', async () => {
+            // abstractNote is valid for every item type but the three the
+            // search already excludes, so there is nothing to restrict.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'abstractNote', operator: 'is', value: '' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            expect(typeReads()).toHaveLength(0);
+        });
+
+        it('leaves a condition with a value alone', async () => {
+            // "publisher is Springer" cannot match a type without the field in
+            // the first place, so there is nothing to narrow.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'is', value: 'Springer' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            expect(typeReads()).toHaveLength(0);
+        });
+
+        it('leaves a condition field that is not an item field alone', async () => {
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'tag', operator: 'doesNotContain', value: '' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            expect(typeReads()).toHaveLength(0);
+        });
+
+        it('does not restrict when the conditions are ORed', async () => {
+            // Under 'any' an item may have matched through a different
+            // disjunct, so the restriction is not true of it.
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [
+                    { field: 'publisher', operator: 'is', value: '' },
+                    { field: 'DOI', operator: 'is', value: '' },
+                ],
+                conditions_join_mode: 'any',
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            expect(typeReads()).toHaveLength(0);
+        });
+
+        it('does not restrict on any_conditions', async () => {
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book' });
+            seedItem(2, { itemType: 'blogPost' });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                any_conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+            }));
+
+            expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            expect(typeReads()).toHaveLength(0);
+        });
+
+        it('leaves the population alone when no type comes back for a field', async () => {
+            // Zotero answers "not valid for this type" without throwing when a
+            // field's item-type map is missing, so a partial load looks like a
+            // field no type has. Restricting on that would refuse an ordinary
+            // single-field filter outright.
+            const itemFields = (globalThis as any).Zotero.ItemFields;
+            const original = itemFields.getFieldIDFromTypeAndBase;
+            itemFields.getFieldIDFromTypeAndBase = vi.fn(() => false);
+            try {
+                searchResultIds = [1, 2];
+                seedItem(1, { itemType: 'book' });
+                seedItem(2, { itemType: 'blogPost' });
+
+                const response = await handleResolvePopulationRequest(makeRequest({
+                    conditions: [{ field: 'abstractNote', operator: 'is', value: '' }],
+                }));
+
+                expect(response.error).toBeUndefined();
+                expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            } finally {
+                itemFields.getFieldIDFromTypeAndBase = original;
+            }
+        });
+
+        it('leaves the population alone when the field data cannot be read', async () => {
+            // Item-field data is loaded lazily; a cold cache must never narrow
+            // a population.
+            const itemFields = (globalThis as any).Zotero.ItemFields;
+            const original = itemFields.getFieldIDFromTypeAndBase;
+            itemFields.getFieldIDFromTypeAndBase = vi.fn(() => {
+                throw new Error('Item field data not yet loaded');
+            });
+            try {
+                searchResultIds = [1, 2];
+                seedItem(1, { itemType: 'book' });
+                seedItem(2, { itemType: 'blogPost' });
+
+                const response = await handleResolvePopulationRequest(makeRequest({
+                    conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+                }));
+
+                expect(response.error).toBeUndefined();
+                expect(response.item_ids).toEqual(['u-KEY1', 'u-KEY2']);
+            } finally {
+                itemFields.getFieldIDFromTypeAndBase = original;
+            }
+        });
+
+        it('restricts the matched items before deriving an attachment population', async () => {
+            searchResultIds = [1, 2];
+            seedItem(1, { itemType: 'book', attachments: [11] });
+            seedItem(2, { itemType: 'blogPost', attachments: [12] });
+
+            const response = await handleResolvePopulationRequest(makeRequest({
+                conditions: [{ field: 'publisher', operator: 'is', value: '' }],
+                item_category: 'attachment',
+            }));
+
+            expect(response.item_ids).toEqual(['u-ATT11']);
+            expect(response.matched_item_count).toBe(1);
         });
     });
 

--- a/tests/unit/utils/batchFindExistingReferences.test.ts
+++ b/tests/unit/utils/batchFindExistingReferences.test.ts
@@ -364,12 +364,12 @@ describe('batchFindExistingReferences — deleted / wrong-type items skipped', (
 
 describe('batchFindExistingReferences — mapped title field', () => {
     it('finds items whose title is stored in a title-mapped field (not the base title field)', async () => {
-        // Seed an item whose title lives in the `publicationTitle` field
-        // (a field that `getTypeFieldsFromBase('title')` returns in the
-        // test setup). The real code path queries all title-mapped field IDs.
+        // Seed an item whose title lives in the `caseName` field — one of the
+        // fields Zotero maps onto the base `title`. The real code path queries
+        // all title-mapped field IDs.
         await seedZoteroItem(conn, ctx, {
             title: 'Journal Title As Title',
-            titleFieldName: 'publicationTitle',
+            titleFieldName: 'caseName',
             creators: ['Editor'],
         });
 
@@ -382,7 +382,7 @@ describe('batchFindExistingReferences — mapped title field', () => {
 
 describe('batchFindExistingReferences — date field precedence', () => {
     it('prefers base date over mapped date fields regardless of row order', async () => {
-        // Seed an item that has BOTH a base 'date' and a mapped 'filingDate'.
+        // Seed an item that has BOTH a base 'date' and a mapped 'dateDecided'.
         // findMatchInCandidates parses the year from whatever meta.date
         // contains — the year check tolerates ±1, so we pick values that
         // differ by more than 1 so the wrong choice would reject the match.
@@ -390,7 +390,7 @@ describe('batchFindExistingReferences — date field precedence', () => {
             title: 'Dated Work',
             creators: ['Author'],
             date: '2020',
-            filingDate: '2010',
+            dateDecided: '2010',
         });
 
         // Input claims 2020 — should match only if base 'date' (2020) wins.


### PR DESCRIPTION
…conditions

- Introduced new functions to manage item type restrictions based on empty-value conditions, ensuring accurate filtering of item types that can hold specific fields.
- Added constants for non-bibliographic item types and refined the logic for determining valid item types based on field presence.
- Updated tests to validate the behavior of item type filtering under various conditions, ensuring robustness in handling empty-value checks.
- Enhanced the seeding process for tests to include item type IDs, improving the accuracy of test scenarios.