### PR TITLE
feat(identity): support portable Zotero library references

### DIFF
--- a/packages/agent-core/src/agents/agentActionTypes.ts
+++ b/packages/agent-core/src/agents/agentActionTypes.ts
@@ -1,4 +1,5 @@
 import { ZoteroItemReference } from '../types/zotero';
+import { hasLibraryIdentity } from '../identity/libraryRef';
 import {
     ActionStatus,
     ActionType,
@@ -224,12 +225,21 @@ export type EditAnnotationsAgentAction = AgentAction & {
 };
 
 /**
- * Check if an agent action has been applied and has a Zotero item reference
+ * Check if an agent action has been applied and has a Zotero item reference.
+ *
+ * The library is tested through `hasLibraryIdentity`, not for a truthy rowid:
+ * `toAgentAction` normalizes an absent `library_id` to `UNRESOLVED_LIBRARY_ID`
+ * (`0`), so an applied action the backend named portably would otherwise read
+ * as having no item at all — its title would never load, and
+ * `validateAppliedAction` would report it valid without checking anything.
  */
 export const hasAppliedZoteroItem = (action: AgentAction): boolean => {
     return action.status === 'applied' &&
            !!action.result_data?.zotero_key &&
-           !!action.result_data?.library_id;
+           hasLibraryIdentity({
+               library_id: action.result_data?.library_id,
+               library_ref: action.result_data?.library_ref,
+           });
 };
 
 export const hasAppliedBulkAnnotations = (action: AgentAction): boolean => {

--- a/packages/agent-core/src/identity/libraryRef.ts
+++ b/packages/agent-core/src/identity/libraryRef.ts
@@ -53,6 +53,42 @@ export function parseLibraryRef(ref: string): ParsedLibraryRef | null {
  */
 export const UNRESOLVED_LIBRARY_ID = 0;
 
+/**
+ * Whether a reference names a library at all — a valid portable `library_ref`,
+ * or a positive device-local `library_id`.
+ *
+ * A portable-only reference is a complete identity on the wire: the rowid is
+ * this device's business alone, so it may arrive absent or as
+ * {@link UNRESOLVED_LIBRARY_ID}. Guards that only test `library_id` reject
+ * such a reference — use this instead.
+ */
+export function hasLibraryIdentity(ref: {
+    library_ref?: string | null;
+    library_id?: number | null;
+}): boolean {
+    if (ref.library_ref && parseLibraryRef(ref.library_ref)) return true;
+    return typeof ref.library_id === 'number'
+        && Number.isInteger(ref.library_id)
+        && ref.library_id > 0;
+}
+
+/**
+ * The library half of a dedup/map key for a reference.
+ *
+ * Mirrors how `resolveLibraryRef` decides identity: only a grammar-valid
+ * `library_ref` names the library portably, and anything else — absent, empty,
+ * or malformed — falls back to the device-local rowid. Keying on a `library_ref`
+ * the resolver would ignore is what collapses two references that load
+ * *different* items onto one entry, where the later one silently wins.
+ */
+export function libraryKeyToken(ref: {
+    library_ref?: string | null;
+    library_id?: number | null;
+}): string {
+    if (ref.library_ref && parseLibraryRef(ref.library_ref)) return ref.library_ref;
+    return String(ref.library_id ?? UNRESOLVED_LIBRARY_ID);
+}
+
 /** A model-facing item id parsed into its portable-or-legacy library reference + key. */
 export type ParsedItemReference = { library_ref?: string; library_id?: number; zotero_key: string };
 

--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -470,8 +470,12 @@ export interface ExternalReferenceCheckItem {
 export interface WSExternalReferenceCheckRequest extends WSBaseEvent {
     event: 'external_reference_check_request';
     request_id: string;
-    /** Library IDs to search in. If not provided, search all libraries. */
-    library_ids?: number[];
+    /**
+     * Libraries to search in, as portable library tokens (`"u"` / `"g<groupID>"`),
+     * library names, or legacy device-local numeric ids. If not provided, search
+     * every library the user has not excluded from Beaver.
+     */
+    library_ids?: Array<number | string>;
     /** References to check */
     items: ExternalReferenceCheckItem[];
 }
@@ -1398,7 +1402,7 @@ export interface WSZoteroSearchResponse {
     total_count: number;
     error?: string | null;
     error_code?: string | null;
-    /** Available libraries (only included when error_code is 'library_not_found') */
+    /** Available libraries (only included when error_code is 'library_not_found' or 'library_unavailable') */
     available_libraries?: AvailableLibraryInfo[] | null;
     /** Non-fatal warnings (e.g., conditions Zotero rejected). Search still executed. */
     warnings?: string[] | null;
@@ -1446,7 +1450,7 @@ export interface WSListItemsResponse {
     collection_name?: string | null;
     error?: string | null;
     error_code?: string | null;
-    /** Available libraries (only included when error_code is 'library_not_found') */
+    /** Available libraries (only included when error_code is 'library_not_found' or 'library_unavailable') */
     available_libraries?: AvailableLibraryInfo[] | null;
 }
 
@@ -1620,7 +1624,7 @@ export interface WSResolvePopulationResponse {
     any_conditions_applied?: boolean | null;
     error?: string | null;
     error_code?: string | null;
-    /** Available libraries (only included when error_code is 'library_not_found') */
+    /** Available libraries (only included when error_code is 'library_not_found' or 'library_unavailable') */
     available_libraries?: AvailableLibraryInfo[] | null;
     /**
      * Unused by this response: a condition Zotero refuses fails the whole
@@ -1785,7 +1789,7 @@ export interface WSListCollectionsResponse {
     library_name?: string | null;
     error?: string | null;
     error_code?: string | null;
-    /** Available libraries (only included when error_code is 'library_not_found') */
+    /** Available libraries (only included when error_code is 'library_not_found' or 'library_unavailable') */
     available_libraries?: AvailableLibraryInfo[] | null;
 }
 
@@ -1865,7 +1869,7 @@ export interface WSListTagsResponse {
     library_name?: string | null;
     error?: string | null;
     error_code?: string | null;
-    /** Available libraries (only included when error_code is 'library_not_found') */
+    /** Available libraries (only included when error_code is 'library_not_found' or 'library_unavailable') */
     available_libraries?: AvailableLibraryInfo[] | null;
 }
 

--- a/packages/agent-core/src/types/zotero.ts
+++ b/packages/agent-core/src/types/zotero.ts
@@ -28,6 +28,18 @@ export interface ZoteroLibrary {
  */
 export interface ZoteroItemReference {
     zotero_key: string;
+    /**
+     * Device-local Zotero library rowid, or `UNRESOLVED_LIBRARY_ID` (`0`) when
+     * the sender has no rowid to give — which is every reference a backend
+     * sends once it stops mapping portable refs onto this device's ids.
+     *
+     * `0` is the wire form for "unresolved", not an omitted field: keeping this
+     * required means a reference always carries both names of its library, and
+     * a consumer that reads only the rowid fails loudly rather than silently
+     * targeting `undefined`. `library_ref` is the identity and wins wherever
+     * the two disagree — resolve with `resolveLibraryRef`, and guard with
+     * `hasLibraryIdentity` rather than testing `library_id` for truthiness.
+     */
     library_id: number;
     /** Device-portable library identity ("u" | "g<groupID>") */
     library_ref?: string;

--- a/packages/agent-ui/src/host/types.ts
+++ b/packages/agent-ui/src/host/types.ts
@@ -452,8 +452,15 @@ export interface PendingApproval {
  * parts and forwards the target, and the host resolves it to a real note.
  */
 export interface EditNoteResolvedTarget {
+    /** Device-local library rowid, or `0` when the library is not on this device. */
     libraryId: number;
     zoteroKey: string;
+    /**
+     * Device-portable library identity ("u" / "g<groupID>") when the target was
+     * named portably. Zotero keys are unique only within a library, so this is
+     * what tells two unavailable libraries apart — their rowids are both `0`.
+     */
+    libraryRef?: string;
 }
 
 /**

--- a/react/agents/agentActionCounts.ts
+++ b/react/agents/agentActionCounts.ts
@@ -1,4 +1,5 @@
 import type { AgentAction } from './agentActions';
+import { hasLibraryIdentity } from '@beaver/agent-core/identity/libraryRef';
 
 /**
  * Count user-visible PDF annotations represented by an applied action.
@@ -27,10 +28,16 @@ export function getAppliedPdfAnnotationCount(action: AgentAction): number {
         return proposedItems.length;
     }
 
+    // Mirrors `hasAppliedZoteroItem` in agentActionTypes.ts, including its
+    // library test: a truthy rowid would miss an applied item the backend
+    // named portably, and the count would then disagree with the undo list.
     const hasAppliedZoteroItem =
         action.status === 'applied' &&
         Boolean(action.result_data?.zotero_key) &&
-        Boolean(action.result_data?.library_id);
+        hasLibraryIdentity({
+            library_id: action.result_data?.library_id,
+            library_ref: action.result_data?.library_ref,
+        });
 
     if (
         hasAppliedZoteroItem &&

--- a/react/agents/agentActions.ts
+++ b/react/agents/agentActions.ts
@@ -3,7 +3,7 @@ import { logger } from '@beaver/agent-core/platform/logger';
 import { isLibraryReferencePortable, resolveItemReference, resolveLibraryRef } from '../../src/utils/libraryIdentity';
 import { checkLibraryExcluded } from '../../src/services/agentDataProvider/utils';
 import { dismissDiffPreview } from '../utils/noteEditorDiffPreview';
-import { updateDiffPreviewForNote, diffPreviewNoteKeyAtom } from '../utils/diffPreviewCoordinator';
+import { updateDiffPreviewForNote, noteLibraryIdFromActionData, diffPreviewNoteKeyAtom } from '../utils/diffPreviewCoordinator';
 import { agentActionsService, AckActionLink } from '@beaver/agent-core/transport/clients/agentActionsService';
 import { notifyApprovalRequest } from '../../src/services/systemNotifications';
 import type { ZoteroItemReference } from '@beaver/agent-core/types/zotero';
@@ -514,9 +514,12 @@ export const addPendingApprovalAtom = atom(
 
         // Trigger in-editor diff preview for edit_note / edit_note_batch approvals
         if (event.action_type === 'edit_note' || event.action_type === 'edit_note_batch') {
-            const { library_id, zotero_key } = event.action_data || {};
-            if (library_id != null && zotero_key) {
-                updateDiffPreviewForNote(library_id, zotero_key);
+            // The target may be named portably only, so resolve the library
+            // rather than reading the numeric id off the event.
+            const libraryId = noteLibraryIdFromActionData(event.action_data);
+            const zoteroKey = event.action_data?.zotero_key;
+            if (libraryId != null && zoteroKey) {
+                updateDiffPreviewForNote(libraryId, zoteroKey);
             }
         }
 
@@ -542,7 +545,7 @@ export const removePendingApprovalsAtom = atom(
         for (const actionId of ids) {
             const removed = prev.get(actionId);
             if (removed?.actionType !== 'edit_note' && removed?.actionType !== 'edit_note_batch') continue;
-            const libraryId = removed.actionData?.library_id;
+            const libraryId = noteLibraryIdFromActionData(removed.actionData);
             const zoteroKey = removed.actionData?.zotero_key;
             if (libraryId == null || !zoteroKey) continue;
             affectedNotes.set(`${libraryId}-${zoteroKey}`, { libraryId, zoteroKey });

--- a/react/atoms/runApprovalPolicy.ts
+++ b/react/atoms/runApprovalPolicy.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai';
 import type { AgentActionType } from '@beaver/agent-core/protocol/agentProtocol';
+import { resolveLibraryRef } from '../../src/utils/libraryIdentity';
 
 /**
  * Stable groups for actual deferred tool names. These seed persistent
@@ -177,11 +178,17 @@ function getNoteEditTarget(actionData?: Record<string, any>): {
     libraryId: number;
     zoteroKey: string;
 } | null {
-    const libraryId = actionData?.library_id;
     const zoteroKey = actionData?.zotero_key;
-    return typeof libraryId === 'number' && Number.isFinite(libraryId) && typeof zoteroKey === 'string' && zoteroKey
-        ? { libraryId, zoteroKey }
-        : null;
+    if (typeof zoteroKey !== 'string' || !zoteroKey) return null;
+    // The grant is recorded against the created note's device-local library, so
+    // resolve the request's identity to the same form. `library_ref` is the
+    // portable identity and wins; the numeric `library_id` may be absent or the
+    // unresolved sentinel, which must not silently key a different resource.
+    const libraryId = resolveLibraryRef({
+        library_ref: actionData?.library_ref,
+        library_id: actionData?.library_id,
+    });
+    return libraryId && libraryId > 0 ? { libraryId, zoteroKey } : null;
 }
 
 /** Transient approval grants for the active run. Never persisted to prefs. */

--- a/react/components/agentRuns/editNoteShared.ts
+++ b/react/components/agentRuns/editNoteShared.ts
@@ -2,7 +2,7 @@ import { ToolCallPart } from '@beaver/agent-core/agents/types';
 import type { ToolCallStatus } from '@beaver/agent-core/run-state/atoms';
 import type { AgentAction } from '../../agents/agentActions';
 import type { EditNoteResolvedTarget, PendingApproval } from '@beaver/agent-ui/host';
-import { resolveObjectId } from '../../../src/utils/libraryIdentity';
+import { parseLibraryRef, resolveLibraryRef, resolveObjectId, UNRESOLVED_LIBRARY_ID } from '../../../src/utils/libraryIdentity';
 
 export type EditNoteDisplayStatus =
     | 'awaiting'
@@ -13,7 +13,10 @@ export type EditNoteDisplayStatus =
     | 'error';
 
 export type EditNoteTarget =
-    | { kind: 'known'; libraryId: number; zoteroKey: string }
+    // Reuses `EditNoteResolvedTarget` rather than restating its fields, so a
+    // field added there (e.g. the portable `libraryRef`) cannot be silently
+    // dropped on the way through the grouping pass.
+    | ({ kind: 'known' } & EditNoteResolvedTarget)
     | { kind: 'pending' }
     | null;
 
@@ -147,20 +150,77 @@ export function resolveEditNoteTargetFromData(
     if (typeof noteId === 'string' && noteId) {
         const ref = resolveObjectId(noteId);
         if (ref) {
-            return { libraryId: ref.library_id, zoteroKey: ref.zotero_key };
+            return {
+                libraryId: ref.library_id,
+                zoteroKey: ref.zotero_key,
+                ...(ref.library_ref ? { libraryRef: ref.library_ref } : {}),
+            };
         }
     }
 
-    const libRaw = parsedArgs.library_id;
     const keyRaw = parsedArgs.zotero_key;
-    const libraryId = typeof libRaw === 'number'
+    if (typeof keyRaw !== 'string' || !keyRaw) return null;
+
+    // The portable `library_ref` is the identity and wins; the numeric
+    // `library_id` may be absent or the unresolved sentinel, so it cannot be
+    // read on its own.
+    //
+    // A library this device doesn't have still yields a target, carrying
+    // `UNRESOLVED_LIBRARY_ID` — the same shape the `note_id` branch above
+    // produces for `g<groupID>-KEY`. The target is an identity, and dropping it
+    // would fold this note's edits into the neighbouring note's group
+    // (`buildEditNoteRenderItems` treats a missing target as "still streaming").
+    // Callers gate their Zotero lookups on `isOpenableEditNoteTarget` instead.
+    const libRaw = parsedArgs.library_id;
+    const numericLibraryId = typeof libRaw === 'number'
         ? libRaw
         : (typeof libRaw === 'string' ? parseInt(libRaw, 10) : NaN);
-    if (Number.isFinite(libraryId) && typeof keyRaw === 'string' && keyRaw) {
-        return { libraryId, zoteroKey: keyRaw };
+    const libraryId = resolveLibraryRef({
+        library_ref: parsedArgs.library_ref,
+        library_id: Number.isFinite(numericLibraryId) ? numericLibraryId : null,
+    });
+    const libraryRef = typeof parsedArgs.library_ref === 'string' && parseLibraryRef(parsedArgs.library_ref)
+        ? parsedArgs.library_ref
+        : undefined;
+    if (libraryId && libraryId > 0) {
+        return { libraryId, zoteroKey: keyRaw, ...(libraryRef ? { libraryRef } : {}) };
     }
-
+    if (libraryRef) {
+        return { libraryId: UNRESOLVED_LIBRARY_ID, zoteroKey: keyRaw, libraryRef };
+    }
     return null;
+}
+
+/**
+ * Whether two resolved targets name the same note.
+ *
+ * A rowid identifies a library only when the library is on this device. When
+ * either side is unresolved its rowid is the `UNRESOLVED_LIBRARY_ID` sentinel,
+ * which every unavailable library shares — and Zotero keys are unique only
+ * within a library, so comparing the sentinel would merge two genuinely
+ * different notes. The portable ref is the only thing that separates them.
+ */
+export function sameEditNoteTarget(
+    a: EditNoteResolvedTarget,
+    b: EditNoteResolvedTarget,
+): boolean {
+    if (a.zoteroKey !== b.zoteroKey) return false;
+    if (a.libraryId > 0 && b.libraryId > 0) return a.libraryId === b.libraryId;
+    return a.libraryRef === b.libraryRef;
+}
+
+/**
+ * Whether a resolved target names a note this device can actually open.
+ *
+ * A target may carry `UNRESOLVED_LIBRARY_ID`: it identifies the note, but its
+ * library is not on this computer, so every `Zotero.Items` lookup keyed on it
+ * silently misses. Gate open/preview affordances on this rather than on the
+ * target's mere presence, or the UI offers buttons that do nothing.
+ */
+export function isOpenableEditNoteTarget(
+    target: EditNoteResolvedTarget | null | undefined,
+): target is EditNoteResolvedTarget {
+    return target != null && target.libraryId > 0;
 }
 
 export function findPendingApprovalForToolcall(
@@ -277,31 +337,23 @@ export function buildEditNoteRenderItems(parts: ToolCallPart[]): EditNoteRenderI
     for (const part of parts) {
         const target = getEditNoteTarget(part);
         if (target?.kind === 'known') {
+            // Strip the discriminant; the portable ref must survive, or two
+            // unavailable libraries become indistinguishable further down.
+            const resolved: EditNoteResolvedTarget = {
+                libraryId: target.libraryId,
+                zoteroKey: target.zoteroKey,
+                ...(target.libraryRef ? { libraryRef: target.libraryRef } : {}),
+            };
             if (runParts.length === 0) {
                 runParts = [part];
-                runTarget = {
-                    libraryId: target.libraryId,
-                    zoteroKey: target.zoteroKey,
-                };
-            } else if (
-                runTarget === null
-                || (
-                    runTarget.libraryId === target.libraryId
-                    && runTarget.zoteroKey === target.zoteroKey
-                )
-            ) {
+                runTarget = resolved;
+            } else if (runTarget === null || sameEditNoteTarget(runTarget, resolved)) {
                 runParts.push(part);
-                runTarget = runTarget ?? {
-                    libraryId: target.libraryId,
-                    zoteroKey: target.zoteroKey,
-                };
+                runTarget = runTarget ?? resolved;
             } else {
                 flushRun();
                 runParts = [part];
-                runTarget = {
-                    libraryId: target.libraryId,
-                    zoteroKey: target.zoteroKey,
-                };
+                runTarget = resolved;
             }
         } else if (target?.kind === 'pending') {
             runParts.push(part);

--- a/react/host/zotero/components/AgentActionView.tsx
+++ b/react/host/zotero/components/AgentActionView.tsx
@@ -30,7 +30,7 @@ import {
     undoAgentActionsAtom,
 } from '../agentActionExecution';
 import { shortItemTitle } from '../../../../src/utils/zoteroUtils';
-import { resolveItemReference, resolveLibraryRef } from '../../../../src/utils/libraryIdentity';
+import { hasLibraryIdentity, resolveItemReference, resolveLibraryRef } from '../../../../src/utils/libraryIdentity';
 import { notifyReferenceUnavailable } from '../sourceActions';
 import {
     TickIcon,
@@ -215,7 +215,10 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
                 action?.proposed_data?.zotero_key ??
                 pendingApproval?.actionData?.zotero_key;
 
-            if (!libraryId || !zoteroKey) return;
+            // A portable `library_ref` is a complete identity: the numeric id may
+            // be absent or the unresolved sentinel, and `resolveItemReference`
+            // prefers the ref anyway.
+            if (!hasLibraryIdentity({ library_ref: libraryRef, library_id: libraryId }) || !zoteroKey) return;
 
             const resolved = await resolveItemReference({ library_ref: libraryRef, library_id: libraryId, zotero_key: zoteroKey });
             if (resolved.status === 'found') {
@@ -437,10 +440,15 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
         const libraryId = action?.result_data?.library_id;
         const zoteroKey = action?.result_data?.zotero_key;
         const libraryRef = action?.result_data?.library_ref;
-        if (!libraryId || !zoteroKey) return;
+        if (!zoteroKey || !hasLibraryIdentity({ library_id: libraryId, library_ref: libraryRef })) return;
+        // The collection lookup is a local query, so it needs this device's
+        // rowid; `revealSource` resolves the reference itself.
+        const resolvedLibraryId = resolveLibraryRef({ library_ref: libraryRef, library_id: libraryId });
         // Reveal within the current collection when the note belongs to it,
         // instead of switching to the library root.
-        const collectionKey = await getCurrentCollectionKeyForItem(libraryId, zoteroKey);
+        const collectionKey = resolvedLibraryId
+            ? await getCurrentCollectionKeyForItem(resolvedLibraryId, zoteroKey)
+            : undefined;
         revealSource({ library_id: libraryId, zotero_key: zoteroKey, library_ref: libraryRef }, collectionKey);
     }, [action]);
 
@@ -475,7 +483,12 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
             matches: () => (
                 toolName === 'create_note' &&
                 action?.status === 'applied' &&
-                !!action?.result_data?.library_id &&
+                // The click handler resolves through `library_ref`, so gate on
+                // library identity rather than a rowid the result may not carry.
+                hasLibraryIdentity({
+                    library_id: action?.result_data?.library_id,
+                    library_ref: action?.result_data?.library_ref,
+                }) &&
                 !!action?.result_data?.zotero_key
             ),
             tooltip: 'Open note',
@@ -519,7 +532,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
             zotero_key: action?.proposed_data?.zotero_key,
             library_ref: action?.proposed_data?.library_ref,
         };
-        if (!revealRef.library_id || !revealRef.zotero_key) return null;
+        if (!hasLibraryIdentity(revealRef) || !revealRef.zotero_key) return null;
 
         return {
             tooltip: 'Reveal in Zotero',
@@ -738,7 +751,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
                             </Button>
                         )}
 
-                        {toolName === 'create_note' && action?.status === 'applied' && action?.result_data?.library_id && action?.result_data?.zotero_key && (
+                        {toolName === 'create_note' && action?.status === 'applied' && hasLibraryIdentity({ library_id: action?.result_data?.library_id, library_ref: action?.result_data?.library_ref }) && action?.result_data?.zotero_key && (
                             <Button
                                 variant="outline"
                                 onClick={handleRevealNote}

--- a/react/host/zotero/components/EditNoteGroupView.tsx
+++ b/react/host/zotero/components/EditNoteGroupView.tsx
@@ -77,6 +77,7 @@ import {
     getEditNoteGroupExpansionKey,
     getOverallEditNoteDisplayStatus,
     isEditNoteStreamingPlaceholder,
+    isOpenableEditNoteTarget,
     parseEditNoteToolCallArgs,
     resolveEditNoteTargetFromData,
 } from '../../../components/agentRuns/editNoteShared';
@@ -642,8 +643,8 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
             logger(`EditNoteGroupView: handlePreviewInEditor — aborting, diff preview not live (kill switch off or Zotero 7)`, 1);
             return;
         }
-        if (!resolvedTarget) {
-            logger(`EditNoteGroupView: handlePreviewInEditor — aborting, no resolvedTarget for ${noteKeyLabel}`, 1);
+        if (!isOpenableEditNoteTarget(resolvedTarget)) {
+            logger(`EditNoteGroupView: handlePreviewInEditor — aborting, no openable resolvedTarget for ${noteKeyLabel}`, 1);
             return;
         }
         const edits = hasPendingApprovals
@@ -751,7 +752,9 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
         !isProcessing
         && isDiffPreviewLive()
         && (
-        resolvedTarget !== null
+        // Openable, not merely identified: the preview opens the note in the
+        // editor, which a library this computer doesn't have cannot do.
+        isOpenableEditNoteTarget(resolvedTarget)
         && (hasPendingApprovals || reapplicableActions.length > 0)
         );
 
@@ -793,7 +796,7 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
                                 <>
                                     <span className="font-color-secondary ml-15">{noteTitle}</span>
                                     {'\u00A0'}
-                                    {resolvedTarget && (
+                                    {isOpenableEditNoteTarget(resolvedTarget) && (
                                         <Tooltip content="Open note" singleLine>
                                             <span
                                                 className="font-color-secondary scale-10"

--- a/react/host/zotero/components/useEditNoteActions.ts
+++ b/react/host/zotero/components/useEditNoteActions.ts
@@ -38,6 +38,7 @@ import {
     getEffectiveEditNotePendingApproval,
     isEditNoteOrphaned,
     isEditNoteStreamingPlaceholder,
+    isOpenableEditNoteTarget,
     parseEditNoteToolCallArgs,
     resolveEditNoteTargetFromData,
     type EditNoteRowDescriptor,
@@ -409,7 +410,7 @@ export function useEditNoteActions({
     }, [action, handleUndo, runApply]);
 
     const handleOpenNote = useCallback(async () => {
-        if (!resolvedTarget) return;
+        if (!isOpenableEditNoteTarget(resolvedTarget)) return;
         const editData = action?.proposed_data ?? pendingApproval?.actionData;
 
         if (editData) {
@@ -437,7 +438,7 @@ export function useEditNoteActions({
      * and undo contexts are joined from the action payload by edit index.
      */
     const handleOpenNoteForRow = useCallback(async (row: EditNoteRowDescriptor) => {
-        if (!resolvedTarget) return;
+        if (!isOpenableEditNoteTarget(resolvedTarget)) return;
         const batchData = action?.proposed_data ?? pendingApproval?.actionData;
         const edits: any[] = Array.isArray(batchData?.edits) ? batchData.edits : [];
         const fullEdit = row.editIndex !== null
@@ -478,7 +479,9 @@ export function useEditNoteActions({
         showReject,
         showUndo,
         showRetry,
-        showOpenNoteAction: resolvedTarget !== null,
+        // Not merely "we know which note": a note in a library this computer
+        // doesn't have cannot be opened, and offering the button would do nothing.
+        showOpenNoteAction: isOpenableEditNoteTarget(resolvedTarget),
         openNoteTooltip: action || pendingApproval ? 'Open note and jump to edit' : 'Open note',
         handleApprove,
         handleReject,

--- a/react/utils/agentActionUtils.ts
+++ b/react/utils/agentActionUtils.ts
@@ -20,7 +20,37 @@ import { saveStreamingNote } from './noteActions';
 import { currentThreadIdAtom } from '../atoms/threads';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { parseZoteroId } from '@beaver/agent-core/citations/citationGrammar';
-import { libraryRefForLibraryID, resolveItemReference, resolveWriteTargetLibrary } from '../../src/utils/libraryIdentity';
+import { hasLibraryIdentity, libraryKeyToken, libraryRefForLibraryID, resolveItemReference, resolveWriteTargetLibrary, UNRESOLVED_LIBRARY_ID } from '../../src/utils/libraryIdentity';
+
+/**
+ * Add a `{library_ref?, library_id?, zotero_key}` reference to the dedup map,
+ * ignoring anything that names no library or no key.
+ *
+ * Keyed on the portable `library_ref` when there is one: an unresolved ref
+ * collapses `library_id` to the sentinel, so two references from different
+ * libraries would otherwise dedup onto the same entry and one item would be
+ * loaded for the other.
+ */
+function addItemReference(
+    refs: Map<string, ZoteroItemReference>,
+    source: { library_id?: unknown; library_ref?: unknown },
+    zoteroKey: unknown,
+): void {
+    if (typeof zoteroKey !== 'string' || !zoteroKey) return;
+    const libraryId = typeof source.library_id === 'number' ? source.library_id : undefined;
+    const libraryRef = typeof source.library_ref === 'string' && source.library_ref
+        ? source.library_ref
+        : undefined;
+    if (!hasLibraryIdentity({ library_id: libraryId, library_ref: libraryRef })) return;
+
+    const key = `${libraryKeyToken({ library_ref: libraryRef, library_id: libraryId })}-${zoteroKey}`;
+    if (refs.has(key)) return;
+    refs.set(key, {
+        library_id: libraryId ?? UNRESOLVED_LIBRARY_ID,
+        zotero_key: zoteroKey,
+        ...(libraryRef ? { library_ref: libraryRef } : {}),
+    });
+}
 
 /**
  * Extract all Zotero item references from agent actions that need to be loaded.
@@ -35,36 +65,12 @@ export function extractItemReferencesFromAgentActions(actions: AgentAction[]): Z
     for (const action of actions) {
         // For annotation actions, extract attachment reference from proposed_data
         if (isAnnotationAgentAction(action)) {
-            const libraryId = action.proposed_data.library_id;
-            const attachmentKey = action.proposed_data.attachment_key;
-            const libraryRef = action.proposed_data.library_ref;
-            if (typeof libraryId === 'number' && typeof attachmentKey === 'string' && attachmentKey) {
-                const key = `${libraryId}-${attachmentKey}`;
-                if (!refs.has(key)) {
-                    refs.set(key, {
-                        library_id: libraryId,
-                        zotero_key: attachmentKey,
-                        ...(typeof libraryRef === 'string' && libraryRef ? { library_ref: libraryRef } : {}),
-                    });
-                }
-            }
+            addItemReference(refs, action.proposed_data, action.proposed_data.attachment_key);
         }
 
         // For zotero_note actions with existing item reference in proposed_data
         if (isZoteroNoteAgentAction(action)) {
-            const libraryId = action.proposed_data.library_id;
-            const zoteroKey = action.proposed_data.zotero_key;
-            const libraryRef = action.proposed_data.library_ref;
-            if (typeof libraryId === 'number' && typeof zoteroKey === 'string' && zoteroKey) {
-                const key = `${libraryId}-${zoteroKey}`;
-                if (!refs.has(key)) {
-                    refs.set(key, {
-                        library_id: libraryId,
-                        zotero_key: zoteroKey,
-                        ...(typeof libraryRef === 'string' && libraryRef ? { library_ref: libraryRef } : {}),
-                    });
-                }
-            }
+            addItemReference(refs, action.proposed_data, action.proposed_data.zotero_key);
         }
 
         // For create_note actions with parent item reference in proposed_data
@@ -75,7 +81,7 @@ export function extractItemReferencesFromAgentActions(actions: AgentAction[]): Z
                 // Key on library_ref when available: an unresolved portable ref
                 // collapses library_id to UNRESOLVED_LIBRARY_ID, and two refs from
                 // different groups would otherwise collide on the same key.
-                const key = `${parsedParent.library_ref ?? parsedParent.library_id}-${parsedParent.zotero_key}`;
+                const key = `${libraryKeyToken(parsedParent)}-${parsedParent.zotero_key}`;
                 if (!refs.has(key)) {
                     refs.set(key, parsedParent);
                 }
@@ -84,19 +90,7 @@ export function extractItemReferencesFromAgentActions(actions: AgentAction[]): Z
 
         // For applied actions, extract the created item reference from result_data
         if (hasAppliedZoteroItem(action)) {
-            const libraryId = action.result_data!.library_id;
-            const zoteroKey = action.result_data!.zotero_key;
-            const libraryRef = action.result_data!.library_ref;
-            if (typeof libraryId === 'number' && typeof zoteroKey === 'string' && zoteroKey) {
-                const key = `${libraryId}-${zoteroKey}`;
-                if (!refs.has(key)) {
-                    refs.set(key, {
-                        library_id: libraryId,
-                        zotero_key: zoteroKey,
-                        ...(typeof libraryRef === 'string' && libraryRef ? { library_ref: libraryRef } : {}),
-                    });
-                }
-            }
+            addItemReference(refs, action.result_data!, action.result_data!.zotero_key);
         }
     }
 

--- a/react/utils/createItemActions.ts
+++ b/react/utils/createItemActions.ts
@@ -11,7 +11,7 @@ import { applyCreateItemData } from './addItemActions';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { ensureItemSynced } from '../../src/utils/sync';
 import { scheduleBackgroundTask, generateTaskId, cancelTasksForItem, deduplicatedSync } from '../../src/utils/backgroundTasks';
-import { resolveItemReference, resolveWriteTargetLibrary } from '../../src/utils/libraryIdentity';
+import { hasLibraryIdentity, modelObjectIdFromReference, resolveItemReference, resolveLibraryRef, resolveWriteTargetLibrary } from '../../src/utils/libraryIdentity';
 
 /** Maximum concurrent item creations in batch jobs */
 const BATCH_CONCURRENCY_LIMIT = 3;
@@ -92,14 +92,20 @@ function scheduleSyncTask(libraryId: number, itemKey: string): void {
 export async function undoCreateItemAction(action: AgentAction): Promise<void> {
     const resultData = action.result_data as CreateItemResultData | undefined;
 
-    if (!resultData?.library_id || !resultData?.zotero_key) {
+    // A portable `library_ref` is a complete reference; the numeric id may be
+    // the unresolved sentinel. `resolveItemReference` below prefers the ref
+    // anyway, so rejecting on the rowid alone fails an undo that would work.
+    if (!resultData?.zotero_key || !hasLibraryIdentity(resultData)) {
         throw new Error('Cannot undo: no result data available (item was not created)');
     }
 
-    logger(`undoCreateItemAction: Deleting item ${resultData.library_id}-${resultData.zotero_key}`, 1);
+    logger(`undoCreateItemAction: Deleting item ${modelObjectIdFromReference(resultData)}`, 1);
 
-    // Cancel any background tasks (PDF fetch, sync) for this item before deletion
-    cancelTasksForItem(resultData.library_id, resultData.zotero_key);
+    // Cancel any background tasks (PDF fetch, sync) for this item before
+    // deletion. Task keys are device-local, so resolve the ref to this
+    // device's rowid rather than passing the wire value through.
+    const taskLibraryId = resolveLibraryRef(resultData);
+    if (taskLibraryId) cancelTasksForItem(taskLibraryId, resultData.zotero_key);
 
     const resolved = await resolveItemReference(resultData);
 

--- a/react/utils/createNoteActions.ts
+++ b/react/utils/createNoteActions.ts
@@ -14,7 +14,7 @@ import { wrapWithSchemaVersion, getBeaverNoteFooterHTML } from './noteActions';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { resolveCreateNoteParent } from '../../src/services/agentDataProvider/actions/resolveCreateNoteParent';
 import { getCollectionByIdOrName } from '../../src/services/agentDataProvider/utils';
-import { libraryRefForLibraryID, resolveItemReference, resolveWriteTargetLibrary } from '../../src/utils/libraryIdentity';
+import { hasLibraryIdentity, libraryRefForLibraryID, resolveItemReference, resolveWriteTargetLibrary } from '../../src/utils/libraryIdentity';
 
 
 export interface CreateNoteResultData {
@@ -254,7 +254,10 @@ export async function executeCreateNoteAction(action: AgentAction, runId?: strin
  */
 export async function undoCreateNoteAction(action: AgentAction): Promise<void> {
     const resultData = action.result_data as CreateNoteResultData | undefined;
-    if (!resultData?.library_id || !resultData?.zotero_key) {
+    // A portable `library_ref` is a complete reference; the numeric id may be
+    // the unresolved sentinel. `resolveItemReference` below prefers the ref
+    // anyway, so rejecting on the rowid alone fails an undo that would work.
+    if (!resultData?.zotero_key || !hasLibraryIdentity(resultData)) {
         throw new Error('Cannot undo: no result data with note reference');
     }
 

--- a/react/utils/diffPreviewCoordinator.ts
+++ b/react/utils/diffPreviewCoordinator.ts
@@ -32,6 +32,7 @@ import { store } from '../store';
 import { pendingApprovalsAtom } from '../agents/agentActions';
 import { sendApprovalResponseAtom } from '../atoms/agentRunAtoms';
 import { buildPreviewableEditOperations } from './editNotePreviewOperations';
+import { resolveLibraryRef } from '../../src/utils/libraryIdentity';
 
 /**
  * Convenience gate that combines the user preference and the runtime
@@ -73,6 +74,25 @@ function makeNoteKey(libraryId: number, zoteroKey: string): string {
     return `${libraryId}-${zoteroKey}`;
 }
 
+/**
+ * The device-local library id an edit_note approval targets, or null when it
+ * names no library this device has.
+ *
+ * The portable `library_ref` is the identity and wins; the numeric `library_id`
+ * is a same-device cache of it that may be absent or the unresolved sentinel.
+ * Everything below this point (note keys, `isNoteInSelectedTab`, the editor
+ * preview itself) works in rowids, so resolve once here rather than threading
+ * the pair through.
+ */
+export function noteLibraryIdFromActionData(actionData: any): number | null {
+    if (!actionData) return null;
+    const libraryId = resolveLibraryRef({
+        library_ref: actionData.library_ref,
+        library_id: actionData.library_id,
+    });
+    return libraryId && libraryId > 0 ? libraryId : null;
+}
+
 // =============================================================================
 // Coordinator
 // =============================================================================
@@ -92,7 +112,7 @@ export function updateDiffPreviewForNote(libraryId: number, zoteroKey: string): 
     const edits: EditOperation[] = [];
     for (const [, pa] of allApprovals) {
         if (pa.actionType !== 'edit_note' && pa.actionType !== 'edit_note_batch') continue;
-        const paLib = pa.actionData?.library_id;
+        const paLib = noteLibraryIdFromActionData(pa.actionData);
         const paKey = pa.actionData?.zotero_key;
         if (paLib == null || !paKey || makeNoteKey(paLib, paKey) !== noteKey) continue;
 
@@ -148,7 +168,7 @@ async function handleBannerAction(action: string): Promise<void> {
         if (pa.actionType !== 'edit_note' && pa.actionType !== 'edit_note_batch') continue;
         // Only act on approvals for the previewed note
         if (previewKey) {
-            const paLib = pa.actionData?.library_id;
+            const paLib = noteLibraryIdFromActionData(pa.actionData);
             const paKey = pa.actionData?.zotero_key;
             if (paLib !== previewKey.libraryId || paKey !== previewKey.zoteroKey) continue;
         }

--- a/src/services/agentDataProvider/actions/annotationPlacement.ts
+++ b/src/services/agentDataProvider/actions/annotationPlacement.ts
@@ -13,7 +13,7 @@ import {
     type AnnotationPlacement,
 } from "../../annotations/createAnnotation";
 import { getReadableContentKind } from "../../documentExtraction/attachmentResolution";
-import { modelObjectId, resolveLibraryRef } from "../../../utils/libraryIdentity";
+import { modelObjectId, modelObjectIdFromReference, resolveLibraryRef } from "../../../utils/libraryIdentity";
 
 /** Annotation types a move can reposition. */
 export type RelocatableAnnotationType = "highlight" | "note";
@@ -44,11 +44,14 @@ function assertSameAttachment(
         targetLibraryId === attachment.libraryID &&
         relocation.attachment_ref.zotero_key === attachment.key;
     if (!matches) {
+        // Name the attachment portably: an unresolvable ref leaves
+        // `targetLibraryId` null, and the request's own numeric id may be the
+        // unresolved sentinel, neither of which means anything to the model.
+        const label = targetLibraryId !== null
+            ? modelObjectId(targetLibraryId, relocation.attachment_ref.zotero_key)
+            : modelObjectIdFromReference(relocation.attachment_ref);
         throw new RelocationMismatchError(
-            `is not on attachment ${modelObjectId(
-                targetLibraryId ?? relocation.attachment_ref.library_id,
-                relocation.attachment_ref.zotero_key,
-            )}; an annotation cannot move to a different document`,
+            `is not on attachment ${label}; an annotation cannot move to a different document`,
         );
     }
 }

--- a/src/services/agentDataProvider/actions/createHighlightAnnotations.ts
+++ b/src/services/agentDataProvider/actions/createHighlightAnnotations.ts
@@ -28,7 +28,7 @@ import type { ZoteroItemReference } from '@beaver/agent-core/types/zotero';
 import { normalizePageLocations } from '@beaver/agent-core/types/agentActions/annotations';
 import { normalizeAnnotationTags } from '@beaver/agent-core/types/agentActions/createAnnotations';
 import { shortItemTitle } from '../../../utils/zoteroUtils';
-import { libraryRefForLibraryID, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
+import { hasLibraryIdentity, libraryRefForLibraryID, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
 import { logger } from '@beaver/agent-core/platform/logger';
 
 function mapAnnotationErrorCode(error: unknown): string {
@@ -93,7 +93,9 @@ function normalizeItem(raw: any): HighlightAnnotationItem {
 }
 
 async function resolveAttachment(ref: ZoteroItemReference): Promise<Zotero.Item | null> {
-    if (!ref.library_id || !ref.zotero_key) return null;
+    // A portable `library_ref` is a complete target on its own, so the numeric
+    // `library_id` may legitimately be the unresolved sentinel.
+    if (!hasLibraryIdentity(ref) || !ref.zotero_key) return null;
     const resolved = await resolveItemReference(ref);
     return resolved.status === 'found' ? resolved.item : null;
 }
@@ -122,7 +124,7 @@ export async function validateCreateHighlightAnnotationsAction(
     const data = getActionData(request);
     const { requested_ref, resolved_ref, items } = data;
 
-    if (!resolved_ref.library_id || !resolved_ref.zotero_key) {
+    if (!hasLibraryIdentity(resolved_ref) || !resolved_ref.zotero_key) {
         return {
             type: 'agent_action_validate_response',
             request_id: request.request_id,
@@ -154,6 +156,19 @@ export async function validateCreateHighlightAnnotationsAction(
             valid: false,
             error: excluded.message,
             error_code: 'library_not_searchable',
+            preference: 'always_ask',
+        };
+    }
+    // A portable ref this device cannot map is a missing library, not a bad
+    // attachment: say so instead of letting the lookup below fail as
+    // "not a local PDF or EPUB attachment".
+    if (targetLibraryId === null) {
+        return {
+            type: 'agent_action_validate_response',
+            request_id: request.request_id,
+            valid: false,
+            error: `The library (${resolved_ref.library_ref}) holding this attachment is not available on this computer.`,
+            error_code: 'library_unavailable',
             preference: 'always_ask',
         };
     }
@@ -259,6 +274,15 @@ export async function executeCreateHighlightAnnotationsAction(
             success: false,
             error: targetExcluded.message,
             error_code: 'library_not_searchable',
+        };
+    }
+    if (targetLibraryId === null) {
+        return {
+            type: 'agent_action_execute_response',
+            request_id: request.request_id,
+            success: false,
+            error: `The library (${resolved_ref.library_ref}) holding this attachment is not available on this computer.`,
+            error_code: 'library_unavailable',
         };
     }
     const attachment = await resolveAttachment(resolved_ref);

--- a/src/services/agentDataProvider/actions/createNote.ts
+++ b/src/services/agentDataProvider/actions/createNote.ts
@@ -323,6 +323,9 @@ async function validateCreateNoteAction(
         const libraryResult = getLibraryByIdOrName(libraryNameOrId);
         if (libraryResult.wasExplicitlyRequested && !libraryResult.library) {
             ta.record('library_resolution_ms', Date.now() - tLib);
+            // A portable token that doesn't resolve means this computer is not
+            // a member of that library, not that no such library exists.
+            const { portableRef } = libraryResult;
             return {
                 type: 'agent_action_validate_response',
                 request_id: request.request_id,
@@ -330,8 +333,10 @@ async function validateCreateNoteAction(
                 // Do not list library names: getAll() includes libraries the
                 // user excluded from Beaver, so echoing them would leak
                 // excluded (private) libraries to the model.
-                error: `Library not found: "${libraryNameOrId}". Omit the library parameter to use the default library.`,
-                error_code: 'library_not_found',
+                error: portableRef
+                    ? `The library "${portableRef}" is not available on this computer.`
+                    : `Library not found: "${libraryNameOrId}". Omit the library parameter to use the default library.`,
+                error_code: portableRef ? 'library_unavailable' : 'library_not_found',
                 preference: 'always_ask',
                 timing: buildTiming(),
             };

--- a/src/services/agentDataProvider/actions/createNoteAnnotations.ts
+++ b/src/services/agentDataProvider/actions/createNoteAnnotations.ts
@@ -26,7 +26,7 @@ import type { ZoteroItemReference } from '@beaver/agent-core/types/zotero';
 import { normalizeNotePosition } from '@beaver/agent-core/types/agentActions/annotations';
 import { normalizeAnnotationTags } from '@beaver/agent-core/types/agentActions/createAnnotations';
 import { shortItemTitle } from '../../../utils/zoteroUtils';
-import { libraryRefForLibraryID, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
+import { hasLibraryIdentity, libraryRefForLibraryID, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
 import { logger } from '@beaver/agent-core/platform/logger';
 
 function mapAnnotationErrorCode(error: unknown): string {
@@ -102,7 +102,9 @@ function normalizeItem(raw: any): NoteAnnotationItem {
 }
 
 async function resolveAttachment(ref: ZoteroItemReference): Promise<Zotero.Item | null> {
-    if (!ref.library_id || !ref.zotero_key) return null;
+    // A portable `library_ref` is a complete target on its own, so the numeric
+    // `library_id` may legitimately be the unresolved sentinel.
+    if (!hasLibraryIdentity(ref) || !ref.zotero_key) return null;
     const resolved = await resolveItemReference(ref);
     return resolved.status === 'found' ? resolved.item : null;
 }
@@ -131,7 +133,7 @@ export async function validateCreateNoteAnnotationsAction(
     const data = getActionData(request);
     const { requested_ref, resolved_ref, items } = data;
 
-    if (!resolved_ref.library_id || !resolved_ref.zotero_key) {
+    if (!hasLibraryIdentity(resolved_ref) || !resolved_ref.zotero_key) {
         return {
             type: 'agent_action_validate_response',
             request_id: request.request_id,
@@ -163,6 +165,19 @@ export async function validateCreateNoteAnnotationsAction(
             valid: false,
             error: excluded.message,
             error_code: 'library_not_searchable',
+            preference: 'always_ask',
+        };
+    }
+    // A portable ref this device cannot map is a missing library, not a bad
+    // attachment: say so instead of letting the lookup below fail as
+    // "not a local PDF or EPUB attachment".
+    if (targetLibraryId === null) {
+        return {
+            type: 'agent_action_validate_response',
+            request_id: request.request_id,
+            valid: false,
+            error: `The library (${resolved_ref.library_ref}) holding this attachment is not available on this computer.`,
+            error_code: 'library_unavailable',
             preference: 'always_ask',
         };
     }
@@ -268,6 +283,15 @@ export async function executeCreateNoteAnnotationsAction(
             success: false,
             error: targetExcluded.message,
             error_code: 'library_not_searchable',
+        };
+    }
+    if (targetLibraryId === null) {
+        return {
+            type: 'agent_action_execute_response',
+            request_id: request.request_id,
+            success: false,
+            error: `The library (${resolved_ref.library_ref}) holding this attachment is not available on this computer.`,
+            error_code: 'library_unavailable',
         };
     }
     const attachment = await resolveAttachment(resolved_ref);

--- a/src/services/agentDataProvider/handleExternalReferenceCheckRequest.ts
+++ b/src/services/agentDataProvider/handleExternalReferenceCheckRequest.ts
@@ -16,7 +16,7 @@ import {
     ExternalReferenceCheckResult,
 
 } from '@beaver/agent-core/protocol/agentProtocol';
-import { getSearchableLibraryIds } from './utils';
+import { getSearchableLibraryIds, resolveLibrariesFilterToSearchableIds } from './utils';
 import { libraryRefForLibraryID } from '../../utils/libraryIdentity';
 
 
@@ -36,13 +36,14 @@ import { libraryRefForLibraryID } from '../../utils/libraryIdentity';
 export async function handleExternalReferenceCheckRequest(request: WSExternalReferenceCheckRequest): Promise<WSExternalReferenceCheckResponse> {
     const startTime = Date.now();
 
-    // Determine which libraries to search. Never search libraries the user
+    // Determine which libraries to search. `library_ids` entries are resolved
+    // through the shared filter resolver, so a portable library token
+    // ("u" / "g<groupID>") is a complete identity here — the backend never has
+    // to map one onto a device-local rowid. Never search libraries the user
     // excluded from Beaver.
-    const searchableLibraryIds = getSearchableLibraryIds();
-    const requestedLibraryIds = request.library_ids && request.library_ids.length > 0
-        ? request.library_ids
-        : searchableLibraryIds;
-    const libraryIds: number[] = requestedLibraryIds.filter(id => searchableLibraryIds.includes(id));
+    const libraryIds: number[] = request.library_ids && request.library_ids.length > 0
+        ? resolveLibrariesFilterToSearchableIds(request.library_ids)
+        : getSearchableLibraryIds();
 
     // Convert request items to batch format
     const batchItems: BatchReferenceCheckItem[] = request.items.map(item => ({

--- a/src/services/agentDataProvider/lookupZoteroReferences.ts
+++ b/src/services/agentDataProvider/lookupZoteroReferences.ts
@@ -6,7 +6,7 @@
  */
 
 import { logger } from '@beaver/agent-core/platform/logger';
-import { libraryRefForLibraryID, modelObjectId, resolveItemReference, resolveLibraryRef } from '../../utils/libraryIdentity';
+import { libraryKeyToken, libraryRefForLibraryID, modelObjectId, resolveItemReference, resolveLibraryRef } from '../../utils/libraryIdentity';
 import { ItemDataWithStatus, AttachmentDataWithStatus, ZoteroItemReference, ItemStub } from '@beaver/agent-core/types/zotero';
 import { searchableLibraryIdsAtom, syncWithZoteroAtom } from '../../../react/atoms/profile';
 import { userIdAtom } from '../../../react/atoms/auth';
@@ -84,6 +84,14 @@ export async function lookupZoteroReferences(
     const annotationsToSerialize: Zotero.Item[] = [];
 
     const makeKey = (libraryId: number, zoteroKey: string) => `${libraryId}-${zoteroKey}`;
+    // Request references are keyed by their portable identity: the backend may
+    // send `library_id: 0` (or omit it) for every portable ref, so keying on the
+    // rowid would collapse references from different libraries onto one entry.
+    // `libraryKeyToken` honors the ref only when it parses, exactly as the
+    // resolution below does — a malformed ref shared by two legacy references
+    // would otherwise collapse them while they still load different items.
+    const requestKey = (reference: ZoteroItemReference) =>
+        `${libraryKeyToken(reference)}-${reference.zotero_key}`;
 
     // Phase 1: Collect primary items from references IN PARALLEL
     const primaryItems: Zotero.Item[] = [];
@@ -124,8 +132,7 @@ export async function lookupZoteroReferences(
     for (const result of loadResults) {
         if ('item' in result && result.item) {
             primaryItems.push(result.item);
-            referenceToItem.set(makeKey(result.reference.library_id, result.reference.zotero_key), result.item);
-            referenceToItem.set(makeKey(result.item.libraryID, result.item.key), result.item);
+            referenceToItem.set(requestKey(result.reference), result.item);
         } else if ('error' in result) {
             errors.push({
                 reference: result.reference,
@@ -149,7 +156,7 @@ export async function lookupZoteroReferences(
 
     // First pass: collect IDs and categorize items
     for (const reference of references) {
-        const zoteroItem = referenceToItem.get(makeKey(reference.library_id, reference.zotero_key));
+        const zoteroItem = referenceToItem.get(requestKey(reference));
         if (!zoteroItem) continue;
 
         try {
@@ -256,7 +263,7 @@ export async function lookupZoteroReferences(
 
     // Second pass: add parents, attachments, and child notes using the pre-loaded items
     for (const reference of references) {
-        const zoteroItem = referenceToItem.get(makeKey(reference.library_id, reference.zotero_key));
+        const zoteroItem = referenceToItem.get(requestKey(reference));
         if (!zoteroItem) continue;
 
         try {

--- a/src/services/agentDataProvider/utils.ts
+++ b/src/services/agentDataProvider/utils.ts
@@ -16,6 +16,7 @@ import {
     parseItemReference,
     parseLibraryRef,
     resolveLibraryRef,
+    UNRESOLVED_LIBRARY_ID,
 } from '../../utils/libraryIdentity';
 import { syncingItemFilterAsync } from '../../utils/sync';
 import { getPref } from '../../utils/prefs';
@@ -509,6 +510,7 @@ export function getLibraryByIdOrName(libraryIdOrName: number | string | null | u
             library: lib || null,
             wasExplicitlyRequested: true,
             searchInput: libraryIdOrName,
+            portableRef: libraryIdOrName,
         };
     }
 
@@ -1322,7 +1324,13 @@ export function resolveLibrariesFilter(filters: Array<string | number>): Librari
         // explicit reference, so it must never reach a library the user excluded
         // from Beaver — enumerating one here would leak its name through the
         // exclusion message.
-        const needle = filter.toLowerCase();
+        // A blank needle would `includes()`-match every library, silently
+        // widening a filter that named nothing into "search everything".
+        const needle = filter.trim().toLowerCase();
+        if (!needle) {
+            unresolved.push(filter);
+            continue;
+        }
         const byName = Zotero.Libraries.getAll()
             .filter((lib) => searchableLibraryIds.includes(lib.libraryID)
                 && lib.name.toLowerCase().includes(needle))
@@ -1357,14 +1365,8 @@ export function librariesFilterError(
     if (resolution.unresolved.length > 0) {
         const label = resolution.unresolved.length === 1 ? 'Library not found' : 'Libraries not found';
         const names = resolution.unresolved.map((entry) => `"${entry}"`).join(', ');
-        const available = getSearchableLibraries()
-            .map((lib) => `"${lib.name}"${lib.library_ref ? ` (${lib.library_ref})` : ''}`)
-            .join(', ');
-        const availableNote = available
-            ? ` Available libraries: ${available}.`
-            : '';
         return {
-            message: `${label}: ${names}. Identify a library by its portable ref ("u" for the personal library, "g<groupID>" for a group).${availableNote}`,
+            message: `${label}: ${names}. Identify a library by its portable ref ("u" for the personal library, "g<groupID>" for a group).${availableLibrariesNote()}`,
             error_code: 'library_not_found',
         };
     }
@@ -1465,8 +1467,12 @@ export function preflightZoteroAttachmentRequest(
     attachment: ZoteroItemReference,
     validateReference: (reference: ZoteroItemReference) => string | null = validateAttachmentReference,
 ): ZoteroAttachmentRequestPreflight {
+    // Echo the identity the request carried, normalizing an omitted numeric id
+    // to the unresolved sentinel: a portable-only request carries no rowid, and
+    // the response reference is typed as if it always does.
     const responseAttachment = {
         ...attachment,
+        library_id: attachment.library_id ?? UNRESOLVED_LIBRARY_ID,
         library_ref:
             attachment.library_ref ??
             libraryRefForLibraryID(attachment.library_id) ??
@@ -1543,6 +1549,23 @@ export function getAvailableLibraries(): AvailableLibraryInfo[] {
 }
 
 /**
+ * The " Available libraries: …" sentence appended to a library error message,
+ * or `''` when there are none to name.
+ *
+ * Duplicates the `available_libraries` field, deliberately: a caller that does
+ * not recognize the error code drops the structured field but still relays the
+ * message, so the model keeps the hint it needs to correct the reference. Only
+ * searchable libraries are named — enumerating an excluded one would leak its
+ * name past the exclusion boundary.
+ */
+function availableLibrariesNote(): string {
+    const available = getSearchableLibraries()
+        .map((lib) => `"${lib.name}"${lib.library_ref ? ` (${lib.library_ref})` : ''}`)
+        .join(', ');
+    return available ? ` Available libraries: ${available}.` : '';
+}
+
+/**
  * Result of library lookup with validation information.
  */
 export interface LibraryLookupResult {
@@ -1552,12 +1575,22 @@ export interface LibraryLookupResult {
     wasExplicitlyRequested: boolean;
     /** The input that was used to search (for error messages) */
     searchInput: string | null;
+    /**
+     * The portable library token the caller used, when the input followed that
+     * grammar. Present whether or not it resolved, so a caller can tell "this
+     * device is not a member of that group" from "no such library".
+     */
+    portableRef?: string;
 }
 
 /**
  * Error codes for library validation failures.
  */
-export type LibraryValidationErrorCode = 'library_not_found' | 'library_not_searchable';
+export type LibraryValidationErrorCode =
+    | 'library_not_found'
+    | 'library_not_searchable'
+    /** A portable library token that names a library this device does not have. */
+    | 'library_unavailable';
 
 /**
  * Result of library validation with searchability check.
@@ -1585,12 +1618,20 @@ export interface LibraryValidationResult {
 export function validateLibraryAccess(libraryIdOrName: number | string | null | undefined): LibraryValidationResult {
     const lookupResult = getLibraryByIdOrName(libraryIdOrName);
     
-    // Check if library was found
+    // Check if library was found. A portable token that doesn't resolve means
+    // this computer is not a member of that library — not that no such library
+    // exists. Only the plugin can tell the two apart, so report them apart.
     if (lookupResult.wasExplicitlyRequested && !lookupResult.library) {
+        const { portableRef } = lookupResult;
         return {
             valid: false,
-            error: `Library not found: "${lookupResult.searchInput}"`,
-            error_code: 'library_not_found',
+            // `library_unavailable` is newer than the backend branches that read
+            // these codes, and an unrecognized code drops `available_libraries`
+            // while still relaying the message — so name them in the message too.
+            error: portableRef
+                ? `The library "${portableRef}" is not available on this computer.${availableLibrariesNote()}`
+                : `Library not found: "${lookupResult.searchInput}"`,
+            error_code: portableRef ? 'library_unavailable' : 'library_not_found',
             available_libraries: getSearchableLibraries(),
         };
     }

--- a/src/services/documentExtraction/referenceValidation.ts
+++ b/src/services/documentExtraction/referenceValidation.ts
@@ -1,11 +1,15 @@
-import { parseLibraryRef, UNRESOLVED_LIBRARY_ID } from '../../utils/libraryIdentity';
+import { hasLibraryIdentity } from '../../utils/libraryIdentity';
 
 /**
  * Validate the Zotero item reference shape used by document extraction.
  */
 export interface ZoteroItemReferenceInput {
-    /** Positive local id, or 0 when a portable library_ref must be resolved. */
-    library_id: number;
+    /**
+     * Device-local library rowid. Optional: a portable `library_ref` is a
+     * complete identity on its own, and such a request carries either no
+     * `library_id` at all or the `UNRESOLVED_LIBRARY_ID` sentinel.
+     */
+    library_id?: number | null;
     library_ref?: string | null;
     zotero_key: string;
 }
@@ -18,16 +22,9 @@ export interface ZoteroItemReferenceInput {
 export function validateZoteroItemReference(ref: ZoteroItemReferenceInput): string | null {
     const { library_id, library_ref, zotero_key } = ref;
 
-    const hasPositiveLibraryId = typeof library_id === 'number'
-        && Number.isFinite(library_id)
-        && library_id >= 1
-        && library_id === Math.floor(library_id);
-    const hasPortableUnresolvedLibrary = library_id === UNRESOLVED_LIBRARY_ID
-        && typeof library_ref === 'string'
-        && parseLibraryRef(library_ref) !== null;
-
-    if (!hasPositiveLibraryId && !hasPortableUnresolvedLibrary) {
-        return `Invalid library_id: '${library_id}'. Must be a positive integer, or 0 with a valid library_ref.`;
+    if (!hasLibraryIdentity({ library_id, library_ref })) {
+        return `Invalid library reference: library_ref '${library_ref}' / library_id '${library_id}'. `
+            + `Provide a valid library_ref ("u" or "g<groupID>"), or a positive library_id.`;
     }
 
     if (typeof zotero_key !== 'string' || !Zotero.Utilities.isValidObjectKey(zotero_key)) {

--- a/src/utils/libraryIdentity.ts
+++ b/src/utils/libraryIdentity.ts
@@ -27,6 +27,8 @@ export {
     LIBRARY_REF_PATTERN,
     parseLibraryRef,
     UNRESOLVED_LIBRARY_ID,
+    hasLibraryIdentity,
+    libraryKeyToken,
     parseItemReference,
     modelObjectIdFromReference,
     resolveObjectIdReference,

--- a/tests/unit/agents/agentActions.test.ts
+++ b/tests/unit/agents/agentActions.test.ts
@@ -88,6 +88,33 @@ describe('validateAppliedAgentAction', () => {
         expect(await validateAppliedAgentAction(appliedAction(5))).toBe('valid');
     });
 
+    // `toAgentAction` normalizes an absent `library_id` to the unresolved
+    // sentinel, so a portably-named applied action arrives as `library_id: 0`.
+    // A truthiness check on the rowid reads that as "no applied item" and
+    // reports the action valid without looking at anything.
+    it('still checks an applied item the backend named only by library_ref', async () => {
+        getByLibraryAndKeyAsync.mockResolvedValue(null);
+        expect(await validateAppliedAgentAction(appliedAction(0, {
+            result_data: { library_id: 0, library_ref: 'g50', zotero_key: 'AAAAAAA1' },
+        }))).toBe('invalid');
+        expect(getByLibraryAndKeyAsync).toHaveBeenCalledWith(5, 'AAAAAAA1');
+    });
+
+    it('still checks one that carries no library_id field at all', async () => {
+        getByLibraryAndKeyAsync.mockResolvedValue({ isAnnotation: () => false });
+        expect(await validateAppliedAgentAction(appliedAction(0, {
+            result_data: { library_ref: 'g50', zotero_key: 'AAAAAAA1' },
+        }))).toBe('valid');
+        expect(getByLibraryAndKeyAsync).toHaveBeenCalledWith(5, 'AAAAAAA1');
+    });
+
+    it('still treats a reference that names no library as having no applied item', async () => {
+        expect(await validateAppliedAgentAction(appliedAction(0, {
+            result_data: { library_id: 0, zotero_key: 'AAAAAAA1' },
+        }))).toBe('valid');
+        expect(getByLibraryAndKeyAsync).not.toHaveBeenCalled();
+    });
+
     it('returns unverifiable when a legacy group-library item (no library_ref) is not found', async () => {
         // A device-local group library_id is not a portable identity: a miss
         // may just mean that id maps to a different group here, so it must not

--- a/tests/unit/atoms/runApprovalPolicy.test.ts
+++ b/tests/unit/atoms/runApprovalPolicy.test.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'jotai';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     clearRunApprovalPolicyAtom,
     DEFAULT_DEFERRED_TOOL_GROUPS,
@@ -271,5 +271,85 @@ describe('runApprovalPolicy', () => {
                 destructive_rewrite: true,
             }),
         ).toBe(true);
+    });
+});
+
+describe('runApprovalPolicy with portable library identity', () => {
+    // The grant is always recorded from the created note's device-local library
+    // (`zoteroNote.libraryID`), but the approval event that follows names the
+    // note portably — with `library_id` absent or the unresolved sentinel once
+    // the backend stops pinning rowids. Group 555 lives at rowid 100 here.
+    let previousZotero: any;
+
+    beforeEach(() => {
+        previousZotero = (globalThis as any).Zotero;
+        (globalThis as any).Zotero = {
+            Libraries: { userLibraryID: 1 },
+            Groups: {
+                getLibraryIDFromGroupID: vi.fn((groupId: number) => (groupId === 555 ? 100 : false)),
+                getGroupIDFromLibraryID: vi.fn((libId: number) => (libId === 100 ? 555 : false)),
+            },
+        };
+    });
+
+    afterEach(() => {
+        (globalThis as any).Zotero = previousZotero;
+    });
+
+    function grantedPolicy(libraryId: number) {
+        const store = createStore();
+        store.set(grantCreatedNoteEditsForRunAtom, { runId: 'run-1', libraryId, zoteroKey: 'NOTE0001' });
+        return store.get(runApprovalPolicyAtom);
+    }
+
+    it('matches the grant when the edit names the note by library_ref alone', () => {
+        const policy = grantedPolicy(100);
+        expect(
+            isActionApprovedForCurrentRun(policy, 'run-1', 'edit_note', {
+                library_ref: 'g555',
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(true);
+        expect(
+            isActionApprovedForCurrentRun(policy, 'run-1', 'edit_note', {
+                library_ref: 'g555',
+                library_id: 0,
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(true);
+    });
+
+    it('lets library_ref win over a disagreeing numeric library_id', () => {
+        // Grant is for the personal library; the ref says so too, so a stale
+        // rowid on the event must not defeat it — nor create a match it shouldn't.
+        expect(
+            isActionApprovedForCurrentRun(grantedPolicy(1), 'run-1', 'edit_note', {
+                library_ref: 'u',
+                library_id: 100,
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(true);
+        expect(
+            isActionApprovedForCurrentRun(grantedPolicy(100), 'run-1', 'edit_note', {
+                library_ref: 'u',
+                library_id: 100,
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(false);
+    });
+
+    it('does not match when the reference names no library this device has', () => {
+        expect(
+            isActionApprovedForCurrentRun(grantedPolicy(100), 'run-1', 'edit_note', {
+                library_ref: 'g999999',
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(false);
+        expect(
+            isActionApprovedForCurrentRun(grantedPolicy(100), 'run-1', 'edit_note', {
+                library_id: 0,
+                zotero_key: 'NOTE0001',
+            }),
+        ).toBe(false);
     });
 });

--- a/tests/unit/handlers/actionLibraryExclusionOrdering.test.ts
+++ b/tests/unit/handlers/actionLibraryExclusionOrdering.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   resolveLibraryRef: vi.fn(),
 }));
 
-vi.mock("../../../src/utils/libraryIdentity", () => ({
+vi.mock("../../../src/utils/libraryIdentity", async () => ({
   libraryRefForLibraryID: vi.fn(() => null),
   modelObjectIdFromReference: vi.fn(
     ({ library_ref, library_id, zotero_key }) =>
@@ -14,6 +14,11 @@ vi.mock("../../../src/utils/libraryIdentity", () => ({
   ),
   resolveItemReference: mocks.resolveItemReference,
   resolveLibraryRef: mocks.resolveLibraryRef,
+  // The real predicate, not a stand-in: it decides whether a portable-only
+  // reference reaches the exclusion gate at all, so a stub would let a
+  // regression in the grammar check pass unnoticed.
+  hasLibraryIdentity: (await import("@beaver/agent-core/identity/libraryRef"))
+    .hasLibraryIdentity,
 }));
 
 vi.mock("../../../src/services/agentDataProvider/utils", () => ({
@@ -115,6 +120,9 @@ const annotationData = {
   items: [{ index: 0, client_item_id: "client-1" }],
 };
 
+/** The same target named portably only — what the backend sends once it stops pinning a rowid. */
+const portableOnlyReference = { library_ref: "g42", zotero_key: "ITEM1234" };
+
 const editNoteData = {
   ...reference,
   old_string: "before",
@@ -126,6 +134,19 @@ const editNoteBatchData = {
   ...reference,
   edits: [{ index: 0, old_string: "before", new_string: "after" }],
 };
+
+/** Same as `validationCases`, with every numeric `library_id` stripped from the action data. */
+function portableOnly(actionData: Record<string, any>): Record<string, any> {
+  if ("resolved_ref" in actionData) {
+    return {
+      ...actionData,
+      requested_ref: portableOnlyReference,
+      resolved_ref: portableOnlyReference,
+    };
+  }
+  const { library_id: _dropped, ...rest } = actionData;
+  return { ...rest, ...portableOnlyReference };
+}
 
 const validationCases = [
   [
@@ -191,6 +212,27 @@ describe("agent action library-exclusion ordering", () => {
         error_code: "library_not_searchable",
       });
       expect(mocks.resolveLibraryRef).toHaveBeenCalled();
+      expect(mocks.checkLibraryExcluded).toHaveBeenCalledWith(7);
+      expect(mocks.resolveItemReference).not.toHaveBeenCalled();
+    },
+  );
+
+  // A portable `library_ref` is a complete target: the identity guards must not
+  // bail out before the exclusion gate just because no rowid came with it.
+  it.each(validationCases)(
+    "reaches the %s exclusion gate with a portable-only reference",
+    async (actionType, validate, actionData) => {
+      const response = await validate({
+        event: "agent_action_validate",
+        request_id: `validate-portable-${actionType}`,
+        action_type: actionType,
+        action_data: portableOnly(actionData),
+      } as any);
+
+      expect(response).toMatchObject({
+        valid: false,
+        error_code: "library_not_searchable",
+      });
       expect(mocks.checkLibraryExcluded).toHaveBeenCalledWith(7);
       expect(mocks.resolveItemReference).not.toHaveBeenCalled();
     },

--- a/tests/unit/handlers/getLibraryByIdOrName.test.ts
+++ b/tests/unit/handlers/getLibraryByIdOrName.test.ts
@@ -173,8 +173,25 @@ describe('getLibraryByIdOrName / validateLibraryAccess', () => {
         const result = getLibraryByIdOrName('g999999');
         expect(result.library).toBeNull();
         expect(result.wasExplicitlyRequested).toBe(true);
+        expect(result.portableRef).toBe('g999999');
 
+        // A portable token this device can't map is "not available here", not
+        // "no such library" — only the plugin can tell the two apart.
         const validation = validateLibraryAccess('g999999');
+        expect(validation.valid).toBe(false);
+        expect(validation.error_code).toBe('library_unavailable');
+    });
+
+    it('does not let a blank library filter substring-match every library', () => {
+        // `''.includes()` is true for every name, so a blank needle would widen
+        // a filter that named nothing into "search everything".
+        expect(resolveLibrariesFilter(['']).libraryIds).toEqual([]);
+        expect(resolveLibrariesFilter(['   ']).libraryIds).toEqual([]);
+        expect(resolveLibrariesFilter(['']).unresolved).toEqual(['']);
+    });
+
+    it('reports an unknown library name as not found rather than unavailable', () => {
+        const validation = validateLibraryAccess('No Such Library');
         expect(validation.valid).toBe(false);
         expect(validation.error_code).toBe('library_not_found');
     });

--- a/tests/unit/handlers/handleExternalReferenceCheckRequest.test.ts
+++ b/tests/unit/handlers/handleExternalReferenceCheckRequest.test.ts
@@ -4,8 +4,8 @@
  * Mocks `batchFindExistingReferences` to verify:
  *   - timing fields propagate into the response
  *   - library_ids default to the searchable (non-excluded) libraries when empty
- *   - explicitly requested libraries are intersected with the searchable set so
- *     excluded libraries are never searched
+ *   - an explicit library_ids is handed to the shared filter resolver verbatim
+ *     (portable tokens included) and only its result is searched
  *   - a thrown error produces an all-null response (no reject)
  */
 
@@ -20,11 +20,13 @@ vi.mock('../../../react/utils/batchFindExistingReferences', () => ({
     batchFindExistingReferences: (...args: any[]) => mockBatchFindExistingReferences(...args),
 }));
 
-const { mockGetSearchableLibraryIds } = vi.hoisted(() => ({
+const { mockGetSearchableLibraryIds, mockResolveLibrariesFilterToSearchableIds } = vi.hoisted(() => ({
     mockGetSearchableLibraryIds: vi.fn(() => [1, 42] as number[]),
+    mockResolveLibrariesFilterToSearchableIds: vi.fn(),
 }));
 vi.mock('../../../src/services/agentDataProvider/utils', () => ({
     getSearchableLibraryIds: mockGetSearchableLibraryIds,
+    resolveLibrariesFilterToSearchableIds: mockResolveLibrariesFilterToSearchableIds,
 }));
 
 import { handleExternalReferenceCheckRequest } from '../../../src/services/agentDataProvider/handleExternalReferenceCheckRequest';
@@ -56,6 +58,8 @@ const baseRequest = {
 beforeEach(() => {
     mockBatchFindExistingReferences.mockReset();
     mockGetSearchableLibraryIds.mockReturnValue([1, 42]);
+    // Matches `baseRequest.library_ids`; cases that care set their own.
+    mockResolveLibrariesFilterToSearchableIds.mockReturnValue([1]);
 });
 
 afterEach(() => {
@@ -145,10 +149,14 @@ describe('handleExternalReferenceCheckRequest', () => {
         );
     });
 
-    it('drops excluded libraries from an explicitly requested library_ids list', async () => {
-        // Library 99 is excluded (absent from the searchable set) and must never
-        // be searched, even though the backend requested it explicitly.
-        mockGetSearchableLibraryIds.mockReturnValue([1]);
+    // The handler's own job for an explicit `library_ids` is to hand the entries
+    // to the shared resolver untouched and search exactly what comes back — it
+    // must not pre-filter, re-map, or widen. The resolver's own contract (portable
+    // tokens, numeric ids, names, and the intersection with the searchable set
+    // that keeps excluded libraries out) is pinned in getLibraryByIdOrName.test.ts.
+    it('forwards an explicit library_ids to the shared resolver verbatim and searches only its result', async () => {
+        mockGetSearchableLibraryIds.mockReturnValue([1, 42]);
+        mockResolveLibrariesFilterToSearchableIds.mockReturnValue([42]);
         mockBatchFindExistingReferences.mockResolvedValue({
             results: baseRequest.items.map(i => ({ id: i.id, item: null })),
             timing: {
@@ -158,13 +166,34 @@ describe('handleExternalReferenceCheckRequest', () => {
             },
         });
 
-        const req = { ...baseRequest, library_ids: [1, 99] };
+        // Portable token, legacy numeric id and a name in one request: none of
+        // them is the handler's to interpret.
+        const req = { ...baseRequest, library_ids: ['g555', 99, 'Group Alpha'] };
         await handleExternalReferenceCheckRequest(req as any);
 
-        expect(mockBatchFindExistingReferences).toHaveBeenCalledWith(
-            expect.any(Array),
-            [1]
-        );
+        expect(mockResolveLibrariesFilterToSearchableIds).toHaveBeenCalledWith(['g555', 99, 'Group Alpha']);
+        expect(mockGetSearchableLibraryIds).not.toHaveBeenCalled();
+        expect(mockBatchFindExistingReferences).toHaveBeenCalledWith(expect.any(Array), [42]);
+    });
+
+    it('searches nothing when an explicit library_ids resolves to nothing', async () => {
+        mockGetSearchableLibraryIds.mockReturnValue([1, 42]);
+        mockResolveLibrariesFilterToSearchableIds.mockReturnValue([]);
+        mockBatchFindExistingReferences.mockResolvedValue({
+            results: baseRequest.items.map(i => ({ id: i.id, item: null })),
+            timing: {
+                total_ms: 1, phase1_identifier_lookup_ms: 0, phase2_title_candidates_ms: 0,
+                phase3_fuzzy_matching_ms: 0, candidates_fetched: 0, matches_by_identifier: 0,
+                matches_by_fuzzy: 0,
+            },
+        });
+
+        // An unresolvable or fully excluded filter must narrow the search to
+        // nothing, never fall back to every searchable library.
+        const req = { ...baseRequest, library_ids: ['g999999'] };
+        await handleExternalReferenceCheckRequest(req as any);
+
+        expect(mockBatchFindExistingReferences).toHaveBeenCalledWith(expect.any(Array), []);
     });
 
     it('returns all items as not found and zero timing on batch failure', async () => {

--- a/tests/unit/handlers/lookupZoteroReferencesPortable.test.ts
+++ b/tests/unit/handlers/lookupZoteroReferencesPortable.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `zotero_data` requests carry portable references, not device-local rowids.
+ *
+ * Once the backend stops pinning a numeric `library_id`, every reference in one
+ * request arrives with the same `library_id: 0` sentinel and is told apart only
+ * by its `library_ref`. The lookup keys request references by that portable
+ * identity, so two items with the same `zotero_key` in different libraries do
+ * not collapse onto one map entry.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+
+const mocks = vi.hoisted(() => ({
+    storeGet: vi.fn(),
+}));
+
+vi.mock('../../../react/store', () => ({ store: { get: mocks.storeGet } }));
+vi.mock('../../../react/atoms/profile', () => ({
+    searchableLibraryIdsAtom: Symbol('searchableLibraryIdsAtom'),
+    syncWithZoteroAtom: Symbol('syncWithZoteroAtom'),
+}));
+vi.mock('../../../react/atoms/auth', () => ({ userIdAtom: Symbol('userIdAtom') }));
+
+vi.mock('../../../src/services/agentDataProvider/utils', () => ({
+    checkLibraryExcluded: vi.fn(() => null),
+    computeItemStatus: vi.fn(async () => 'in_library'),
+    prefetchSyncDates: vi.fn(async () => new Map()),
+    getAttachmentFileStatus: vi.fn(),
+    getAttachmentFileStatusLightweight: vi.fn(),
+    getBestAttachmentBatch: vi.fn(async () => new Map()),
+}));
+
+vi.mock('../../../src/utils/zoteroSerializers', () => ({
+    formatZoteroCreatorsString: vi.fn(() => ''),
+    getCreatorsFromItem: vi.fn(() => []),
+    getYearFromItem: vi.fn(() => null),
+    serializeAttachment: vi.fn(),
+    serializeAnnotation: vi.fn(),
+    // Enough to tell the two items apart in the response.
+    serializeItem: vi.fn(async (item: any) => ({
+        library_id: item.libraryID,
+        zotero_key: item.key,
+        title: item.title,
+    })),
+    serializeNote: vi.fn(),
+    serializeItemStub: vi.fn(),
+}));
+
+import { lookupZoteroReferences } from '../../../src/services/agentDataProvider/lookupZoteroReferences';
+
+// Group 555 -> local rowid 100, group 777 -> local rowid 300. Both hold an item
+// under the same key, which is exactly what a per-library key space allows.
+const SHARED_KEY = '3RRUYX5J';
+
+function regularItem(libraryID: number, title: string) {
+    return {
+        id: libraryID,
+        key: SHARED_KEY,
+        libraryID,
+        title,
+        parentID: null,
+        isAttachment: () => false,
+        isNote: () => false,
+        isAnnotation: () => false,
+        isRegularItem: () => true,
+        getAttachments: () => [],
+        getNotes: () => [],
+    };
+}
+
+const alphaItem = regularItem(100, 'Alpha paper');
+const excludedGroupItem = regularItem(300, 'Beta paper');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.storeGet.mockImplementation(() => [1, 100, 300]);
+    (globalThis as any).Zotero = {
+        Libraries: {
+            get: vi.fn((id: number) => ({ libraryID: id, name: `Library ${id}` })),
+            getAll: vi.fn(() => []),
+            userLibraryID: 1,
+        },
+        Groups: {
+            getGroupIDFromLibraryID: vi.fn((libId: number) =>
+                libId === 100 ? 555 : libId === 300 ? 777 : false),
+            getLibraryIDFromGroupID: vi.fn((groupId: number) =>
+                groupId === 555 ? 100 : groupId === 777 ? 300 : false),
+        },
+        Items: {
+            getByLibraryAndKeyAsync: vi.fn(async (libraryID: number, key: string) => {
+                if (key !== SHARED_KEY) return null;
+                if (libraryID === 100) return alphaItem;
+                if (libraryID === 300) return excludedGroupItem;
+                return null;
+            }),
+            loadDataTypes: vi.fn(async () => undefined),
+            getAsync: vi.fn(async () => []),
+        },
+    };
+});
+
+describe('lookupZoteroReferences with portable-only references', () => {
+    it('keeps same-key items in different libraries apart when no numeric id distinguishes them', async () => {
+        const result = await lookupZoteroReferences(
+            [
+                { library_id: 0, library_ref: 'g555', zotero_key: SHARED_KEY },
+                { library_id: 0, library_ref: 'g777', zotero_key: SHARED_KEY },
+            ],
+            { include_attachments: false, include_parents: false, include_notes: false, file_status_level: 'none' },
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.items.map(i => i.item.title).sort()).toEqual(['Alpha paper', 'Beta paper']);
+    });
+
+    it('keeps legacy references apart when they share a malformed library_ref', async () => {
+        // Historical threads still carry numeric library ids. `resolveLibraryRef`
+        // ignores a ref that does not parse and falls back to the rowid, so both
+        // of these load — from *different* libraries. A key that trusted the
+        // unparseable ref would collapse them and serialize one item twice.
+        const result = await lookupZoteroReferences(
+            [
+                { library_id: 100, library_ref: '', zotero_key: SHARED_KEY } as any,
+                { library_id: 300, library_ref: '', zotero_key: SHARED_KEY } as any,
+            ],
+            { include_attachments: false, include_parents: false, include_notes: false, file_status_level: 'none' },
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.items.map(i => i.item.title).sort()).toEqual(['Alpha paper', 'Beta paper']);
+    });
+
+    it('keeps them apart when the malformed ref is a non-empty bogus string', async () => {
+        const result = await lookupZoteroReferences(
+            [
+                { library_id: 100, library_ref: 'not-a-ref', zotero_key: SHARED_KEY } as any,
+                { library_id: 300, library_ref: 'not-a-ref', zotero_key: SHARED_KEY } as any,
+            ],
+            { include_attachments: false, include_parents: false, include_notes: false, file_status_level: 'none' },
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.items.map(i => i.item.title).sort()).toEqual(['Alpha paper', 'Beta paper']);
+    });
+
+    it('reports a group that is not on this device as library_unavailable', async () => {
+        const result = await lookupZoteroReferences(
+            [{ library_id: 0, library_ref: 'g999999', zotero_key: SHARED_KEY }],
+            { include_attachments: false, include_parents: false, include_notes: false, file_status_level: 'none' },
+        );
+
+        expect(result.items).toEqual([]);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].error_code).toBe('library_unavailable');
+    });
+});

--- a/tests/unit/handlers/portableIdentityInbound.test.ts
+++ b/tests/unit/handlers/portableIdentityInbound.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Portable identity is sufficient on every inbound backend -> plugin request.
+ *
+ * The backend must never have to turn `g5183253` into "library 3 on this Mac":
+ * a Zotero `libraryID` is a device-local SQLite rowid, and only the plugin can
+ * resolve one. These tests pin that contract on the seams every inbound request
+ * class goes through, each exercised with NO usable numeric `library_id`:
+ *
+ *   library scope        -> validateLibraryAccess / resolveLibrariesFilterToSearchableIds
+ *   item / attachment    -> validateZoteroItemReference + preflightZoteroAttachmentRequest
+ *   compound object ids  -> resolveObjectId
+ *   write actions        -> hasLibraryIdentity + resolveWriteTargetLibrary
+ *
+ * The module under test has a wide transitive dependency surface (document
+ * extraction, sync, popups, …) that none of these functions touch, so every
+ * unrelated dependency is stubbed out just to make it importable in isolation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({
+    logger: vi.fn(),
+}));
+vi.mock('../../../src/utils/zoteroUtils', () => ({
+    safeIsInTrash: vi.fn(),
+    safeFileExists: vi.fn(),
+    isLinkedUrlAttachment: vi.fn(),
+}));
+vi.mock('../../../src/utils/sync', () => ({
+    syncingItemFilterAsync: vi.fn(),
+}));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: vi.fn(),
+}));
+vi.mock('../../../src/utils/webAPI', () => ({
+    isAttachmentOnServer: vi.fn(),
+}));
+vi.mock('../../../react/utils/popupMessageUtils', () => ({
+    addPopupMessageAtom: {},
+}));
+vi.mock('../../../react/utils/sourceUtils', () => ({
+    wasItemAddedBeforeLastSync: vi.fn(),
+}));
+vi.mock('../../../react/atoms/deferredToolPreferences', () => ({
+    deferredToolPreferencesAtom: {},
+}));
+vi.mock('../../../src/utils/agentItemSupport', () => ({
+    isAgentSupportedItem: vi.fn(),
+}));
+vi.mock('../../../react/store', () => ({
+    store: { get: vi.fn() },
+}));
+vi.mock('@beaver/agent-core/run-state/atoms', () => ({
+    activeRunAtom: Symbol('activeRunAtom'),
+}));
+vi.mock('../../../react/atoms/profile', () => ({
+    searchableLibraryIdsAtom: Symbol('searchableLibraryIdsAtom'),
+    isLibraryAccessReadyAtom: Symbol('isLibraryAccessReadyAtom'),
+}));
+vi.mock('../../../src/services/documentExtraction/attachmentInfo', () => ({
+    getAttachmentInfo: vi.fn(),
+}));
+vi.mock('../../../src/services/documentExtraction/attachmentInfoBatch', () => ({
+    getBestAttachmentBatch: vi.fn(),
+    prepareAttachmentInfoBatchData: vi.fn(),
+    processAttachmentInfoBatch: vi.fn(),
+}));
+vi.mock('../../../src/services/documentExtraction', () => ({
+    loadPdfData: vi.fn(),
+    isRemoteAccessAvailable: vi.fn(),
+    validateZoteroItemReference: vi.fn(),
+    checkRemotePdfSize: vi.fn(),
+    preflightCachedPdfMeta: vi.fn(),
+    resolveToPdfAttachment: vi.fn(),
+    resolveToImageAttachment: vi.fn(),
+}));
+
+import { store } from '../../../react/store';
+import { isLibraryAccessReadyAtom, searchableLibraryIdsAtom } from '../../../react/atoms/profile';
+import {
+    preflightZoteroAttachmentRequest,
+    resolveLibrariesFilterToSearchableIds,
+    validateLibraryAccess,
+} from '../../../src/services/agentDataProvider/utils';
+// The real validator, not the barrel stub above: the attachment handlers pass
+// it into the preflight explicitly, so the portable-only path must be the real one.
+import { validateZoteroItemReference } from '../../../src/services/documentExtraction/referenceValidation';
+import {
+    hasLibraryIdentity,
+    resolveObjectId,
+    resolveWriteTargetLibrary,
+} from '../../../src/utils/libraryIdentity';
+
+// Group 555 is on this device (local rowid 100), group 777 is on it but
+// excluded from Beaver (rowid 300), and group 999999 is not here at all —
+// exactly the case a backend snapshot cannot distinguish.
+const userLibrary = { libraryID: 1, name: 'My Library' };
+const groupAlpha = { libraryID: 100, name: 'Group Alpha' };
+const groupExcluded = { libraryID: 300, name: 'Excluded Group' };
+const allLibraries = [userLibrary, groupAlpha, groupExcluded];
+
+function installZoteroMock() {
+    (globalThis as any).Zotero = {
+        Libraries: {
+            get: vi.fn((id: number) => allLibraries.find(l => l.libraryID === id) ?? false),
+            getAll: vi.fn(() => allLibraries),
+            userLibraryID: 1,
+            userLibrary,
+        },
+        Groups: {
+            getGroupIDFromLibraryID: vi.fn((libId: number) => {
+                if (libId === 100) return 555;
+                if (libId === 300) return 777;
+                return false;
+            }),
+            getLibraryIDFromGroupID: vi.fn((groupId: number) => {
+                if (groupId === 555) return 100;
+                if (groupId === 777) return 300;
+                return false;
+            }),
+        },
+        Utilities: {
+            isValidObjectKey: vi.fn((key: string) =>
+                /^[23456789ABCDEFGHIJKLMNPQRSTUVWXYZ]{8}$/.test(key)),
+        },
+        Items: { getByLibraryAndKeyAsync: vi.fn() },
+    };
+}
+
+let previousZotero: any;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    previousZotero = (globalThis as any).Zotero;
+    installZoteroMock();
+    vi.mocked(store.get).mockImplementation((atom: any) => {
+        if (atom === isLibraryAccessReadyAtom) return true;
+        if (atom === searchableLibraryIdsAtom) return [1, 100];
+        return undefined;
+    });
+});
+
+afterEach(() => {
+    (globalThis as any).Zotero = previousZotero;
+});
+
+describe('library-scope requests accept a portable token alone', () => {
+    it('scopes zotero_search / list_* / find_annotations by "g<groupID>"', () => {
+        const validation = validateLibraryAccess('g555');
+        expect(validation.valid).toBe(true);
+        expect(validation.library).toEqual(groupAlpha);
+    });
+
+    it('scopes them by "u" without knowing the personal library rowid', () => {
+        expect(validateLibraryAccess('u').library).toEqual(userLibrary);
+    });
+
+    it('reports a group that is not on this device as unavailable, never as the default library', () => {
+        const validation = validateLibraryAccess('g999999');
+        expect(validation.valid).toBe(false);
+        expect(validation.error_code).toBe('library_unavailable');
+        expect(validation.library).toBeUndefined();
+    });
+
+    it('still enforces exclusion on a portable token', () => {
+        expect(validateLibraryAccess('g777').error_code).toBe('library_not_searchable');
+    });
+
+    it('resolves a libraries_filter of portable tokens only', () => {
+        expect(resolveLibrariesFilterToSearchableIds(['u', 'g555'])).toEqual([1, 100]);
+        expect(resolveLibrariesFilterToSearchableIds(['g999999'])).toEqual([]);
+    });
+});
+
+describe('item / attachment targets accept a portable reference alone', () => {
+    it('validates a reference whose numeric library_id is the unresolved sentinel', () => {
+        expect(validateZoteroItemReference({
+            library_id: 0,
+            library_ref: 'g555',
+            zotero_key: '3RRUYX5J',
+        })).toBeNull();
+    });
+
+    it('validates a reference that carries no numeric library_id at all', () => {
+        expect(validateZoteroItemReference({
+            library_ref: 'g555',
+            zotero_key: '3RRUYX5J',
+        })).toBeNull();
+    });
+
+    it('routes a portable-only attachment request to the local library', () => {
+        const result = preflightZoteroAttachmentRequest(
+            { library_ref: 'g555', zotero_key: '3RRUYX5J' } as any,
+            validateZoteroItemReference,
+        );
+
+        expect(result).toEqual({
+            ok: true,
+            responseAttachment: { library_id: 0, library_ref: 'g555', zotero_key: '3RRUYX5J' },
+            requestKey: 'g555-3RRUYX5J',
+            resolvedLibraryId: 100,
+        });
+    });
+
+    it('lets library_ref win over a numeric library_id that disagrees', () => {
+        const result = preflightZoteroAttachmentRequest(
+            { library_id: 300, library_ref: 'g555', zotero_key: '3RRUYX5J' },
+            validateZoteroItemReference,
+        );
+        expect(result.ok && result.resolvedLibraryId).toBe(100);
+    });
+
+    it('fails a group that is not on this device as library_unavailable, before any item lookup', () => {
+        const result = preflightZoteroAttachmentRequest(
+            { library_ref: 'g999999', zotero_key: '3RRUYX5J' } as any,
+            validateZoteroItemReference,
+        );
+        expect(result).toMatchObject({ ok: false, errorCode: 'library_unavailable' });
+        expect(Zotero.Items.getByLibraryAndKeyAsync).not.toHaveBeenCalled();
+    });
+
+    it('rejects a reference that names no library at all', () => {
+        expect(validateZoteroItemReference({ zotero_key: '3RRUYX5J' }))
+            .toContain('Invalid library reference');
+    });
+});
+
+describe('compound object ids parse the portable grammar first', () => {
+    it('resolves "g<groupID>-KEY" to the local library', () => {
+        expect(resolveObjectId('g555-3RRUYX5J')).toEqual({
+            library_id: 100,
+            library_ref: 'g555',
+            zotero_key: '3RRUYX5J',
+        });
+    });
+
+    it('resolves "u-KEY" to the personal library', () => {
+        expect(resolveObjectId('u-3RRUYX5J')).toEqual({
+            library_id: 1,
+            library_ref: 'u',
+            zotero_key: '3RRUYX5J',
+        });
+    });
+
+    it('keeps the portable ref and flags the library as unresolved for a group that is not here', () => {
+        expect(resolveObjectId('g999999-3RRUYX5J')).toEqual({
+            library_id: 0,
+            library_ref: 'g999999',
+            zotero_key: '3RRUYX5J',
+        });
+    });
+
+    it('still parses the legacy numeric grammar for old thread replay', () => {
+        expect(resolveObjectId('100-3RRUYX5J')).toEqual({
+            library_id: 100,
+            library_ref: 'g555',
+            zotero_key: '3RRUYX5J',
+        });
+    });
+});
+
+describe('write targets accept a portable library_ref alone', () => {
+    it('treats a library_ref with no numeric id as a complete target', () => {
+        expect(hasLibraryIdentity({ library_ref: 'g555' })).toBe(true);
+        expect(hasLibraryIdentity({ library_ref: 'u', library_id: 0 })).toBe(true);
+        expect(resolveWriteTargetLibrary({ library_ref: 'g555' })).toEqual({ ok: true, libraryID: 100 });
+    });
+
+    it('rejects a reference that names no library at all', () => {
+        expect(hasLibraryIdentity({})).toBe(false);
+        expect(hasLibraryIdentity({ library_id: 0 })).toBe(false);
+        expect(hasLibraryIdentity({ library_ref: 'not-a-library' })).toBe(false);
+    });
+
+    it('fails closed on a group that is not on this device instead of writing to the personal library', () => {
+        expect(resolveWriteTargetLibrary({ library_ref: 'g999999' })).toMatchObject({
+            ok: false,
+            code: 'library_unavailable',
+        });
+    });
+
+    it('lets library_ref win over a numeric library_id that disagrees', () => {
+        expect(resolveWriteTargetLibrary({ library_ref: 'u', library_id: 300 }))
+            .toEqual({ ok: true, libraryID: 1 });
+    });
+});

--- a/tests/unit/services/referenceValidation.test.ts
+++ b/tests/unit/services/referenceValidation.test.ts
@@ -18,17 +18,30 @@ describe('validateZoteroItemReference', () => {
         })).toBeNull();
     });
 
+    it('accepts a portable reference that carries no local library id at all', () => {
+        expect(validateZoteroItemReference({
+            library_ref: 'u',
+            zotero_key: '3RRUYX5J',
+        })).toBeNull();
+    });
+
     it('rejects an unresolved local library id without a valid portable ref', () => {
         expect(validateZoteroItemReference({
             library_id: 0,
             zotero_key: '3RRUYX5J',
-        })).toContain('0 with a valid library_ref');
+        })).toContain('Invalid library reference');
 
         expect(validateZoteroItemReference({
             library_id: 0,
             library_ref: 'not-a-library',
             zotero_key: '3RRUYX5J',
-        })).toContain('0 with a valid library_ref');
+        })).toContain('Invalid library reference');
+    });
+
+    it('rejects a reference that names no library at all', () => {
+        expect(validateZoteroItemReference({
+            zotero_key: '3RRUYX5J',
+        })).toContain('Invalid library reference');
     });
 
     it('continues accepting legacy references with a positive local library id', () => {

--- a/tests/unit/utils/diffPreviewCoordinator.test.ts
+++ b/tests/unit/utils/diffPreviewCoordinator.test.ts
@@ -5,7 +5,7 @@
  * edit_note approvals for the note currently being previewed, not on
  * approvals for other notes.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { atom, createStore } from 'jotai';
 
 // ---------------------------------------------------------------------------
@@ -93,7 +93,7 @@ vi.mock('../../../react/atoms/agentRunAtoms', () => ({
 // ---------------------------------------------------------------------------
 
 import { diffPreviewNoteKeyAtom } from '../../../react/utils/diffPreviewCoordinator';
-import { updateDiffPreviewForNote } from '../../../react/utils/diffPreviewCoordinator';
+import { noteLibraryIdFromActionData, updateDiffPreviewForNote } from '../../../react/utils/diffPreviewCoordinator';
 
 // Now create the real atom and assign it
 const pendingApprovalsAtom = atom<Map<string, any>>(new Map());
@@ -106,7 +106,8 @@ testPendingApprovalsAtom.ref = pendingApprovalsAtom;
 function makePendingApproval(overrides: {
     actionId: string;
     actionType?: string;
-    library_id?: number;
+    library_id?: number | null;
+    library_ref?: string;
     zotero_key?: string;
     old_string?: string;
     new_string?: string;
@@ -118,7 +119,10 @@ function makePendingApproval(overrides: {
         toolcallId: `tc-${overrides.actionId}`,
         actionType: overrides.actionType ?? 'edit_note',
         actionData: {
-            library_id: overrides.library_id ?? 1,
+            // `null` opts out entirely, for the portable-only shape the backend
+            // sends once it stops pinning device-local rowids.
+            ...(overrides.library_id === null ? {} : { library_id: overrides.library_id ?? 1 }),
+            ...(overrides.library_ref ? { library_ref: overrides.library_ref } : {}),
             zotero_key: overrides.zotero_key ?? 'AAAA1111',
             old_string: overrides.old_string ?? 'old',
             new_string: overrides.new_string ?? 'new',
@@ -411,6 +415,98 @@ describe('diffPreviewCoordinator — handleBannerAction', () => {
             expect(responses).toHaveLength(3);
             expect(responses.every(r => r.approved === true)).toBe(true);
             expect(storeRef.current.get(pendingApprovalsAtom).size).toBe(0);
+        });
+    });
+
+    // An edit_note approval names its note by portable `library_ref`; the numeric
+    // `library_id` is absent or the unresolved sentinel once the backend stops
+    // pinning rowids. Everything below the coordinator's API works in rowids, so
+    // the ref has to be resolved before any note key is built. Group 555 is the
+    // local library 100 on this device.
+    describe('portable library identity', () => {
+        let previousGroups: any;
+
+        beforeEach(() => {
+            previousGroups = (globalThis as any).Zotero.Groups;
+            (globalThis as any).Zotero.Groups = {
+                getLibraryIDFromGroupID: (groupID: number) => (groupID === 555 ? 100 : false),
+                getGroupIDFromLibraryID: (libraryID: number) => (libraryID === 100 ? 555 : false),
+            };
+        });
+
+        afterEach(() => {
+            (globalThis as any).Zotero.Groups = previousGroups;
+        });
+
+        it('shows the preview for an approval that carries only a library_ref', () => {
+            seedApprovals(
+                makePendingApproval({ actionId: 'a1', library_id: null, library_ref: 'g555', zotero_key: 'NOTE_A' }),
+            );
+
+            updateDiffPreviewForNote(100, 'NOTE_A');
+
+            expect(mockShowDiffPreview).toHaveBeenCalledWith(100, 'NOTE_A', expect.any(Array));
+        });
+
+        it('shows the preview when library_id is the unresolved sentinel', () => {
+            seedApprovals(
+                makePendingApproval({ actionId: 'a1', library_id: 0, library_ref: 'g555', zotero_key: 'NOTE_A' }),
+            );
+
+            updateDiffPreviewForNote(100, 'NOTE_A');
+
+            expect(mockShowDiffPreview).toHaveBeenCalledWith(100, 'NOTE_A', expect.any(Array));
+        });
+
+        it('does not confuse two libraries that both arrive with the sentinel', () => {
+            seedApprovals(
+                makePendingApproval({ actionId: 'a1', library_id: 0, library_ref: 'g555', zotero_key: 'NOTE_A' }),
+                makePendingApproval({ actionId: 'b1', library_id: 0, library_ref: 'u', zotero_key: 'NOTE_A' }),
+            );
+
+            updateDiffPreviewForNote(100, 'NOTE_A');
+
+            // Only the group-library edit belongs to this preview.
+            expect(mockShowDiffPreview).toHaveBeenCalledTimes(1);
+            const [, , edits] = mockShowDiffPreview.mock.calls[0];
+            expect(edits).toHaveLength(1);
+        });
+
+        // The helper `agentActions.ts` calls at both approval entry points, so a
+        // regression there is caught here rather than only through the UI.
+        describe('noteLibraryIdFromActionData', () => {
+            it('resolves a portable ref, with or without the sentinel', () => {
+                expect(noteLibraryIdFromActionData({ library_ref: 'g555' })).toBe(100);
+                expect(noteLibraryIdFromActionData({ library_ref: 'g555', library_id: 0 })).toBe(100);
+            });
+
+            it('lets library_ref win over a disagreeing numeric library_id', () => {
+                expect(noteLibraryIdFromActionData({ library_ref: 'g555', library_id: 7 })).toBe(100);
+            });
+
+            it('keeps reading a legacy numeric library_id when no ref is present', () => {
+                expect(noteLibraryIdFromActionData({ library_id: 7 })).toBe(7);
+            });
+
+            it('returns null when nothing names a library this device has', () => {
+                expect(noteLibraryIdFromActionData({ library_ref: 'g999999' })).toBeNull();
+                expect(noteLibraryIdFromActionData({ library_id: 0 })).toBeNull();
+                expect(noteLibraryIdFromActionData({})).toBeNull();
+                expect(noteLibraryIdFromActionData(undefined)).toBeNull();
+            });
+        });
+
+        it('scopes the banner to the previewed note when approvals name it portably', async () => {
+            capturedHandlers.previewNoteKey = { libraryId: 100, zoteroKey: 'NOTE_A' };
+
+            seedApprovals(
+                makePendingApproval({ actionId: 'a1', library_id: null, library_ref: 'g555', zotero_key: 'NOTE_A' }),
+                makePendingApproval({ actionId: 'b1', library_id: null, library_ref: 'g555', zotero_key: 'NOTE_B' }),
+            );
+            await capturedHandlers.bannerAction!('approveAll');
+
+            expect(getApprovalResponses()).toEqual([{ actionId: 'a1', approved: true }]);
+            expect(storeRef.current.get(pendingApprovalsAtom).size).toBe(1);
         });
     });
 });

--- a/tests/unit/utils/editNoteShared.test.ts
+++ b/tests/unit/utils/editNoteShared.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ToolCallPart } from '@beaver/agent-core/agents/types';
 import {
     buildEditNoteRenderItems,
@@ -9,6 +9,7 @@ import {
     getOverallEditNoteDisplayStatus,
     isEditNoteOrphaned,
     isEditNoteStreamingPlaceholder,
+    isOpenableEditNoteTarget,
     parseEditNoteToolCallArgs,
     resolveEditNoteTargetFromData,
 } from '../../../react/components/agentRuns/editNoteShared';
@@ -52,6 +53,7 @@ describe('editNoteShared', () => {
                 expect(resolveEditNoteTargetFromData({ note_id: 'u-ABCDE' })).toEqual({
                     libraryId: 5,
                     zoteroKey: 'ABCDE',
+                    libraryRef: 'u',
                 });
             } finally {
                 (globalThis as any).Zotero.Libraries = original;
@@ -69,11 +71,126 @@ describe('editNoteShared', () => {
                 expect(resolveEditNoteTargetFromData({ note_id: 'g42-FGHIJ' })).toEqual({
                     libraryId: 12,
                     zoteroKey: 'FGHIJ',
+                    libraryRef: 'g42',
                 });
             } finally {
                 (globalThis as any).Zotero.Libraries = originalLibraries;
                 (globalThis as any).Zotero.Groups = originalGroups;
             }
+        });
+
+        // Action data (unlike the model's own tool args) names the note as a
+        // `library_ref` + `zotero_key` pair. Once the backend stops pinning
+        // rowids the numeric half is absent or the unresolved sentinel, so the
+        // ref is the only thing that identifies the note.
+        describe('library_ref + zotero_key targets', () => {
+            const originals: any = {};
+
+            beforeEach(() => {
+                originals.Libraries = (globalThis as any).Zotero.Libraries;
+                originals.Groups = (globalThis as any).Zotero.Groups;
+                (globalThis as any).Zotero.Libraries = { ...originals.Libraries, userLibraryID: 5 };
+                (globalThis as any).Zotero.Groups = {
+                    getLibraryIDFromGroupID: (groupID: number) => (groupID === 42 ? 12 : null),
+                };
+            });
+
+            afterEach(() => {
+                (globalThis as any).Zotero.Libraries = originals.Libraries;
+                (globalThis as any).Zotero.Groups = originals.Groups;
+            });
+
+            it('resolves a library_ref with no numeric library_id', () => {
+                expect(resolveEditNoteTargetFromData({ library_ref: 'g42', zotero_key: 'FGHIJ' })).toEqual({
+                    libraryId: 12,
+                    zoteroKey: 'FGHIJ',
+                    libraryRef: 'g42',
+                });
+            });
+
+            it('resolves a library_ref carrying the unresolved sentinel', () => {
+                expect(resolveEditNoteTargetFromData({
+                    library_ref: 'u',
+                    library_id: 0,
+                    zotero_key: 'FGHIJ',
+                })).toEqual({ libraryId: 5, zoteroKey: 'FGHIJ', libraryRef: 'u' });
+            });
+
+            it('lets library_ref win over a disagreeing numeric library_id', () => {
+                expect(resolveEditNoteTargetFromData({
+                    library_ref: 'g42',
+                    library_id: 7,
+                    zotero_key: 'FGHIJ',
+                })).toEqual({ libraryId: 12, zoteroKey: 'FGHIJ', libraryRef: 'g42' });
+            });
+
+            it('keeps the identity of a note whose library is not on this device', () => {
+                // Dropping the target would make `buildEditNoteRenderItems` read
+                // the part as "still streaming" and fold this note's edits into
+                // the neighbouring note's group. Same shape the note_id branch
+                // produces for an unavailable group.
+                expect(resolveEditNoteTargetFromData({
+                    library_ref: 'g999999',
+                    zotero_key: 'FGHIJ',
+                })).toEqual({ libraryId: 0, zoteroKey: 'FGHIJ', libraryRef: 'g999999' });
+                expect(resolveEditNoteTargetFromData({ note_id: 'g999999-FGHIJ' }))
+                    .toEqual({ libraryId: 0, zoteroKey: 'FGHIJ', libraryRef: 'g999999' });
+            });
+
+            it('marks such a target as not openable, so no affordance is offered for it', () => {
+                expect(isOpenableEditNoteTarget(
+                    resolveEditNoteTargetFromData({ library_ref: 'g999999', zotero_key: 'FGHIJ' }),
+                )).toBe(false);
+                expect(isOpenableEditNoteTarget(
+                    resolveEditNoteTargetFromData({ note_id: 'g999999-FGHIJ' }),
+                )).toBe(false);
+                expect(isOpenableEditNoteTarget(
+                    resolveEditNoteTargetFromData({ library_ref: 'g42', zotero_key: 'FGHIJ' }),
+                )).toBe(true);
+                expect(isOpenableEditNoteTarget(null)).toBe(false);
+            });
+
+            it('carries the portable ref on the target so unavailable libraries stay distinct', () => {
+                expect(resolveEditNoteTargetFromData({ note_id: 'g999999-AAAAA' }))
+                    .toEqual({ libraryId: 0, zoteroKey: 'AAAAA', libraryRef: 'g999999' });
+                expect(resolveEditNoteTargetFromData({ library_ref: 'g999999', zotero_key: 'AAAAA' }))
+                    .toEqual({ libraryId: 0, zoteroKey: 'AAAAA', libraryRef: 'g999999' });
+            });
+
+            it('keeps edits to different notes in separate groups when neither library is here', () => {
+                const items = buildEditNoteRenderItems([
+                    makeToolCallPart('tc-1', 'edit_note', { note_id: 'g999999-AAAAA' }),
+                    makeToolCallPart('tc-2', 'edit_note', { note_id: 'g888888-BBBBB' }),
+                ]);
+                expect(items).toHaveLength(2);
+                expect(items.every((item) => item.kind === 'edit-note-group')).toBe(true);
+            });
+
+            it('does not merge two unavailable libraries that share a zotero_key', () => {
+                // Zotero keys are unique only within a library, and every
+                // unavailable library reports the same rowid sentinel — so the
+                // portable ref is the only thing separating these two notes.
+                const items = buildEditNoteRenderItems([
+                    makeToolCallPart('tc-1', 'edit_note', { note_id: 'g999999-AAAAA' }),
+                    makeToolCallPart('tc-2', 'edit_note', { note_id: 'g888888-AAAAA' }),
+                ]);
+                expect(items).toHaveLength(2);
+            });
+
+            it('still groups consecutive edits to one note named both ways', () => {
+                // `u-KEY` and a bare `library_id: 5` name the same resolvable
+                // library here, so the run must not be split on the spelling.
+                const items = buildEditNoteRenderItems([
+                    makeToolCallPart('tc-1', 'edit_note', { note_id: 'u-AAAAA' }),
+                    makeToolCallPart('tc-2', 'edit_note', { library_id: 5, zotero_key: 'AAAAA' }),
+                ]);
+                expect(items).toHaveLength(1);
+                expect((items[0] as any).parts).toHaveLength(2);
+            });
+
+            it('returns null when nothing names a library', () => {
+                expect(resolveEditNoteTargetFromData({ zotero_key: 'FGHIJ' })).toBeNull();
+            });
         });
     });
 

--- a/tests/unit/utils/undoPortableResultData.test.ts
+++ b/tests/unit/utils/undoPortableResultData.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Undo works on an applied action the backend named only by `library_ref`.
+ *
+ * `toAgentAction` normalizes an absent `library_id` to `UNRESOLVED_LIBRARY_ID`,
+ * so a portably-named applied action reaches undo carrying `library_id: 0`.
+ * `hasAppliedZoteroItem` now admits those into the undo list, so the undo
+ * handlers must accept them too — a guard on the rowid alone turns what used to
+ * be a silently-skipped note into a failed undo.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+vi.mock('@beaver/agent-core/transport/supabaseClient', () => ({
+    supabase: { auth: { getSession: vi.fn() } },
+}));
+
+const mocks = vi.hoisted(() => ({
+    cancelTasksForItem: vi.fn(),
+}));
+vi.mock('../../../react/utils/backgroundTaskCancellation', () => ({
+    cancelTasksForItem: mocks.cancelTasksForItem,
+}));
+
+import { undoCreateNoteAction } from '../../../react/utils/createNoteActions';
+
+// Group 50 lives at local rowid 5 on this device.
+const eraseTx = vi.fn();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    eraseTx.mockResolvedValue(undefined);
+    const zotero = (globalThis as any).Zotero;
+    zotero.Libraries = { ...zotero.Libraries, userLibraryID: 1 };
+    zotero.Groups = {
+        ...zotero.Groups,
+        getLibraryIDFromGroupID: vi.fn((groupID: number) => (groupID === 50 ? 5 : false)),
+        getGroupIDFromLibraryID: vi.fn((libraryID: number) => (libraryID === 5 ? 50 : false)),
+    };
+    zotero.Items = {
+        ...zotero.Items,
+        getByLibraryAndKeyAsync: vi.fn(async (libraryID: number, key: string) =>
+            libraryID === 5 && key === 'AAAAAAA1' ? { eraseTx } : null),
+    };
+});
+
+function appliedNote(result_data: Record<string, unknown>) {
+    return {
+        id: 'action-1',
+        run_id: 'run-1',
+        action_type: 'create_note',
+        status: 'applied',
+        proposed_data: {},
+        result_data,
+    } as any;
+}
+
+describe('undoCreateNoteAction with portable-only result data', () => {
+    it('deletes the note when the result carries the unresolved sentinel', async () => {
+        await undoCreateNoteAction(appliedNote({
+            library_id: 0,
+            library_ref: 'g50',
+            zotero_key: 'AAAAAAA1',
+        }));
+
+        expect(Zotero.Items.getByLibraryAndKeyAsync).toHaveBeenCalledWith(5, 'AAAAAAA1');
+        expect(eraseTx).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes it when the result carries no numeric library_id at all', async () => {
+        await undoCreateNoteAction(appliedNote({
+            library_ref: 'g50',
+            zotero_key: 'AAAAAAA1',
+        }));
+
+        expect(eraseTx).toHaveBeenCalledTimes(1);
+    });
+
+    it('still deletes a legacy note named by rowid alone', async () => {
+        await undoCreateNoteAction(appliedNote({ library_id: 5, zotero_key: 'AAAAAAA1' }));
+
+        expect(eraseTx).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns quietly when the library is not on this device', async () => {
+        await undoCreateNoteAction(appliedNote({
+            library_id: 0,
+            library_ref: 'g999999',
+            zotero_key: 'AAAAAAA1',
+        }));
+
+        expect(eraseTx).not.toHaveBeenCalled();
+        expect(Zotero.Items.getByLibraryAndKeyAsync).not.toHaveBeenCalled();
+    });
+
+    it('still refuses a result that names no library at all', async () => {
+        await expect(undoCreateNoteAction(appliedNote({
+            library_id: 0,
+            zotero_key: 'AAAAAAA1',
+        }))).rejects.toThrow('Cannot undo');
+        expect(eraseTx).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- Add portable library identity parsing and validation alongside legacy library IDs.
- Update reference resolution, deduplication, actions, citations, and document handling to preserve portable references.
- Remove the deprecated stored-table subsystem and related UI, endpoints, styles, and tests.

## Testing

- Not run