### PR TITLE
Redirect read on a stored table to read_table

### DIFF
--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -883,6 +883,7 @@ export type ZoteroDocumentErrorCode =
     | 'library_excluded'    // Attachment is in a library the user excluded from Beaver
     | 'library_unavailable' // Attachment is in a library unavailable on this computer
     | 'document_too_large'  // Serialized extraction result exceeds the WebSocket transfer budget
+    | 'beaver_table'        // The item is a Beaver table; `error` names its portable id so the backend can redirect to read_table
     | 'schema_version_mismatch'
     | 'mode_mismatch';
 

--- a/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
+++ b/src/services/agentDataProvider/handleZoteroDocumentRequest.ts
@@ -44,12 +44,16 @@ import {
     validateZoteroItemReference,
 } from './utils';
 import { EXTERNAL_LIBRARY_ID, resolveExternalFile } from '../externalFiles';
+// Identification only — `tableItemIdentity` is the esbuild-safe half of the
+// stored-table subsystem (see its module comment); `tableItem`/`tableStore`
+// must never be imported from here.
+import { isTableItem } from '../artifacts/tableItemIdentity';
 import { effectiveMaxFileSizeMB } from '@beaver/agent-core/transport/attachmentLimits';
 import { withWorkerDiagnostics } from './workerDiagnostics';
 import type { ExternalFileRecord } from '../database';
 import { serializeAttachmentStub, serializeItemStub } from '../../utils/zoteroSerializers';
 import { getBestAttachmentBatch } from '../documentExtraction/attachmentInfoBatch';
-import { libraryRefForLibraryID, modelObjectIdFromReference } from '../../utils/libraryIdentity';
+import { libraryRefForLibraryID, modelObjectId } from '../../utils/libraryIdentity';
 import {
     createPreparedJsonMessage,
     type PreparedJsonMessage,
@@ -378,6 +382,21 @@ export async function handleZoteroDocumentRequest(
         }
 
         const { item: resolvedItem, key: resolvedKey, contentKind, contentType } = resolved;
+
+        // A Beaver table is a snapshot attachment, so search surfaces it and the
+        // model reads it like any other document. Extracting it would hand back
+        // the rendered HTML instead of the table, so answer with the table's
+        // handle and let the backend point at `read_table`. A table is always a
+        // top-level attachment, so it is the requested item and `loadAllData`
+        // above has loaded the tags and `itemData` that `isTableItem` reads.
+        if (contentKind === 'snapshot' && isTableItem(resolvedItem)) {
+            const handle = modelObjectId(resolvedItem.libraryID, resolvedItem.key);
+            return errorResponse(
+                `Attachment '${handle}' is a Beaver table, not a readable document.`,
+                'beaver_table',
+            );
+        }
+
         timeoutContentKind = readableToExtractKind(contentKind);
         // View-row metadata for the backend tool-result view (parent-centric
         // display + the served file's own name/content_kind). Both are optional;

--- a/tests/unit/handlers/handleZoteroDocumentRequest.tableRedirect.test.ts
+++ b/tests/unit/handlers/handleZoteroDocumentRequest.tableRedirect.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `read` on a stored table: a Beaver table is a snapshot attachment, so search
+ * surfaces it and the model tries to read it like any other document. The
+ * handler must answer with the table's handle and the `beaver_table` code
+ * instead of extracting the rendered HTML.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The handler module's import chain reaches supabaseClient (which throws
+// without env config) — stub it and its store dependencies like the
+// companion handler tests do.
+vi.mock('@beaver/agent-core/transport/supabaseClient', () => ({
+    supabase: { auth: { getSession: vi.fn() } },
+}));
+vi.mock('../../../react/store', () => ({
+    store: { get: vi.fn(), set: vi.fn() },
+}));
+vi.mock('../../../react/atoms/profile', () => ({
+    searchableLibraryIdsAtom: { toString: () => 'searchableLibraryIdsAtom' },
+}));
+
+vi.mock('../../../src/services/documentExtraction', async () => {
+    const actual = await vi.importActual<typeof import('../../../src/services/documentExtraction')>(
+        '../../../src/services/documentExtraction',
+    );
+    return {
+        ...actual,
+        resolveToReadableAttachment: vi.fn(),
+        validateZoteroItemReference: vi.fn(() => null),
+    };
+});
+
+import { handleZoteroDocumentRequest } from '../../../src/services/agentDataProvider/handleZoteroDocumentRequest';
+import { resolveToReadableAttachment } from '../../../src/services/documentExtraction';
+import { getReadableContentKind } from '../../../src/services/documentExtraction/attachmentResolution';
+import { TABLE_TAG, TABLE_URL_PREFIX } from '../../../src/services/artifacts/tableItemIdentity';
+
+/** An item that satisfies the real `isTableItem` marks. */
+function makeTableItem(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 7,
+        key: 'TBL12345',
+        libraryID: 1,
+        attachmentLinkMode: (globalThis as any).Zotero.Attachments.LINK_MODE_IMPORTED_URL,
+        attachmentContentType: 'text/html',
+        isAttachment: () => true,
+        isTopLevelItem: () => true,
+        isPDFAttachment: () => false,
+        hasTag: (tag: string) => tag === TABLE_TAG,
+        getField: (field: string) => (field === 'url' ? `${TABLE_URL_PREFIX}my-table` : ''),
+        loadAllData: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function documentRequest() {
+    return {
+        event: 'zotero_document_request' as const,
+        request_id: 'req-table',
+        attachment: { library_id: 1, zotero_key: 'TBL12345' },
+        mode: 'structured' as const,
+    };
+}
+
+describe('handleZoteroDocumentRequest table redirect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (globalThis as any).Zotero.Libraries.userLibraryID = 1;
+        (globalThis as any).Zotero.Items = {
+            getByLibraryAndKeyAsync: vi.fn().mockResolvedValue(makeTableItem()),
+        };
+        vi.mocked(resolveToReadableAttachment).mockImplementation(
+            async (item: any) =>
+                ({
+                    resolved: true,
+                    item,
+                    key: '1-TBL12345',
+                    contentKind: 'snapshot',
+                    contentType: 'text/html',
+                }) as any,
+        );
+    });
+
+    it('answers a table item with beaver_table and its portable handle', async () => {
+        const response = await handleZoteroDocumentRequest(documentRequest());
+
+        expect(response).toMatchObject({
+            type: 'zotero_document',
+            request_id: 'req-table',
+            error_code: 'beaver_table',
+        });
+        expect(response.error).toContain('u-TBL12345');
+        expect(response.error).toContain('Beaver table');
+    });
+
+    // The redirect is guarded on `contentKind === 'snapshot'`, so a table that
+    // classified as anything else would silently fall through to extraction.
+    it('classifies a table item as a snapshot', () => {
+        expect(getReadableContentKind(makeTableItem() as any)).toBe('snapshot');
+    });
+
+    it('leaves an ordinary snapshot attachment on the extraction path', async () => {
+        // Same item without the tag: not one of ours, so the redirect must not fire.
+        (globalThis as any).Zotero.Items.getByLibraryAndKeyAsync = vi
+            .fn()
+            .mockResolvedValue(makeTableItem({ hasTag: () => false }));
+
+        const response = await handleZoteroDocumentRequest(documentRequest());
+
+        expect(response.error_code).not.toBe('beaver_table');
+    });
+});


### PR DESCRIPTION
A Beaver table is a snapshot attachment, so search surfaces it and the model reads it like any other document. The document handler now recognises one after resolution and answers with the new beaver_table error code plus the table's portable id, instead of handing back the rendered snapshot HTML.