### PR TITLE
feat(voice): add batched transcription and capture quality diagnostics

### DIFF
--- a/docs/voice-protocol.md
+++ b/docs/voice-protocol.md
@@ -1,154 +1,157 @@
 # Voice protocol v1
 
-Voice support currently provides contracts, a session controller and a development-only
-synthetic harness, plus a macOS native capture adapter and a local capture harness.
-Production activation remains feature-disabled (`disabled`); transcription, editor insertion,
-shortcuts, billing, and submission are not enabled. Native source, IPC, and development
-verification are documented in [native voice capture](../native/voice/README.md).
+Voice support provides a portable batch session controller, a synthetic development harness,
+and a macOS capture adapter with a local capture harness. Production activation remains
+feature-disabled. Backend transcription, compression/upload, vocabulary collection, preferences,
+editor insertion, shortcuts, billing, and submission are not enabled. See
+[native capture](../native/voice/README.md) for build and IPC verification.
 
 ## Ownership and lifecycle
 
-`VoiceController` is portable (`@beaver/agent-core/voice/controller`). Create exactly one
-per application instance. In Zotero, `Zotero.Beaver.voice` owns it in the plugin realm.
-Views can subscribe to the controller and use `projectVoice` to identify the one originating
-window/output. React hooks and composer-specific locking/recording fields are deferred until
-they have a UI consumer. Outputs are immutable `{kind: "composer" | "draft", id}` identities. Only
-`ownsOutput` may apply transcript changes; other mounted views observe the busy state.
-The controller does not write any editor or chat store.
+Create exactly one `VoiceController` (`@beaver/agent-core/voice/controller`) per application
+instance. In Zotero, `Zotero.Beaver.voice` owns it in the plugin realm. Views subscribe and use
+`projectVoice` to identify the originating window/output. Only `ownsOutput` may insert a result;
+other mounted views observe the busy state. Outputs are immutable `{kind: "composer" | "draft",
+id}` identities. The controller never writes editor or chat state.
 
 ```mermaid
 stateDiagram-v2
     [*] --> idle
     idle --> starting: enabled + available + lock acquired
-    starting --> listening: auth + transport + capture ready
+    starting --> listening: auth + capture ready
     starting --> canceled: finish / cancel / owner lost
     starting --> error: setup failure / startup deadline
     listening --> finalizing: finish
     listening --> canceled: cancel / owner lost
-    listening --> error: capture / network / bounds / duration
-    finalizing --> completed: capture flushed + queue drained + end_audio + complete
+    listening --> error: capture failure / duration bound
+    finalizing --> completed: capture flushed + energy gate + batch result
     finalizing --> canceled: cancel / owner lost
-    finalizing --> error: failure / finalization deadline
+    finalizing --> error: no speech / failure / deadline
     completed --> starting: fresh activation
     canceled --> starting: fresh activation
     error --> starting: fresh activation
 ```
 
-Ready means setup succeeded, not that audio has flowed. `audioStarted` becomes true on the
-first valid frame, including silence. Silence never implies denied permission. Finishing while
-starting cancels: late permission/setup completion must require a new activation.
-`start()` returns the allocated session ID, not a readiness guarantee. The snapshot is
-authoritative even if a synchronous observer cancels that session before `start()` returns. Repeated
-finish/cancel and old-session commands are harmless. Session IDs must be unique per activation.
+Ready means setup succeeded, not that audio flowed. `audioStarted` becomes true on the first
+valid frame, including silence. Silence never implies denied permission. Finishing while starting
+cancels; late permission/setup results require fresh activation. `start()` returns the allocated
+session ID, not a readiness guarantee. The snapshot remains authoritative if a synchronous
+observer cancels before `start()` returns. Repeated finish/cancel and old-session commands are
+harmless. Session IDs must be unique per activation.
 
-The Zotero service accepts activation only from a focused window, canceling on its unload or top-level
-blur, and removes those listeners on termination. Main-window cleanup also cancels explicitly.
-Logout/account replacement revokes the session, including while authentication is unresolved;
-a new account must not inherit an earlier activation. Hosts pass the known user ID to `start()`
-so another window reporting the same account during setup does not revoke that activation.
-The expected ID is required, and the resolved credentials must still match it.
-Same-user token refresh does not notify
-the controller of an identity change. Plugin shutdown disposes the service. Timers
-use Gecko's system timer module so closing a window cannot disable a watchdog.
-Permission setup that steals focus cancels activation; granting permission must not silently
-start audio afterward. The user activates again once setup is complete.
+The service accepts activation only from a focused window and cancels on that window's unload
+or top-level blur. Internal focus movement is ignored. Logout/account replacement cancels,
+including while authentication is unresolved. The expected user ID is required at activation;
+resolved credentials must match. Same-user token refresh does not cancel. Credentials are
+reacquired before upload, checked again against the same user, and never stored in public state
+or passed to the native helper. Plugin shutdown disposes the service. System timers remain
+active independently of window realms. Closing the last macOS window cancels its session
+without destroying app-lifetime services.
 
-## Adapter contract
+## Capture and batch adapters
 
-Factories synchronously return an owned handle **before** asynchronous setup. Factory callbacks
-must be associated with the supplied session. Capture `start()` emits `ready` with the negotiated
-format and resolves; it may then emit frames. Transcription `start(credential)` must authenticate
-and establish bounded transport capacity before resolving. Only then is capture created.
-Capture/transcription factories and capability checks are constructor dependencies of the
-service. Production leaves the feature disabled while transcription and installation are unavailable; a compile-time development branch
-constructs the separate plugin-owned `DevelopmentVoiceHarness` with fake adapters. Voice has
-its own package closure roots, independent of the agent-run protocol barrel.
+Factories synchronously return owned handles before asynchronous setup. They must not start
+network work in their constructors. Capture `start()` emits `ready` with the format and resolves;
+frames may follow readiness. `finish()` stops capture, flushes a possible short final frame, and
+resolves only after all callbacks. No frame or quality event may follow its resolution.
 
-Credentials are provided through an injected function, never imported from React into the plugin
-bundle, included in a snapshot, or sent to a native helper.
+The controller copies incoming PCM into a bounded private buffer. No audio leaves the plugin
+while listening. On finish it releases capture, applies the duration/energy gate, refreshes auth,
+and calls `VoiceTranscription.transcribe(recording, credential)` exactly once. `VoiceRecording`
+contains the session envelope, format, total sample count, borrowed PCM, and immutable options.
+The future backend adapter must compress before its authenticated POST and return the corrected
+transcript. Codec, provider, and network details belong in that adapter, not native capture or
+portable state. There is no transcription WebSocket, frame-send method, segment stream, or
+separate completion acknowledgement.
 
-`dispose()` is idempotent, including during setup. It synchronously revokes setup/callbacks,
-stops capture, and initiates closing owned resources. Native adapters must ensure permission
-results cannot restart audio after disposal, and must enforce bounded process termination,
-independent control watchdogs, and parent-death cleanup. Their local IPC and kill/close details
-belong in the adapter. The controller invalidates callbacks before invoking either disposal and
-still disposes the other resource if one throws. Adapters must not silently reconnect or replay.
+`VoiceTranscript` returns `{version, sessionId, text}` or `{version, sessionId, error: {code}}`.
+A valid result atomically sets `committedText` and completes the session. Empty text is valid and
+must not trigger insertion/countdown/submission in consumers. While listening/finalizing there
+is no provisional text. Wrong-session/version or malformed results fail; canceled sessions
+ignore late promise settlements. Failed sessions have no partial transcript. Existing composer
+text remains owned by the editor and must be preserved by the future insertion integration.
 
-Capture `finish()` stops and flushes, resolving only after the final frame callback. No frames
-may follow its resolution. Transcription `send(frame)` must resolve when bounded transport
-capacity is available, not immediately after appending to an unbounded WebSocket buffer.
-The controller drains frames serially; `finish(end_audio)` follows all sends. A separate
-`complete` event acknowledges that all transcript finals were emitted. Resolving `finish()`
-alone does not complete a session. Transport EOF before `complete` is `disconnected`.
+`dispose()` is idempotent, even during setup. Capture revokes callbacks and stops its resources;
+transcription aborts encoding/upload and releases all borrowed bytes. The controller revokes the
+session first, clears timers, zeroes/releases its audio buffer, and disposes both handles even
+if one throws. Adapters must release any derived encoded buffers on disposal and must not retain,
+log, or persist audio by default. No transparent replay/reconnect is permitted.
 
-## Envelopes, frames and ordering
+## Activation options
 
-Every event/control has `{version: 1, sessionId}`. IPC adapters validate unknown input, negotiate
-versions, enforce payload bounds before decoding/allocating, and convert to these typed contracts.
-A mismatched version fails the active session; callbacks belonging to another session are ignored.
-The interfaces specify semantics, not a required HTTP/pipe/WebSocket serialization.
+`VoiceOptions` contains an explicit language (default `en`), provider bias terms, and a larger
+correction vocabulary. The controller copies/freezes both arrays at activation; later selection
+or preference changes cannot alter the utterance's context. Hosts must filter excluded libraries
+before constructing these lists. Each list is bounded to 1,000 nonempty terms and 32,000 UTF-16
+code units; adapters must apply their provider's smaller token/term budget. Library discovery,
+term selection, language preference UI, and backend correction are integration responsibilities.
+Options, credentials, vocabulary, and PCM are absent from snapshots and telemetry.
 
-Audio is **16,000 Hz, mono, signed PCM16 little-endian**, `encoding: "pcm_s16le"`.
-`VoiceFrame` carries `sequence` (zero-based contiguous), `sampleCount`, `format`, and `pcm`
-(`Uint8Array`, exactly two bytes per sample). Frames normally contain 1,600 samples (100 ms).
-Finish permits one shorter, nonempty last frame. Empty tails emit no frame. Gaps, duplicate
-frames, wrong lengths/formats, and frames after a short tail are protocol errors. The controller
-copies bytes synchronously so capture can reuse its buffer, and exposes normalized RMS levels.
-`end_audio` includes the total `frameCount` and `sampleCount` for server-side validation.
+## Frames and quality
 
-Transcript events use a separate zero-based contiguous `sequence`. Duplicate/older sequence
-numbers are ignored; gaps fail. Segments use contiguous zero-based numeric `segmentId`s.
-Only one segment is provisional at a time. Each interim replaces its text. `segment_final`
-commits once and advances the segment; subsequent updates to a committed segment are ignored.
-Text concatenates exactly as delivered, so adapters supply punctuation and inter-segment spacing.
-A segment final never ends recording. `complete` is valid only after end-of-audio, with no
-unfinalized provisional text. Failed/canceled sessions discard provisional text and retain
-committed text for explicit review, never successful submission.
+Every event has `{version: 1, sessionId}`. Capture frame sequences are zero-based and contiguous;
+transcription has no segment identities or sequence counters. IPC adapters validate unknown
+input, negotiate versions, and enforce bounds before decoding/allocating. Wrong-session capture
+callbacks are ignored; a mismatched version fails the active session.
 
-`VoiceControl` defines `finish`, `cancel`, and `end_audio`. Native readiness, permission,
-heartbeat, token/host validation and transport shutdown envelopes are adapter-specific.
-A Windows pipe adapter can map readiness into `ready`, accumulate partial pipe reads into
-bounded frames, flush the last samples before resolving `finish()`, and map device discontinuity
-into the distinct `discontinuity` error. Control-pipe EOF must release its microphone even if
-no audio callback arrives. A macOS adapter can express the same lifecycle over authenticated
-loopback IPC without sharing Windows launch mechanics.
+Audio is **16,000 Hz, mono, signed PCM16 little-endian** (`pcm_s16le`). `VoiceFrame` carries
+`sequence`, `sampleCount`, `format`, and `pcm` (`Uint8Array`, two bytes/sample). Frames normally
+contain 1,600 samples (100 ms). Finish permits one shorter, nonempty tail. Empty tails emit no
+frame. Gaps, duplicates, wrong lengths/formats, early short frames, and frames after a short tail
+are protocol errors. Native IPC keeps its own ordering, backpressure, and watchdogs.
 
-## Limits and errors
+`quality` capture events carry cumulative `inputPeak`, `clippedSamples` (input sample positions
+where any channel approaches full scale), and `discontinuityCount`. Values must be finite,
+nonnegative, and nondecreasing; counts must be safe integers. Snapshots expose immutable quality
+and a session-latched `clipping` flag for warning UI. Counts remain available after termination
+for content-free telemetry. A discontinuity can still fail capture; counting it does not authorize
+silently dropping speech. Silence remains valid audio during capture.
 
-`VOICE_LIMITS` names the v1 client bounds. Backend/native adapters must also enforce their
-corresponding bounds independently; client checks are not an authorization boundary.
+The macOS converter downmixes and applies bounded gain before conversion. It preserves ordinary
+speech levels, avoids boosting near-silence, caps quiet-speech amplification at 4×, and limits
+peaks with headroom for resampling. Input clipping is measured before processing; already-clipped
+microphone audio cannot be repaired. Audio sample timestamps detect missing/repeated input.
+The development native harness exposes clipping recovery text and quality through `nativeState()`.
 
-| Limit | Value |
-|---|---:|
-| Frame samples / bytes | 1,600 / 3,200 |
-| Queued bytes, including in-flight send | 160,000 (5 seconds) |
-| Authentication + transport + capture startup | 30 seconds |
-| Finish + flush + drain + completion | 10 seconds |
-| Listening duration | 120 seconds |
-| Retained transcript characters (UTF-16 code units) | 64,000 |
-| Final segments | 1,000 |
+## Limits and energy gate
 
-Error payloads contain a named `code`, without provider messages, credentials, audio or text:
-`disabled`, `unavailable`, `busy`, `unauthenticated`, `permission_denied`, `device_unavailable`,
-`capture_failed`, `discontinuity`, `transcription_failed`, `disconnected`, `protocol_error`,
-`overflow`, `startup_timeout`, `finalization_timeout`, `duration_limit`.
-Activation rejection returns an error without replacing another session's state. Active-session
-failure disposes resources and preserves committed text. Overflow is an error, never silent loss.
-No audio or transcript is logged or persisted by this layer.
+| Limit                                                  |                                             Value |
+| ------------------------------------------------------ | ------------------------------------------------: |
+| Frame samples / bytes                                  |                                     1,600 / 3,200 |
+| Full recording buffer                                  |                       3,840,000 bytes (120 s PCM) |
+| Authentication + capture startup                       |                                              30 s |
+| Native finish + tail flush                             |                                              10 s |
+| Auth refresh + compression + upload + corrected result |                                              30 s |
+| Listening duration                                     |              120 s, also enforced by sample count |
+| Minimum recording                                      |                            4,800 samples (300 ms) |
+| Energy window                                          |                               320 samples (20 ms) |
+| Required energy                                        | 3,200 samples (200 ms) in windows with RMS ≥ 0.01 |
+| Final transcript                                       |                          64,000 UTF-16 code units |
+
+Energy windows span frame boundaries and include complete windows in the final tail. The gate
+rejects short, muted, near-silent, and isolated-click captures with `no_speech`, without invoking
+transcription. RMS 0.01 is −40 dBFS. This is a conservative energy gate, not a speech classifier;
+thresholds require real-microphone validation and cannot distinguish sustained noise from speech.
+The 300 ms check is independent of the future keyboard hold threshold.
+
+`VOICE_LIMITS` defines client bounds. Native and backend adapters independently enforce their
+applicable bounds; client limits are not an authorization boundary. Recording past either duration
+bound fails with `duration_limit`, without silently truncating or uploading a partial recording.
+
+Errors contain named codes only: `disabled`, `unavailable`, `busy`, `unauthenticated`,
+`permission_denied`, `device_unavailable`, `capture_failed`, `discontinuity`,
+`transcription_failed`, `disconnected`, `protocol_error`, `overflow`, `startup_timeout`,
+`finalization_timeout`, `transcription_timeout`, `duration_limit`, `no_speech`.
 
 ## Reproducible synthetic harness
 
-The development harness uses a synthetic window owner; real-window focus and unload behavior are
-covered separately by service tests. Start callers must supply the expected account ID before
-credentials resolve.
-
-Use a development build in a logged-in Zotero instance (desktop focus is not required). The endpoint is absent in production;
-the handler also checks development mode. The harness starts disabled and can never open a microphone
-or provider connection. Determine the instance's HTTP port from its worktree metadata or
-`Zotero.Server.port`; do not assume the default port.
+Use a development build in a logged-in Zotero instance. The endpoint is absent in production
+and rejects production invocation. The harness starts disabled and cannot open a microphone
+or provider connection. Its synthetic owner makes HTTP tests independent of desktop focus;
+service tests separately cover real-window lifecycle. Determine the actual port from worktree
+metadata or `Zotero.Server.port`.
 
 ```sh
-# Set VOICE_HTTP_PORT to the intended instance's actual port.
 voice() {
   curl --fail -sS -X POST "http://127.0.0.1:$VOICE_HTTP_PORT/beaver/test/voice" \
     -H 'Content-Type: application/json' -d "$1"
@@ -157,22 +160,23 @@ voice '{"command":"enable","enabled":true}'
 voice '{"command":"start"}'
 voice '{"command":"state"}' # wait for listening
 voice '{"command":"frame"}'
-voice '{"command":"interim","segmentId":0,"text":"A short"}'
-voice '{"command":"segment_final","segmentId":0,"text":"A short voice test."}'
+voice '{"command":"frame"}'
+voice '{"command":"frame"}'
+voice '{"command":"transcript","text":"A short voice test."}' # stages the fake response only
 voice '{"command":"finish"}'
-voice '{"command":"state"}' # completed, 2 frames, 2240 samples, resources disposed
+voice '{"command":"state"}' # completed: 4 frames, 5440 samples, 1 request, handles disposed
 voice '{"command":"enable","enabled":false}'
 ```
 
-`tests/fixtures/voice/session.json` is the versioned handoff fixture. Its frame descriptors
-represent zero-filled PCM, including a 640-sample tail. Unit tests replay it through the
-controller; live tests reproduce it through both Zotero bundles, assert disposal counts, and verify
-that current thread/run IDs are unchanged. `FakeVoiceCapture` and `FakeVoiceTranscription`
-permit explicit scripted callbacks without timers, native helpers, or a provider.
+`tests/fixtures/voice/session.json` is the handoff fixture. Fake frames contain a deterministic
+440 Hz tone at amplitude 0.2, followed by a 640-sample tail. Fakes record request/sample counts
+without retaining audio. Unit tests replay the fixture; live tests replay it through both Zotero
+bundles and check that thread/run IDs remain unchanged. Nothing is submitted as chat.
 
 ```sh
 npx vitest run tests/unit/voice
 ZOTERO_HTTP_PORT="$VOICE_HTTP_PORT" npx vitest run --config vitest.live.config.ts tests/live/voice.live.test.ts
+native/voice/macos/test.sh
 npm run typecheck:core
 npm run typecheck:ui
 npm run check:bundle

--- a/native/voice/README.md
+++ b/native/voice/README.md
@@ -70,8 +70,8 @@ await Zotero.Beaver.voiceHarness.saveRecording("/absolute/path/voice-test.wav");
 ```
 
 The retention bound is 120 seconds. Saving clears the retained buffers. A fresh activation
-also replaces them. No backend connection or transcription occurs: this harness uses the
-scripted transcription adapter to acknowledge completion. Native recording/metrics/export
+also replaces them. No backend connection or transcription occurs: this harness uses a fake batch adapter after the controller’s energy gate.
+Short or silent captures finish with `no_speech`. Native recording/metrics/export
 live in `NativeCaptureHarness`, composed with the synthetic harness around one shared
 `VoiceService`. Session IDs select the capture adapter; a native activation does not enable
 subsequent synthetic sessions. Do not log or publish recordings.
@@ -100,15 +100,15 @@ Authenticated malformed messages fail that lease. No request content reaches hos
 Each body carries `version: 1` and `sessionId`. Helper event messages have contiguous
 `eventSequence` starting at zero:
 
-| Type              | Additional fields                                               |
-| ----------------- | --------------------------------------------------------------- |
-| `hello`           | `helperVersion: 1`, diagnostic process `pid`                    |
-| `permission`      | `status: not_determined / granted / denied / restricted`        |
-| `permission_done` | setup-only terminal permission status; no capture               |
-| `ready`           | `format: {encoding: pcm_s16le, sampleRate: 16000, channels: 1}` |
-| `frame`           | contiguous audio `sequence`, `sampleCount`, base64 `pcm`        |
-| `error`           | a named capture error `code`                                    |
-| `done`            | total `frameCount`, `sampleCount` after all frames              |
+| Type              | Additional fields                                                              |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `hello`           | `helperVersion: 2`, diagnostic process `pid`                                   |
+| `permission`      | `status: not_determined / granted / denied / restricted`                       |
+| `permission_done` | setup-only terminal permission status; no capture                              |
+| `ready`           | `format: {encoding: pcm_s16le, sampleRate: 16000, channels: 1}`                |
+| `frame`           | contiguous audio `sequence`, `sampleCount`, base64 `pcm`, cumulative `quality` |
+| `error`           | a named capture error `code`, cumulative `quality`                             |
+| `done`            | total `frameCount`, `sampleCount` after all frames                             |
 
 Control requests have `type: control` and their own contiguous `sequence`. They do not
 share the event upload queue. Every successful response contains the session envelope
@@ -127,11 +127,20 @@ finalization to 10 seconds. App/window/identity/plugin lifecycle invalidates the
 lease; the helper receives cancellation at its next contact or expires independently.
 
 The audio tap copies into a bounded input queue (2 MiB), then performs arithmetic channel
-averaging and stateful AVAudioConverter conversion on a serial queue. The event queue
+averaging, bounded gain control/peak limiting, and stateful AVAudioConverter conversion on a serial queue.
+Gain leaves ordinary speech unchanged, boosts quiet speech by at most 4×, and avoids amplifying
+near-silence. A fast attenuation/slow recovery limiter targets 0.85 peak before resampling.
+Clipping diagnostics measure the input before gain control; software cannot repair already
+clipped microphone audio. Frames and errors carry cumulative `quality` fields: `inputPeak`,
+`clippedSamples`, and `discontinuityCount`. The adapter validates these and emits portable quality
+events. `nativeState()` exposes the counters and a clipping warning with recovery guidance.
+Helper version 2 is required; rebuild older development helpers before using this adapter. The event queue
 retains at most 160,000 PCM bytes. Overflow fails instead of dropping speech. Finish stops
 the engine, drains admitted input, signals end-of-stream to the converter, flushes the last
 short frame, uploads it, and only then sends `done`. A device configuration change fails
-with `discontinuity`, requiring a fresh activation.
+with `discontinuity`, requiring a fresh activation. Noncontiguous audio sample timestamps also
+increment that counter and fail capture. The controller accumulates the received PCM into a
+bounded 120-second batch buffer; the local event queue remains a separate transport bound.
 
 ## Verification
 

--- a/native/voice/macos/Sources/PCMConverter.swift
+++ b/native/voice/macos/Sources/PCMConverter.swift
@@ -8,6 +8,15 @@ final class PCMConverter {
     private var pending = Data()
     private(set) var frames = 0
     private(set) var samples = 0
+    private(set) var inputPeak: Float = 0
+    private(set) var clippedSamples = 0
+    private(set) var discontinuityCount = 0
+    private var expectedSampleTime: Int64?
+    private var gain: Float = 1
+    var quality: [String: Any] {
+        ["inputPeak": inputPeak, "clippedSamples": clippedSamples, "discontinuityCount": discontinuityCount]
+    }
+    func markDiscontinuity() { discontinuityCount += 1 }
     var emit: (Data, Int) throws -> Void
 
     init(format: AVAudioFormat, emit: @escaping (Data, Int) throws -> Void) throws {
@@ -22,17 +31,46 @@ final class PCMConverter {
         self.emit = emit
     }
 
-    func append(_ input: AVAudioPCMBuffer) throws {
+    func append(_ input: AVAudioPCMBuffer, sampleTime: Int64? = nil) throws {
+        if let time = sampleTime {
+            if let expected = expectedSampleTime, time != expected {
+                markDiscontinuity(); throw VoiceFailure("discontinuity")
+            }
+            let (next, overflow) = time.addingReportingOverflow(Int64(input.frameLength))
+            guard !overflow else { throw VoiceFailure("capture_failed") }
+            expectedSampleTime = next
+        } else { expectedSampleTime = nil }
         guard input.format == inputFormat, input.frameLength <= 32768,
               let source = input.floatChannelData,
               let mixed = AVAudioPCMBuffer(pcmFormat: mono, frameCapacity: input.frameLength),
               let destination = mixed.floatChannelData else { throw VoiceFailure("discontinuity") }
         mixed.frameLength = input.frameLength
+        var squares: Double = 0
         for i in 0..<Int(input.frameLength) {
             var value: Float = 0
-            for channel in 0..<Int(inputFormat.channelCount) { value += source[channel][i] / Float(inputFormat.channelCount) }
-            guard value.isFinite else { throw VoiceFailure("capture_failed") }
-            destination[0][i] = max(-1, min(1, value))
+            var clipped = false
+            for channel in 0..<Int(inputFormat.channelCount) {
+                let sample = source[channel][i]
+                guard sample.isFinite else { throw VoiceFailure("capture_failed") }
+                inputPeak = max(inputPeak, abs(sample))
+                clipped = clipped || abs(sample) >= 0.99
+                value += sample / Float(inputFormat.channelCount)
+            }
+            if clipped { clippedSamples += 1 }
+            destination[0][i] = value
+            squares += Double(value) * Double(value)
+        }
+        let rms = Float(sqrt(squares / Double(max(1, input.frameLength))))
+        // Preserve ordinary speech levels. Never amplify near-silence; cap quiet-speech gain.
+        let desired: Float = rms >= 0.01 && (rms < 0.1 || rms > 0.35) ? min(4, 0.2 / rms) : 1
+        let attack = Float(1 - exp(-1 / (0.005 * inputFormat.sampleRate)))
+        let release = Float(1 - exp(-1 / (0.5 * inputFormat.sampleRate)))
+        for i in 0..<Int(input.frameLength) {
+            let value = destination[0][i]
+            gain += (desired - gain) * (desired < gain ? attack : release)
+            // Immediate peak limiting with slow gain recovery leaves resampling headroom.
+            if abs(value) * gain > 0.85 { gain = 0.85 / abs(value) }
+            destination[0][i] = value * gain
         }
         try convert(mixed, ending: false)
     }

--- a/native/voice/macos/Sources/main.swift
+++ b/native/voice/macos/Sources/main.swift
@@ -125,7 +125,7 @@ final class Helper {
         }
         self.watchdog = watchdog; watchdog.resume()
         eventQueue.async { [self] in
-            guard event(["type": "hello", "helperVersion": 1, "pid": getpid()]) == "continue" else { act("cancel"); return }
+            guard event(["type": "hello", "helperVersion": 2, "pid": getpid()]) == "continue" else { act("cancel"); return }
             state.touchControl()
             startControl()
             DispatchQueue.main.async { self.permission() }
@@ -186,9 +186,10 @@ final class Helper {
     func makeConverter(_ format: AVAudioFormat) throws -> PCMConverter {
         try PCMConverter(format: format) { [self] bytes, sequence in
             guard state.reserve(bytes.count, input: false) else { throw VoiceFailure("overflow") }
+            let quality = converter?.quality ?? ["inputPeak": 0, "clippedSamples": 0, "discontinuityCount": 0]
             eventQueue.async { [self] in
                 defer { state.release(bytes.count, input: false) }
-                act(event(["type": "frame", "sequence": sequence, "sampleCount": bytes.count / 2, "pcm": bytes.base64EncodedString()]))
+                act(event(["type": "frame", "sequence": sequence, "sampleCount": bytes.count / 2, "pcm": bytes.base64EncodedString(), "quality": quality]))
             }
         }
     }
@@ -265,7 +266,7 @@ final class Helper {
         guard AVCaptureDevice.default(for: .audio) != nil else { fail("device_unavailable"); return }
         let current = engine.inputNode.outputFormat(forBus: 0)
         guard current.isEqual(format) else { fail("discontinuity"); return }
-        engine.inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [self] buffer, _ in
+        engine.inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [self] buffer, time in
             let size = Int(buffer.frameLength) * Int(format.channelCount) * 4
             guard buffer.frameLength > 0, buffer.frameLength <= 32768, state.reserve(size, input: true) else {
                 DispatchQueue.main.async { self.fail("overflow") }; return
@@ -276,10 +277,11 @@ final class Helper {
             }
             copy.frameLength = buffer.frameLength
             for channel in 0..<Int(format.channelCount) { target[channel].update(from: source[channel], count: Int(buffer.frameLength)) }
+            let sampleTime = time.isSampleTimeValid ? time.sampleTime : nil
             state.touchAudio()
             audioQueue.async { [self] in
                 defer { state.release(size, input: true) }
-                do { try converter?.append(copy) }
+                do { try converter?.append(copy, sampleTime: sampleTime) }
                 catch { DispatchQueue.main.async { self.fail((error as? VoiceFailure)?.code ?? "capture_failed") } }
             }
         }
@@ -319,7 +321,11 @@ final class Helper {
     func fail(_ code: String) {
         guard !terminal else { return }
         terminal = true; stopEngine()
-        eventQueue.async { [self] in _ = event(["type": "error", "code": code]); _exit(1) }
+        audioQueue.async { [self] in
+            if code == "discontinuity", converter?.discontinuityCount == 0 { converter?.markDiscontinuity() }
+            let quality = converter?.quality ?? ["inputPeak": 0, "clippedSamples": 0, "discontinuityCount": code == "discontinuity" ? 1 : 0]
+            eventQueue.async { [self] in _ = event(["type": "error", "code": code, "quality": quality]); _exit(1) }
+        }
     }
 }
 let helper = Helper(port: port, token: token, sessionID: sessionID)

--- a/native/voice/macos/Tests/lifecycle.py
+++ b/native/voice/macos/Tests/lifecycle.py
@@ -40,7 +40,9 @@ class Scenario:
                     else:
                         assert data['eventSequence'] == len(scenario.events)
                         scenario.events.append(data)
-                        if data['type'] == 'hello': scenario.pid = data['pid']
+                        if data['type'] == 'hello':
+                            assert data['helperVersion'] == 2
+                            scenario.pid = data['pid']
                     if scenario.behavior == 'audio-stall' and data['type'] == 'frame': time.sleep(2.5)
                     if scenario.behavior == 'control-stall' and data['type'] == 'control': time.sleep(4)
                     command = scenario.command
@@ -102,6 +104,8 @@ for mode, behavior, error in [
     if mode in ['startup-discontinuity', 'unrequested']:
         assert not any(e['type']=='frame' for e in s.events), 'Capture started after invalid setup'
     if error: assert any(e.get('code')==error for e in s.events), (mode,s.events)
+    if error == 'discontinuity':
+        assert next(e for e in s.events if e.get('code') == error)['quality']['discontinuityCount'] >= 1
     if behavior == 'finish' and mode == 'fixture':
         frames=[e for e in s.events if e['type']=='frame']; done=s.events[-1]
         assert done['type']=='done'
@@ -109,6 +113,9 @@ for mode, behavior, error in [
         assert done['sampleCount']==sum(e['sampleCount'] for e in frames)
         for i,frame in enumerate(frames):
             assert frame['sequence']==i
+            assert frame['quality']['inputPeak'] > 0
+            assert frame['quality']['clippedSamples'] == 0
+            assert frame['quality']['discontinuityCount'] == 0
             assert len(base64.b64decode(frame['pcm'],validate=True))==frame['sampleCount']*2
             if i<len(frames)-1: assert frame['sampleCount']==1600
         assert any(base64.b64decode(e['pcm']).strip(b'\x00') for e in frames)

--- a/native/voice/macos/Tests/main.swift
+++ b/native/voice/macos/Tests/main.swift
@@ -53,3 +53,52 @@ for i in 0..<4800 { buffer.floatChannelData![0][i] = 0.75; buffer.floatChannelDa
 try converter.append(buffer); try converter.finish()
 check(silence.allSatisfy { $0 == 0 }, "Downmix did not cancel")
 print("PASS opposite-channel downmix")
+
+// Gain control must preserve sample counts, bound peaks, report pre-gain clipping,
+// and avoid boosting a muted/noisy microphone into plausible speech.
+func controlledSignal(_ amplitude: Float, seconds: Double = 2) throws -> (PCMConverter, [Double]) {
+    let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false)!
+    var data = Data()
+    let converter = try PCMConverter(format: format) { bytes, _ in data.append(bytes) }
+    for offset in stride(from: 0, to: Int(48000 * seconds), by: 960) {
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 960)!
+        buffer.frameLength = 960
+        for i in 0..<960 { buffer.floatChannelData![0][i] = amplitude * Float(sin(2 * Double.pi * 440 * Double(offset + i) / 48000)) }
+        try converter.append(buffer, sampleTime: Int64(offset))
+    }
+    try converter.finish()
+    return (converter, stride(from: 0, to: data.count, by: 2).map {
+        Double(Int16(bitPattern: UInt16(data[$0]) | UInt16(data[$0 + 1]) << 8)) / 32768
+    })
+}
+let (loud, limited) = try controlledSignal(2)
+check(limited.count == 32000, "Limiter lost samples")
+check(limited.map { abs($0) }.max()! < 0.95, "Limiter failed to leave headroom")
+check(loud.inputPeak > 1.9 && loud.clippedSamples > 0, "Input clipping hidden by limiter")
+let (quiet, normalized) = try controlledSignal(0.04)
+let settled = normalized.suffix(8000)
+let normalizedRMS = sqrt(settled.reduce(0) { $0 + $1 * $1 } / Double(settled.count))
+check(normalizedRMS > 0.08 && normalizedRMS < 0.12, "Quiet speech gain out of bounds")
+check(quiet.clippedSamples == 0, "Quiet input misreported as clipping")
+let (_, noise) = try controlledSignal(0.002)
+check(noise.map { abs($0) }.max()! < 0.003, "Near-silence amplified")
+let (_, muted) = try controlledSignal(0)
+check(muted.allSatisfy { $0 == 0 }, "Muted microphone produced samples")
+print("PASS gain normalization, peak limiter, clipping diagnostics, silence floor")
+
+let timelineFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 1, interleaved: false)!
+let timeline = try PCMConverter(format: timelineFormat) { _, _ in }
+let timelineBuffer = AVAudioPCMBuffer(pcmFormat: timelineFormat, frameCapacity: 960)!
+timelineBuffer.frameLength = 960
+timelineBuffer.floatChannelData![0].initialize(repeating: 0, count: 960)
+try timeline.append(timelineBuffer, sampleTime: 0)
+try timeline.append(timelineBuffer, sampleTime: 960)
+check(timeline.discontinuityCount == 0, "Contiguous audio misclassified")
+do {
+    try timeline.append(timelineBuffer, sampleTime: 2880)
+    fatalError("Missing samples not detected")
+} catch {
+    check((error as? VoiceFailure)?.code == "discontinuity", "Wrong timeline error")
+    check(timeline.discontinuityCount == 1, "Missing discontinuity count")
+}
+print("PASS audio timestamp discontinuity detection")

--- a/native/voice/tests/zotero-ipc.py
+++ b/native/voice/tests/zotero-ipc.py
@@ -27,15 +27,16 @@ try:
     # Authorization copied directly into this local test process, never printed.
     token=rdp('return JSON.stringify({token:Zotero.Beaver.voiceNative.capture.active.token});')['token']
     envelope={'version':1,'sessionId':'ipc-test'}
-    assert b' 403 ' in req({**envelope,'type':'hello','helperVersion':1,'eventSequence':0})
+    assert b' 403 ' in req({**envelope,'type':'hello','helperVersion':2,'eventSequence':0})
     assert b' 400 ' in req({},'Origin: https://example.com\r\n')
     assert b' 400 ' in req({},raw=f'POST /voice HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Type: application/json\r\nContent-Length: 9999\r\n\r\n'.encode())
     auth=f'Authorization: Bearer {token}\r\n'
     def event(kind,seq,**fields):
-        response=req({**envelope,'type':kind,'eventSequence':seq,**fields},auth)
+        quality={'quality': {'inputPeak':0,'clippedSamples':0,'discontinuityCount':0}} if kind in ['frame','error'] else {}
+        response=req({**envelope,'type':kind,'eventSequence':seq,**quality,**fields},auth)
         assert b' 200 ' in response,response[:100]
         return response
-    event('hello',0,helperVersion=1)
+    event('hello',0,helperVersion=2)
     event('permission',1,status='granted')
     event('ready',2,format={'encoding':'pcm_s16le','sampleRate':16000,'channels':1})
     import base64
@@ -43,7 +44,7 @@ try:
     rdp('Zotero.__voiceCapture.finish(); return JSON.stringify({ok:true});')
     event('frame',4,sequence=1,sampleCount=37,pcm=base64.b64encode(bytes(74)).decode())
     event('done',5,frameCount=2,sampleCount=1637)
-    assert rdp('return JSON.stringify(Zotero.__voiceEvents);')==['ready','frame','frame']
+    assert rdp('return JSON.stringify(Zotero.__voiceEvents);')==['ready','quality','frame','quality','frame']
     print('PASS real Zotero socket: fragmented requests, denied token/origin/oversize, handshake, PCM, tail, done')
 finally:
     rdp('Zotero.__voiceCapture.dispose(); Zotero.Beaver.voiceNative.capture.host.launch=Zotero.__voiceSavedLaunch; delete Zotero.__voiceCapture; delete Zotero.__voiceSavedLaunch; delete Zotero.__voiceEvents; return JSON.stringify({ok:true});')

--- a/packages/agent-core/src/voice/contracts.ts
+++ b/packages/agent-core/src/voice/contracts.ts
@@ -1,22 +1,51 @@
 /** Transport-independent voice protocol. Adapters validate/decode their wire envelopes. */
 export const VOICE_VERSION = 1 as const;
-export const VOICE_FORMAT = Object.freeze({ encoding: 'pcm_s16le', sampleRate: 16000, channels: 1 } as const);
+export const VOICE_FORMAT = Object.freeze({
+    encoding: "pcm_s16le",
+    sampleRate: 16000,
+    channels: 1,
+} as const);
 export const VOICE_LIMITS = {
     frameSamples: 1600,
-    queuedBytes: 160000,
+    bufferBytes: 3840000,
+    minimumSamples: 4800, // 300 ms
+    energyWindowSamples: 320, // 20 ms, independent of capture callback size
+    minimumEnergySamples: 3200, // 200 ms above the energy floor
+    energyRms: 0.01, // -40 dBFS; a conservative energy gate, not speech recognition
+    vocabularyCharacters: 32000,
+    vocabularyTerms: 1000,
     startupMs: 30000,
-    finalizationMs: 10000,
+    finalizationMs: 10000, // native stop + flush
+    transcriptionMs: 30000, // auth refresh + compression + upload + corrected result
     durationMs: 120000,
     transcriptCharacters: 64000,
-    segments: 1000,
 } as const;
 
-export type VoiceErrorCode = 'disabled' | 'unavailable' | 'busy' | 'unauthenticated'
-    | 'permission_denied' | 'device_unavailable' | 'capture_failed' | 'discontinuity'
-    | 'transcription_failed' | 'disconnected' | 'protocol_error' | 'overflow'
-    | 'startup_timeout' | 'finalization_timeout' | 'duration_limit';
-export interface VoiceError { code: VoiceErrorCode }
-export interface VoiceEnvelope { version: typeof VOICE_VERSION; sessionId: string }
+export type VoiceErrorCode =
+    | "disabled"
+    | "unavailable"
+    | "busy"
+    | "unauthenticated"
+    | "permission_denied"
+    | "device_unavailable"
+    | "capture_failed"
+    | "discontinuity"
+    | "transcription_failed"
+    | "disconnected"
+    | "protocol_error"
+    | "overflow"
+    | "startup_timeout"
+    | "finalization_timeout"
+    | "transcription_timeout"
+    | "duration_limit"
+    | "no_speech";
+export interface VoiceError {
+    code: VoiceErrorCode;
+}
+export interface VoiceEnvelope {
+    version: typeof VOICE_VERSION;
+    sessionId: string;
+}
 export interface VoiceFrame extends VoiceEnvelope {
     sequence: number;
     sampleCount: number;
@@ -25,19 +54,55 @@ export interface VoiceFrame extends VoiceEnvelope {
     pcm: Uint8Array;
 }
 export type CaptureEvent =
-    | (VoiceEnvelope & { type: 'ready'; format: typeof VOICE_FORMAT })
-    | (VoiceEnvelope & { type: 'frame'; frame: VoiceFrame })
-    | (VoiceEnvelope & { type: 'error'; error: VoiceError });
-export type TranscriptEvent = VoiceEnvelope & (
-    | { type: 'interim' | 'segment_final'; sequence: number; segmentId: number; text: string }
-    | { type: 'complete'; sequence: number }
-    | { type: 'error'; error: VoiceError }
-);
-export type VoiceControl = VoiceEnvelope & (
-    | { type: 'finish' }
-    | { type: 'cancel' }
-    | { type: 'end_audio'; frameCount: number; sampleCount: number }
-);
+    | (VoiceEnvelope & { type: "ready"; format: typeof VOICE_FORMAT })
+    | (VoiceEnvelope & { type: "frame"; frame: VoiceFrame })
+    | (VoiceEnvelope & { type: "quality"; quality: VoiceQuality })
+    | (VoiceEnvelope & { type: "error"; error: VoiceError });
+/** Content-free, cumulative capture diagnostics. Clipping refers to input before gain control. */
+export interface VoiceQuality {
+    inputPeak: number;
+    clippedSamples: number;
+    discontinuityCount: number;
+}
+export const emptyVoiceQuality = (): VoiceQuality => ({
+    inputPeak: 0,
+    clippedSamples: 0,
+    discontinuityCount: 0,
+});
+export function validVoiceQuality(
+    value: VoiceQuality,
+    previous = emptyVoiceQuality(),
+): boolean {
+    return (
+        !!value &&
+        Number.isFinite(value.inputPeak) &&
+        value.inputPeak >= previous.inputPeak &&
+        Number.isSafeInteger(value.clippedSamples) &&
+        value.clippedSamples >= previous.clippedSamples &&
+        Number.isSafeInteger(value.discontinuityCount) &&
+        value.discontinuityCount >= previous.discontinuityCount
+    );
+}
+/** Hosts filter excluded libraries before building this activation-time snapshot. */
+export interface VoiceOptions {
+    language: string;
+    biasTerms: readonly string[];
+    correctionVocabulary: readonly string[];
+}
+export const defaultVoiceOptions = (): VoiceOptions => ({
+    language: "en",
+    biasTerms: [],
+    correctionVocabulary: [],
+});
+export interface VoiceRecording extends VoiceEnvelope {
+    format: typeof VOICE_FORMAT;
+    sampleCount: number;
+    /** Borrowed until transcribe settles or disposal; never retain, log, or persist these bytes. */
+    pcm: Uint8Array;
+    options: Readonly<VoiceOptions>;
+}
+export type VoiceTranscript = VoiceEnvelope &
+    ({ text: string } | { error: VoiceError });
 export interface VoiceCapture {
     /** Resolves only after ready; must not deliver frames before ready. */
     start(): Promise<void>;
@@ -47,35 +112,50 @@ export interface VoiceCapture {
     dispose(): void;
 }
 export interface VoiceTranscription {
-    /** Authenticate and become ready before capture starts. Never retain credentials in state. */
-    start(credential: string): Promise<void>;
-    /** Resolves when bounded transport capacity is available again, not merely after enqueue. */
-    send(frame: VoiceFrame): Promise<void>;
-    /** Complete is a separate event, emitted after all final segments. */
-    finish(control: VoiceControl & { type: 'end_audio' }): Promise<void>;
-    /** Close transport/provider; cancel setup and pending sends. Never reconnect/replay. */
+    /** Called once, after capture is flushed and passes the energy gate. The adapter compresses
+     * before the authenticated POST and returns the corrected transcript. No network during capture. */
+    transcribe(
+        recording: VoiceRecording,
+        credential: string,
+    ): Promise<VoiceTranscript>;
+    /** Abort compression/upload, release borrowed audio, and revoke any pending result; idempotent. */
     dispose(): void;
 }
 export interface VoiceClock {
     setTimeout(callback: () => void, ms: number): unknown;
     clearTimeout(handle: unknown): void;
 }
-export interface VoiceAuth { userId: string; credential: string }
+export interface VoiceAuth {
+    userId: string;
+    credential: string;
+}
 export interface VoiceDependencies {
     clock: VoiceClock;
     createId(): string;
     getAuth(): Promise<VoiceAuth | null>;
     capability(): { enabled: boolean; available: boolean };
-    createCapture(session: VoiceEnvelope, emit: (event: CaptureEvent) => void): VoiceCapture;
-    createTranscription(session: VoiceEnvelope, emit: (event: TranscriptEvent) => void): VoiceTranscription;
+    createCapture(
+        session: VoiceEnvelope,
+        emit: (event: CaptureEvent) => void,
+    ): VoiceCapture;
+    createTranscription(session: VoiceEnvelope): VoiceTranscription;
 }
 export interface VoiceOwner {
     windowId: string;
-    output: { kind: 'composer' | 'draft'; id: string };
+    output: { kind: "composer" | "draft"; id: string };
 }
-export type VoicePhase = 'idle' | 'starting' | 'listening' | 'finalizing' | 'completed' | 'canceled' | 'error';
+export type VoicePhase =
+    | "idle"
+    | "starting"
+    | "listening"
+    | "finalizing"
+    | "completed"
+    | "canceled"
+    | "error";
 export function isBusyPhase(phase: VoicePhase): boolean {
-    return phase === 'starting' || phase === 'listening' || phase === 'finalizing';
+    return (
+        phase === "starting" || phase === "listening" || phase === "finalizing"
+    );
 }
 
 export interface VoiceSnapshot {
@@ -88,17 +168,30 @@ export interface VoiceSnapshot {
     sampleCount: number;
     level: number;
     committedText: string;
-    provisionalText: string;
+    quality: Readonly<VoiceQuality>;
+    clipping: boolean;
     error: VoiceError | null;
 }
 export const idleVoiceSnapshot = (): VoiceSnapshot => ({
-    sessionId: null, owner: null, phase: 'idle', captureReady: false, audioStarted: false,
-    frameCount: 0, sampleCount: 0, level: 0, committedText: '', provisionalText: '', error: null,
+    sessionId: null,
+    owner: null,
+    phase: "idle",
+    captureReady: false,
+    audioStarted: false,
+    frameCount: 0,
+    sampleCount: 0,
+    level: 0,
+    committedText: "",
+    quality: Object.freeze(emptyVoiceQuality()),
+    clipping: false,
+    error: null,
 });
 
 /** A shared projection reserves transcript insertion for the originating output only. */
 export function projectVoice(snapshot: VoiceSnapshot, owner: VoiceOwner) {
-    const ownsOutput = snapshot.owner?.windowId === owner.windowId
-        && snapshot.owner.output.kind === owner.output.kind && snapshot.owner.output.id === owner.output.id;
+    const ownsOutput =
+        snapshot.owner?.windowId === owner.windowId &&
+        snapshot.owner.output.kind === owner.output.kind &&
+        snapshot.owner.output.id === owner.output.id;
     return { ...snapshot, busy: isBusyPhase(snapshot.phase), ownsOutput };
 }

--- a/packages/agent-core/src/voice/controller.ts
+++ b/packages/agent-core/src/voice/controller.ts
@@ -1,8 +1,20 @@
 import {
-    VOICE_FORMAT, VOICE_LIMITS, VOICE_VERSION, idleVoiceSnapshot,
-    type CaptureEvent, type TranscriptEvent, type VoiceCapture, type VoiceDependencies,
-    type VoiceErrorCode, type VoiceFrame, type VoiceOwner, type VoiceSnapshot, type VoiceTranscription,
-} from './contracts';
+    VOICE_FORMAT,
+    VOICE_LIMITS,
+    VOICE_VERSION,
+    idleVoiceSnapshot,
+    defaultVoiceOptions,
+    validVoiceQuality,
+    type VoiceOptions,
+    type CaptureEvent,
+    type VoiceCapture,
+    type VoiceDependencies,
+    type VoiceErrorCode,
+    type VoiceFrame,
+    type VoiceOwner,
+    type VoiceSnapshot,
+    type VoiceTranscription,
+} from "./contracts";
 
 interface Session {
     id: string;
@@ -10,14 +22,13 @@ interface Session {
     capture?: VoiceCapture;
     transcription?: VoiceTranscription;
     timers: unknown[];
-    queue: VoiceFrame[];
-    queuedBytes: number;
-    draining: boolean;
+    buffer?: Uint8Array;
+    options: Readonly<VoiceOptions>;
+    energySamples: number;
+    windowSamples: number;
+    windowSquares: number;
     captureDone: boolean;
-    endSent: boolean;
     tailSeen: boolean;
-    transcriptSequence: number;
-    nextSegment: number;
 }
 
 /** One controller per host instance, owned outside UI realms. All terminal paths revoke first. */
@@ -32,25 +43,69 @@ export class VoiceController {
     getSnapshot = (): VoiceSnapshot => this.state;
     subscribe = (listener: () => void): (() => void) => {
         this.listeners.add(listener);
-        return () => { this.listeners.delete(listener); };
+        return () => {
+            this.listeners.delete(listener);
+        };
     };
 
-    start(owner: VoiceOwner, expectedUserId: string): { sessionId: string } | { error: { code: VoiceErrorCode } } {
-        if (this.active) return { error: { code: 'busy' } };
+    start(
+        owner: VoiceOwner,
+        expectedUserId: string,
+        options: VoiceOptions = defaultVoiceOptions(),
+    ): { sessionId: string } | { error: { code: VoiceErrorCode } } {
+        if (this.active) return { error: { code: "busy" } };
         const capability = this.deps.capability();
-        if (this.disposed || !capability.enabled) return { error: { code: 'disabled' } };
-        if (!capability.available) return { error: { code: 'unavailable' } };
+        if (this.disposed || !capability.enabled)
+            return { error: { code: "disabled" } };
+        if (!capability.available) return { error: { code: "unavailable" } };
+        if (
+            !options ||
+            typeof options.language !== "string" ||
+            !/^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/.test(options.language) ||
+            ![options.biasTerms, options.correctionVocabulary].every(
+                (terms) =>
+                    Array.isArray(terms) &&
+                    terms.length <= VOICE_LIMITS.vocabularyTerms &&
+                    terms.every(
+                        (term) => typeof term === "string" && term.length > 0,
+                    ) &&
+                    terms.reduce((n, term) => n + term.length, 0) <=
+                        VOICE_LIMITS.vocabularyCharacters,
+            )
+        ) {
+            return { error: { code: "protocol_error" } };
+        }
         const session: Session = {
-            id: this.deps.createId(), userId: expectedUserId, timers: [], queue: [], queuedBytes: 0, draining: false,
-            captureDone: false, endSent: false, tailSeen: false, transcriptSequence: -1, nextSegment: 0,
+            id: this.deps.createId(),
+            userId: expectedUserId,
+            timers: [],
+            options: Object.freeze({
+                language: options.language,
+                biasTerms: Object.freeze([...options.biasTerms]),
+                correctionVocabulary: Object.freeze([
+                    ...options.correctionVocabulary,
+                ]),
+            }),
+            energySamples: 0,
+            windowSamples: 0,
+            windowSquares: 0,
+            captureDone: false,
+            tailSeen: false,
         };
         this.active = session;
         this.state = idleVoiceSnapshot();
-        const frozenOwner = Object.freeze({ windowId: owner.windowId, output: Object.freeze({ ...owner.output }) });
-        this.update({ sessionId: session.id, owner: frozenOwner, phase: 'starting' });
+        const frozenOwner = Object.freeze({
+            windowId: owner.windowId,
+            output: Object.freeze({ ...owner.output }),
+        });
+        this.update({
+            sessionId: session.id,
+            owner: frozenOwner,
+            phase: "starting",
+        });
         // Listeners may cancel synchronously when an owning surface disappears.
         if (this.isActive(session)) {
-            this.deadline(session, VOICE_LIMITS.startupMs, 'startup_timeout');
+            this.deadline(session, VOICE_LIMITS.startupMs, "startup_timeout");
             void this.setup(session);
         }
         return { sessionId: session.id };
@@ -58,44 +113,58 @@ export class VoiceController {
 
     finish(sessionId: string): void {
         const s = this.active;
-        if (!s || s.id !== sessionId || this.state.phase === 'finalizing') return;
+        if (!s || s.id !== sessionId || this.state.phase === "finalizing")
+            return;
         // Releasing activation during permission/setup requires a fresh activation.
-        if (this.state.phase === 'starting') { this.cancel(sessionId); return; }
+        if (this.state.phase === "starting") {
+            this.cancel(sessionId);
+            return;
+        }
         this.clearTimers(s);
-        this.update({ phase: 'finalizing' });
+        this.update({ phase: "finalizing" });
         if (!this.isActive(s)) return;
-        this.deadline(s, VOICE_LIMITS.finalizationMs, 'finalization_timeout');
+        this.deadline(s, VOICE_LIMITS.finalizationMs, "finalization_timeout");
         void this.finishCapture(s);
     }
 
     cancel(sessionId: string): void {
-        if (this.active?.id === sessionId) this.terminate(this.active, 'canceled');
+        if (this.active?.id === sessionId)
+            this.terminate(this.active, "canceled");
     }
 
     windowUnloaded(windowId: string): void {
-        if (this.active && this.state.owner?.windowId === windowId) this.cancel(this.active.id);
+        if (this.active && this.state.owner?.windowId === windowId)
+            this.cancel(this.active.id);
     }
 
     /** Call on logout/account replacement, including while credentials are still being resolved. */
     authChanged(userId: string | null): void {
         if (this.active && (!userId || this.active.userId !== userId)) {
-            this.terminate(this.active, 'canceled');
+            this.terminate(this.active, "canceled");
         }
     }
 
     dispose(): void {
         this.disposed = true;
-        if (this.active) this.terminate(this.active, 'canceled');
+        if (this.active) this.terminate(this.active, "canceled");
         this.listeners.clear();
     }
 
-    private isActive(s: Session): boolean { return this.active === s; }
+    private isActive(s: Session): boolean {
+        return this.active === s;
+    }
 
     private update(patch: Partial<VoiceSnapshot>): void {
         this.state = Object.freeze({ ...this.state, ...patch });
         if (patch.error) Object.freeze(patch.error);
         // A view failing to render must not prevent resource disposal or another view's update.
-        for (const listener of [...this.listeners]) { try { listener(); } catch { /* Isolated observer. */ } }
+        for (const listener of [...this.listeners]) {
+            try {
+                listener();
+            } catch {
+                /* Isolated observer. */
+            }
+        }
     }
 
     private deadline(s: Session, ms: number, code: VoiceErrorCode): void {
@@ -108,30 +177,46 @@ export class VoiceController {
     }
 
     private async setup(s: Session): Promise<void> {
-        let failureCode: VoiceErrorCode = 'unauthenticated';
+        let failureCode: VoiceErrorCode = "unauthenticated";
         try {
             const auth = await this.deps.getAuth();
             if (!this.isActive(s)) return;
-            if (!auth?.credential || !auth.userId) { this.fail(s, 'unauthenticated'); return; }
-            if (s.userId && s.userId !== auth.userId) { this.terminate(s, 'canceled'); return; }
+            if (!auth?.credential || !auth.userId) {
+                this.fail(s, "unauthenticated");
+                return;
+            }
+            if (s.userId && s.userId !== auth.userId) {
+                this.terminate(s, "canceled");
+                return;
+            }
             s.userId = auth.userId;
             const envelope = { version: VOICE_VERSION, sessionId: s.id };
-            failureCode = 'transcription_failed';
-            const transcription = this.deps.createTranscription(envelope, event => this.transcript(s, event));
-            if (!this.isActive(s)) { transcription.dispose(); return; }
+            failureCode = "transcription_failed";
+            const transcription = this.deps.createTranscription(envelope);
+            if (!this.isActive(s)) {
+                transcription.dispose();
+                return;
+            }
             s.transcription = transcription;
-            await transcription.start(auth.credential);
-            if (!this.isActive(s)) return;
-            failureCode = 'capture_failed';
-            const capture = this.deps.createCapture(envelope, event => this.capture(s, event));
-            if (!this.isActive(s)) { capture.dispose(); return; }
+            failureCode = "capture_failed";
+            const capture = this.deps.createCapture(envelope, (event) =>
+                this.capture(s, event),
+            );
+            if (!this.isActive(s)) {
+                capture.dispose();
+                return;
+            }
             s.capture = capture;
             await capture.start();
             if (!this.isActive(s)) return;
-            if (!this.state.captureReady) { this.fail(s, 'protocol_error'); return; }
+            if (!this.state.captureReady) {
+                this.fail(s, "protocol_error");
+                return;
+            }
             this.clearTimers(s);
-            this.update({ phase: 'listening' });
-            if (this.isActive(s)) this.deadline(s, VOICE_LIMITS.durationMs, 'duration_limit');
+            this.update({ phase: "listening" });
+            if (this.isActive(s))
+                this.deadline(s, VOICE_LIMITS.durationMs, "duration_limit");
         } catch {
             this.fail(s, failureCode);
         }
@@ -139,110 +224,200 @@ export class VoiceController {
 
     private capture(s: Session, event: CaptureEvent): void {
         if (!this.isActive(s) || event.sessionId !== s.id) return;
-        if (event.version !== VOICE_VERSION) { this.fail(s, 'protocol_error'); return; }
-        if (event.type === 'error') { this.fail(s, event.error.code); return; }
-        if (event.type === 'ready') {
-            if (this.state.captureReady || !this.validFormat(event.format)) { this.fail(s, 'protocol_error'); return; }
+        if (event.version !== VOICE_VERSION) {
+            this.fail(s, "protocol_error");
+            return;
+        }
+        if (event.type === "error") {
+            this.fail(s, event.error.code);
+            return;
+        }
+        if (event.type === "quality") {
+            if (
+                s.captureDone ||
+                !validVoiceQuality(event.quality, this.state.quality)
+            ) {
+                this.fail(s, "protocol_error");
+                return;
+            }
+            this.update({
+                quality: Object.freeze({ ...event.quality }),
+                clipping: event.quality.clippedSamples > 0,
+            });
+            return;
+        }
+        if (event.type === "ready") {
+            if (this.state.captureReady || !this.validFormat(event.format)) {
+                this.fail(s, "protocol_error");
+                return;
+            }
             this.update({ captureReady: true });
             return;
         }
         const f = event.frame;
-        if (!this.state.captureReady || s.captureDone || s.tailSeen || f.version !== VOICE_VERSION
-            || f.sessionId !== s.id || f.sequence !== this.state.frameCount
-            || !Number.isInteger(f.sampleCount) || f.sampleCount <= 0 || f.sampleCount > VOICE_LIMITS.frameSamples
-            || f.pcm.byteLength !== f.sampleCount * 2 || !this.validFormat(f.format)
-            || (f.sampleCount < VOICE_LIMITS.frameSamples && this.state.phase !== 'finalizing')) {
-            this.fail(s, 'protocol_error'); return;
+        if (
+            !this.state.captureReady ||
+            s.captureDone ||
+            s.tailSeen ||
+            f.version !== VOICE_VERSION ||
+            f.sessionId !== s.id ||
+            f.sequence !== this.state.frameCount ||
+            !Number.isInteger(f.sampleCount) ||
+            f.sampleCount <= 0 ||
+            f.sampleCount > VOICE_LIMITS.frameSamples ||
+            f.pcm.byteLength !== f.sampleCount * 2 ||
+            !this.validFormat(f.format) ||
+            (f.sampleCount < VOICE_LIMITS.frameSamples &&
+                this.state.phase !== "finalizing")
+        ) {
+            this.fail(s, "protocol_error");
+            return;
         }
-        if (s.queuedBytes + f.pcm.byteLength > VOICE_LIMITS.queuedBytes) { this.fail(s, 'overflow'); return; }
+        const offset = this.state.sampleCount * 2;
+        if (offset + f.pcm.byteLength > VOICE_LIMITS.bufferBytes) {
+            this.fail(s, "duration_limit");
+            return;
+        }
         s.tailSeen = f.sampleCount < VOICE_LIMITS.frameSamples;
-        const pcm = new Uint8Array(f.pcm);
-        s.queue.push({ ...f, format: VOICE_FORMAT, pcm });
-        s.queuedBytes += pcm.byteLength;
+        s.buffer ??= new Uint8Array(VOICE_LIMITS.bufferBytes);
+        s.buffer.set(f.pcm, offset);
+        const pcm = s.buffer.subarray(offset, offset + f.pcm.byteLength);
         let squares = 0;
         for (let i = 0; i < pcm.length; i += 2) {
             const unsigned = pcm[i] | (pcm[i + 1] << 8);
-            const sample = (unsigned >= 32768 ? unsigned - 65536 : unsigned) / 32768;
+            const sample =
+                (unsigned >= 32768 ? unsigned - 65536 : unsigned) / 32768;
             squares += sample * sample;
+            s.windowSquares += sample * sample;
+            if (++s.windowSamples === VOICE_LIMITS.energyWindowSamples) {
+                if (
+                    s.windowSquares / s.windowSamples >=
+                    VOICE_LIMITS.energyRms ** 2
+                )
+                    s.energySamples += s.windowSamples;
+                s.windowSamples = 0;
+                s.windowSquares = 0;
+            }
         }
-        this.update({ audioStarted: true, frameCount: f.sequence + 1,
-            sampleCount: this.state.sampleCount + f.sampleCount, level: Math.sqrt(squares / f.sampleCount) });
-        if (this.isActive(s)) void this.drain(s);
+        this.update({
+            audioStarted: true,
+            frameCount: f.sequence + 1,
+            sampleCount: this.state.sampleCount + f.sampleCount,
+            level: Math.sqrt(squares / f.sampleCount),
+        });
     }
 
-    private validFormat(format: VoiceFrame['format']): boolean {
-        return format.encoding === VOICE_FORMAT.encoding && format.sampleRate === VOICE_FORMAT.sampleRate
-            && format.channels === VOICE_FORMAT.channels;
-    }
-
-    private async drain(s: Session): Promise<void> {
-        if (s.draining || !this.isActive(s)) return;
-        s.draining = true;
-        try {
-            while (this.isActive(s) && s.queue.length) {
-                const frame = s.queue.shift()!;
-                await s.transcription!.send(frame);
-                if (!this.isActive(s)) return;
-                s.queuedBytes -= frame.pcm.byteLength;
-            }
-            if (this.isActive(s) && s.captureDone && !s.endSent) {
-                s.endSent = true;
-                await s.transcription!.finish({ type: 'end_audio', version: VOICE_VERSION, sessionId: s.id,
-                    frameCount: this.state.frameCount, sampleCount: this.state.sampleCount });
-            }
-        } catch { this.fail(s, 'transcription_failed'); }
-        finally { s.draining = false; }
+    private validFormat(format: VoiceFrame["format"]): boolean {
+        return (
+            format.encoding === VOICE_FORMAT.encoding &&
+            format.sampleRate === VOICE_FORMAT.sampleRate &&
+            format.channels === VOICE_FORMAT.channels
+        );
     }
 
     private async finishCapture(s: Session): Promise<void> {
+        let failureCode: VoiceErrorCode = "capture_failed";
         try {
             await s.capture!.finish();
             if (!this.isActive(s)) return;
             s.captureDone = true;
-            void this.drain(s);
-        } catch { this.fail(s, 'capture_failed'); }
-    }
-
-    private transcript(s: Session, event: TranscriptEvent): void {
-        if (!this.isActive(s) || event.sessionId !== s.id) return;
-        if (event.version !== VOICE_VERSION) { this.fail(s, 'protocol_error'); return; }
-        if (event.type === 'error') { this.fail(s, event.error.code); return; }
-        if (!Number.isSafeInteger(event.sequence) || event.sequence < 0) { this.fail(s, 'protocol_error'); return; }
-        if (event.sequence <= s.transcriptSequence) return;
-        if (event.sequence !== s.transcriptSequence + 1) { this.fail(s, 'protocol_error'); return; }
-        s.transcriptSequence = event.sequence;
-        if (event.type === 'complete') {
-            if (!s.endSent || this.state.provisionalText) { this.fail(s, 'protocol_error'); return; }
-            this.terminate(s, 'completed');
-            return;
-        }
-        if (typeof event.text !== 'string' || !Number.isSafeInteger(event.segmentId) || event.segmentId < 0) { this.fail(s, 'protocol_error'); return; }
-        if (event.segmentId < s.nextSegment) return;
-        if (event.segmentId !== s.nextSegment) { this.fail(s, 'protocol_error'); return; }
-        if (s.nextSegment >= VOICE_LIMITS.segments
-            || this.state.committedText.length + event.text.length > VOICE_LIMITS.transcriptCharacters) {
-            this.fail(s, 'overflow'); return;
-        }
-        if (event.type === 'interim') this.update({ provisionalText: event.text });
-        else {
-            s.nextSegment++;
-            this.update({ committedText: this.state.committedText + event.text, provisionalText: '' });
+            // Release the microphone/lease before authentication, encoding or network work.
+            s.capture!.dispose();
+            if (!this.isActive(s)) return;
+            if (
+                this.state.sampleCount < VOICE_LIMITS.minimumSamples ||
+                s.energySamples < VOICE_LIMITS.minimumEnergySamples
+            ) {
+                this.fail(s, "no_speech");
+                return;
+            }
+            this.clearTimers(s);
+            this.deadline(
+                s,
+                VOICE_LIMITS.transcriptionMs,
+                "transcription_timeout",
+            );
+            failureCode = "unauthenticated";
+            const auth = await this.deps.getAuth();
+            if (!this.isActive(s)) return;
+            if (!auth?.credential || !auth.userId) {
+                this.fail(s, "unauthenticated");
+                return;
+            }
+            if (auth.userId !== s.userId) {
+                this.terminate(s, "canceled");
+                return;
+            }
+            failureCode = "transcription_failed";
+            const result = await s.transcription!.transcribe(
+                {
+                    version: VOICE_VERSION,
+                    sessionId: s.id,
+                    format: VOICE_FORMAT,
+                    pcm: s.buffer!.subarray(0, this.state.sampleCount * 2),
+                    sampleCount: this.state.sampleCount,
+                    options: s.options,
+                },
+                auth.credential,
+            );
+            if (!this.isActive(s)) return;
+            if (
+                !result ||
+                result.version !== VOICE_VERSION ||
+                result.sessionId !== s.id
+            ) {
+                this.fail(s, "protocol_error");
+                return;
+            }
+            if ("error" in result) {
+                this.fail(s, result.error.code);
+                return;
+            }
+            if (typeof result.text !== "string") {
+                this.fail(s, "protocol_error");
+                return;
+            }
+            if (result.text.length > VOICE_LIMITS.transcriptCharacters) {
+                this.fail(s, "overflow");
+                return;
+            }
+            this.terminate(s, "completed", undefined, result.text);
+        } catch {
+            this.fail(s, failureCode);
         }
     }
 
     private fail(s: Session, code: VoiceErrorCode): void {
-        if (this.isActive(s)) this.terminate(s, 'error', code);
+        if (this.isActive(s)) this.terminate(s, "error", code);
     }
 
-    private terminate(s: Session, phase: 'completed' | 'canceled' | 'error', code?: VoiceErrorCode): void {
+    private terminate(
+        s: Session,
+        phase: "completed" | "canceled" | "error",
+        code?: VoiceErrorCode,
+        text = "",
+    ): void {
         if (!this.isActive(s)) return;
         this.active = undefined;
         this.clearTimers(s);
-        s.queue = [];
-        s.queuedBytes = 0;
+        s.buffer?.fill(0);
+        s.buffer = undefined;
         // Revocation precedes disposal: adapters may synchronously deliver their last callback.
-        try { s.capture?.dispose(); } catch { /* Still dispose the transport. */ }
-        try { s.transcription?.dispose(); } catch { /* Terminal state is authoritative. */ }
-        this.update({ phase, provisionalText: '', level: 0, error: code ? { code } : null });
+        try {
+            s.capture?.dispose();
+        } catch {
+            /* Still dispose the transport. */
+        }
+        try {
+            s.transcription?.dispose();
+        } catch {
+            /* Terminal state is authoritative. */
+        }
+        this.update({
+            phase,
+            committedText: text,
+            level: 0,
+            error: code ? { code } : null,
+        });
     }
 }

--- a/packages/agent-core/src/voice/fakes.ts
+++ b/packages/agent-core/src/voice/fakes.ts
@@ -1,25 +1,55 @@
 import {
-    VOICE_FORMAT, type CaptureEvent, type TranscriptEvent, type VoiceCapture,
-    type VoiceControl, type VoiceEnvelope, type VoiceFrame, type VoiceTranscription,
-} from './contracts';
+    VOICE_FORMAT,
+    type CaptureEvent,
+    type VoiceCapture,
+    type VoiceEnvelope,
+    type VoiceRecording,
+    type VoiceTranscript,
+    type VoiceTranscription,
+} from "./contracts";
 
 /** Manually driven fake: no microphone, provider, timers, or retained audio. */
 export class FakeVoiceCapture implements VoiceCapture {
-    get disposed(): boolean { return this.disposeCount > 0; }
+    get disposed(): boolean {
+        return this.disposeCount > 0;
+    }
     disposeCount = 0;
     finishCount = 0;
     sequence = 0;
     tailSamples = 640;
-    constructor(readonly session: VoiceEnvelope, readonly emit: (event: CaptureEvent) => void) {}
+    constructor(
+        readonly session: VoiceEnvelope,
+        readonly emit: (event: CaptureEvent) => void,
+    ) {}
     async start(): Promise<void> {
-        if (!this.disposed) this.emit({ ...this.session, type: 'ready', format: VOICE_FORMAT });
+        if (!this.disposed)
+            this.emit({ ...this.session, type: "ready", format: VOICE_FORMAT });
     }
-    frame(sampleCount = 1600): void {
+    frame(sampleCount = 1600, amplitude = 0.2): void {
         if (this.disposed) return;
-        this.emit({ ...this.session, type: 'frame', frame: {
-            ...this.session, sequence: this.sequence++, sampleCount, format: VOICE_FORMAT,
-            pcm: new Uint8Array(sampleCount * 2),
-        } });
+        const pcm = new Uint8Array(sampleCount * 2);
+        const view = new DataView(pcm.buffer);
+        for (let i = 0; i < sampleCount; i++)
+            view.setInt16(
+                i * 2,
+                Math.round(
+                    Math.sin((2 * Math.PI * 440 * i) / 16000) *
+                        amplitude *
+                        32767,
+                ),
+                true,
+            );
+        this.emit({
+            ...this.session,
+            type: "frame",
+            frame: {
+                ...this.session,
+                sequence: this.sequence++,
+                sampleCount,
+                format: VOICE_FORMAT,
+                pcm,
+            },
+        });
     }
     async finish(): Promise<void> {
         if (this.disposed || this.finishCount) return;
@@ -32,32 +62,24 @@ export class FakeVoiceCapture implements VoiceCapture {
     }
 }
 
-/** Script transcript events explicitly; finish optionally emits a complete acknowledgement. */
+/** Deterministic batch adapter. Retains counts only; callers may delay/replace transcribe in tests. */
 export class FakeVoiceTranscription implements VoiceTranscription {
-    get disposed(): boolean { return this.disposeCount > 0; }
+    get disposed(): boolean {
+        return this.disposeCount > 0;
+    }
     disposeCount = 0;
-    sendCount = 0;
+    requestCount = 0;
     sampleCount = 0;
-    sequence = 0;
-    autoComplete = true;
-    endAudio?: VoiceControl & { type: 'end_audio' };
-    constructor(readonly session: VoiceEnvelope, readonly emit: (event: TranscriptEvent) => void) {}
-    async start(_credential: string): Promise<void> {}
-    async send(frame: VoiceFrame): Promise<void> {
-        if (this.disposed) return;
-        this.sendCount++;
-        this.sampleCount += frame.sampleCount;
-    }
-    text(type: 'interim' | 'segment_final', segmentId: number, text: string): void {
-        if (!this.disposed) this.emit({ ...this.session, type, segmentId, text, sequence: this.sequence++ });
-    }
-    complete(): void {
-        if (!this.disposed) this.emit({ ...this.session, type: 'complete', sequence: this.sequence++ });
-    }
-    async finish(control: VoiceControl & { type: 'end_audio' }): Promise<void> {
-        if (this.disposed) return;
-        this.endAudio = control;
-        if (this.autoComplete) this.complete();
+    resultText = "";
+    constructor(readonly session: VoiceEnvelope) {}
+    async transcribe(
+        recording: VoiceRecording,
+        _credential: string,
+    ): Promise<VoiceTranscript> {
+        if (this.disposed) throw new Error("Transcription disposed");
+        this.requestCount++;
+        this.sampleCount = recording.sampleCount;
+        return { ...this.session, text: this.resultText };
     }
     dispose(): void {
         if (this.disposed) return;

--- a/src/services/voice/developmentHarness.ts
+++ b/src/services/voice/developmentHarness.ts
@@ -1,12 +1,25 @@
-import { FakeVoiceCapture, FakeVoiceTranscription } from '@beaver/agent-core/voice/fakes';
-import { VOICE_LIMITS, type VoiceAuth, type VoiceClock } from '@beaver/agent-core/voice/contracts';
-import { NativeCaptureHarness, type NativeCaptureHost } from './nativeCaptureHarness';
-import { createVoiceService, type VoiceService, type VoiceWindow } from './voiceService';
+import {
+    FakeVoiceCapture,
+    FakeVoiceTranscription,
+} from "@beaver/agent-core/voice/fakes";
+import {
+    VOICE_LIMITS,
+    type VoiceAuth,
+    type VoiceClock,
+} from "@beaver/agent-core/voice/contracts";
+import {
+    NativeCaptureHarness,
+    type NativeCaptureHost,
+} from "./nativeCaptureHarness";
+import {
+    createVoiceService,
+    type VoiceService,
+    type VoiceWindow,
+} from "./voiceService";
 
 export interface VoiceHarnessRequest {
     command: string;
     text?: string;
-    segmentId?: number;
     enabled?: boolean;
 }
 
@@ -26,63 +39,102 @@ export class DevelopmentVoiceHarness {
     private transcription?: FakeVoiceTranscription;
 
     constructor(clock?: VoiceClock, native?: NativeCaptureHost) {
-        this.service = createVoiceService({
-            capability: () => ({ enabled: this.enabled || this.nativeHarness?.activating === true, available: true }),
-            createCapture: (session, emit) => this.nativeHarness?.ownsSession(session.sessionId)
-                ? this.nativeHarness.createCapture(session, emit)
-                : this.capture = new FakeVoiceCapture(session, emit),
-            createTranscription: (session, emit) => this.transcription = new FakeVoiceTranscription(session, emit),
-        }, clock);
-        if (native) this.nativeHarness = new NativeCaptureHarness(this.service, native);
+        this.service = createVoiceService(
+            {
+                capability: () => ({
+                    enabled:
+                        this.enabled || this.nativeHarness?.activating === true,
+                    available: true,
+                }),
+                createCapture: (session, emit) =>
+                    this.nativeHarness?.ownsSession(session.sessionId)
+                        ? this.nativeHarness.createCapture(session, emit)
+                        : (this.capture = new FakeVoiceCapture(session, emit)),
+                createTranscription: (session) =>
+                    (this.transcription = new FakeVoiceTranscription(session)),
+            },
+            clock,
+        );
+        if (native)
+            this.nativeHarness = new NativeCaptureHarness(this.service, native);
     }
 
     start(expectedUserId: string, getAuth: () => Promise<VoiceAuth | null>) {
-        if (this.nativeHarness?.preparingPermission) return { error: { code: 'busy' as const } };
-        return this.service.start(this.owner, { kind: 'draft', id: 'fake-voice-draft' }, getAuth, expectedUserId);
+        if (this.nativeHarness?.preparingPermission)
+            return { error: { code: "busy" as const } };
+        return this.service.start(
+            this.owner,
+            { kind: "draft", id: "fake-voice-draft" },
+            getAuth,
+            expectedUserId,
+        );
     }
 
     /** Explicit local invocation; no HTTP command can activate the microphone. */
     async startNative(win: Window, retainAudio = false) {
-        if (!this.nativeHarness) throw new Error('Configure the development helper first');
+        if (!this.nativeHarness)
+            throw new Error("Configure the development helper first");
         return this.nativeHarness.start(win, retainAudio);
     }
 
-    nativeState() { return this.nativeHarness?.getState(); }
+    nativeState() {
+        return this.nativeHarness?.getState();
+    }
 
     async saveRecording(path: string) {
-        if (!this.nativeHarness) throw new Error('No completed opt-in recording');
+        if (!this.nativeHarness)
+            throw new Error("No completed opt-in recording");
         await this.nativeHarness.saveRecording(path);
     }
 
     /** Never accepts PCM, credentials, or a provider URL. */
     run(request: VoiceHarnessRequest) {
         const { sessionId } = this.service.controller.getSnapshot();
-        const capture = this.capture?.session.sessionId === sessionId ? this.capture : undefined;
-        const transcription = this.transcription?.session.sessionId === sessionId ? this.transcription : undefined;
+        const capture =
+            this.capture?.session.sessionId === sessionId
+                ? this.capture
+                : undefined;
+        const transcription =
+            this.transcription?.session.sessionId === sessionId
+                ? this.transcription
+                : undefined;
         switch (request.command) {
-            case 'enable':
+            case "enable":
                 this.enabled = request.enabled === true;
-                if (!this.enabled && sessionId) this.service.controller.cancel(sessionId);
+                if (!this.enabled && sessionId)
+                    this.service.controller.cancel(sessionId);
                 break;
-            case 'frame': capture?.frame(); break;
-            case 'interim':
-            case 'segment_final':
-                if (typeof request.text !== 'string' || request.text.length > VOICE_LIMITS.transcriptCharacters
-                    || !Number.isSafeInteger(request.segmentId) || request.segmentId! < 0) {
-                    throw new Error('Invalid synthetic transcript');
+            case "frame":
+                capture?.frame();
+                break;
+            case "transcript":
+                if (
+                    typeof request.text !== "string" ||
+                    request.text.length > VOICE_LIMITS.transcriptCharacters
+                ) {
+                    throw new Error("Invalid synthetic transcript");
                 }
-                transcription?.text(request.command, request.segmentId!, request.text);
+                if (transcription) transcription.resultText = request.text;
                 break;
-            case 'finish': if (sessionId) this.service.controller.finish(sessionId); break;
-            case 'cancel': if (sessionId) this.service.controller.cancel(sessionId); break;
-            case 'state': break;
-            default: throw new Error('Unknown voice harness command');
+            case "finish":
+                if (sessionId) this.service.controller.finish(sessionId);
+                break;
+            case "cancel":
+                if (sessionId) this.service.controller.cancel(sessionId);
+                break;
+            case "state":
+                break;
+            default:
+                throw new Error("Unknown voice harness command");
         }
-        return { state: this.service.controller.getSnapshot(), resources: {
-            captureDisposeCount: capture?.disposeCount ?? 0,
-            transcriptionDisposeCount: transcription?.disposeCount ?? 0,
-            sentFrames: transcription?.sendCount ?? 0,
-            endAudio: transcription?.endAudio ?? null,
-        } };
+        return {
+            state: this.service.controller.getSnapshot(),
+            resources: {
+                captureDisposeCount: capture?.disposeCount ?? 0,
+                transcriptionDisposeCount: transcription?.disposeCount ?? 0,
+                requestCount: transcription?.requestCount ?? 0,
+                transcribedSamples: transcription?.sampleCount ?? 0,
+            },
+        };
     }
 }

--- a/src/services/voice/macCapture.ts
+++ b/src/services/voice/macCapture.ts
@@ -2,6 +2,8 @@ import {
     VOICE_FORMAT,
     VOICE_LIMITS,
     VOICE_VERSION,
+    emptyVoiceQuality,
+    validVoiceQuality,
     type CaptureEvent,
     type VoiceCapture,
     type VoiceClock,
@@ -136,6 +138,7 @@ class MacCapture implements VoiceCapture {
     private stopping = false;
     private tail = false;
     private sequence = 0;
+    private quality = emptyVoiceQuality();
     private sampleCount = 0;
     private controlSequence = 0;
     private eventSequence = 0;
@@ -231,6 +234,21 @@ class MacCapture implements VoiceCapture {
             if (!this.dead) this.watch();
         }, MAC_VOICE_LIMITS.heartbeatMs);
     }
+    private receiveQuality(value: unknown): void {
+        const quality = value as ReturnType<typeof emptyVoiceQuality>;
+        if (!validVoiceQuality(quality, this.quality))
+            throw new Error("quality");
+        this.quality = {
+            inputPeak: quality.inputPeak,
+            clippedSamples: quality.clippedSamples,
+            discontinuityCount: quality.discontinuityCount,
+        };
+        this.emit({
+            ...this.session,
+            type: "quality",
+            quality: { ...this.quality },
+        });
+    }
     receive(m: any): VoiceHttpResponse {
         if (this.dead || !this.started)
             return { status: 403, body: { command: "cancel" } };
@@ -249,7 +267,7 @@ class MacCapture implements VoiceCapture {
                 throw new Error("event_order");
             switch (m.type) {
                 case "hello":
-                    if (this.hello || m.helperVersion !== 1)
+                    if (this.hello || m.helperVersion !== 2)
                         throw new Error("hello");
                     this.hello = true;
                     this.lastControl = this.host.now();
@@ -320,6 +338,15 @@ class MacCapture implements VoiceCapture {
                         )
                     )
                         throw new Error("frame");
+                    if (
+                        this.sampleCount + m.sampleCount >
+                        VOICE_LIMITS.bufferBytes / 2
+                    ) {
+                        this.fail("duration_limit");
+                        break;
+                    }
+                    this.receiveQuality(m.quality);
+                    if (this.dead) break;
                     const pcm = this.host.decode(m.pcm);
                     if (pcm.length !== m.sampleCount * 2)
                         throw new Error("pcm");
@@ -355,6 +382,7 @@ class MacCapture implements VoiceCapture {
                     };
                 case "error":
                     if (!nativeErrors.has(m.code)) throw new Error("error");
+                    this.receiveQuality(m.quality);
                     this.fail(m.code);
                     break;
                 default:

--- a/src/services/voice/nativeCaptureHarness.ts
+++ b/src/services/voice/nativeCaptureHarness.ts
@@ -128,7 +128,11 @@ export class NativeCaptureHarness {
             state,
             permission: this.native.permission,
             metrics: { ...this.metrics },
-            help: state.error ? microphoneHelp(state.error.code) : null,
+            help: state.error
+                ? microphoneHelp(state.error.code)
+                : state.clipping
+                  ? "Your microphone is clipping. Lower the microphone input level or move farther away."
+                  : null,
             retainedBytes: this.retainedBytes,
         };
     }

--- a/src/services/voice/nativeVoice.ts
+++ b/src/services/voice/nativeVoice.ts
@@ -159,6 +159,8 @@ export class NativeVoice {
 }
 
 export function microphoneHelp(code: VoiceErrorCode): string {
+    if (code === "no_speech")
+        return "No speech detected. Check that your microphone is unmuted and try again.";
     if (code === "permission_denied")
         return "Allow Beaver Voice Input in System Settings → Privacy & Security → Microphone, then start again.";
     if (code === "device_unavailable")

--- a/src/services/voice/voiceService.ts
+++ b/src/services/voice/voiceService.ts
@@ -1,18 +1,35 @@
-import { VoiceController } from '@beaver/agent-core/voice/controller';
-import { isBusyPhase, type VoiceAuth, type VoiceClock, type VoiceDependencies, type VoiceOwner } from '@beaver/agent-core/voice/contracts';
+import { VoiceController } from "@beaver/agent-core/voice/controller";
+import {
+    isBusyPhase,
+    type VoiceAuth,
+    type VoiceClock,
+    type VoiceDependencies,
+    type VoiceOwner,
+    type VoiceOptions,
+} from "@beaver/agent-core/voice/contracts";
 
-export type VoiceWindow = Pick<Window, 'closed' | 'addEventListener' | 'removeEventListener'> & {
-    document: Pick<Document, 'hasFocus'>;
+export type VoiceWindow = Pick<
+    Window,
+    "closed" | "addEventListener" | "removeEventListener"
+> & {
+    document: Pick<Document, "hasFocus">;
 };
 
-export type VoiceAdapters = Pick<VoiceDependencies, 'capability' | 'createCapture' | 'createTranscription'>;
+export type VoiceAdapters = Pick<
+    VoiceDependencies,
+    "capability" | "createCapture" | "createTranscription"
+>;
 
 // The capability gate prevents activation; these factories also fail closed if
 // capability is enabled without supplying capture and transcription adapters.
 const unavailableAdapters: VoiceAdapters = {
     capability: () => ({ enabled: false, available: false }),
-    createCapture: () => { throw new Error('Voice capture unavailable'); },
-    createTranscription: () => { throw new Error('Voice transcription unavailable'); },
+    createCapture: () => {
+        throw new Error("Voice capture unavailable");
+    },
+    createTranscription: () => {
+        throw new Error("Voice transcription unavailable");
+    },
 };
 
 /** Plugin-realm owner. Production stays unavailable until capture and transport adapters ship. */
@@ -23,7 +40,10 @@ export class VoiceService {
     private windows = new WeakMap<VoiceWindow, string>();
     private nextWindowId = 0;
 
-    constructor(clock: VoiceClock, adapters: VoiceAdapters = unavailableAdapters) {
+    constructor(
+        clock: VoiceClock,
+        adapters: VoiceAdapters = unavailableAdapters,
+    ) {
         this.controller = new VoiceController({
             ...adapters,
             clock,
@@ -42,36 +62,52 @@ export class VoiceService {
 
     windowId(win: VoiceWindow): string {
         let id = this.windows.get(win);
-        if (!id) { id = `voice-window-${++this.nextWindowId}`; this.windows.set(win, id); }
+        if (!id) {
+            id = `voice-window-${++this.nextWindowId}`;
+            this.windows.set(win, id);
+        }
         return id;
     }
 
-    start(win: VoiceWindow | null | undefined, output: VoiceOwner['output'], getAuth: () => Promise<VoiceAuth | null>, expectedUserId: string) {
+    start(
+        win: VoiceWindow | null | undefined,
+        output: VoiceOwner["output"],
+        getAuth: () => Promise<VoiceAuth | null>,
+        expectedUserId: string,
+        options?: VoiceOptions,
+    ) {
         if (isBusyPhase(this.controller.getSnapshot().phase)) {
-            return { error: { code: 'busy' as const } };
+            return { error: { code: "busy" as const } };
         }
-        if (!win || win.closed || !win.document.hasFocus()) return { error: { code: 'unavailable' as const } };
+        if (!win || win.closed || !win.document.hasFocus())
+            return { error: { code: "unavailable" as const } };
         this.auth = getAuth;
         const windowId = this.windowId(win);
         const cancel = () => this.controller.windowUnloaded(windowId);
-        win.addEventListener('unload', cancel);
+        win.addEventListener("unload", cancel);
         // Ignore focus moving among controls/reader frames in this top-level window.
-        const blur = (event: Event) => { if (Object.is(event.target, win)) cancel(); };
-        win.addEventListener('blur', blur);
+        const blur = (event: Event) => {
+            if (Object.is(event.target, win)) cancel();
+        };
+        win.addEventListener("blur", blur);
         this.releaseWindow = () => {
-            win.removeEventListener('unload', cancel);
-            win.removeEventListener('blur', blur);
+            win.removeEventListener("unload", cancel);
+            win.removeEventListener("blur", blur);
         };
         let result;
         try {
-            result = this.controller.start({ windowId, output }, expectedUserId);
+            result = this.controller.start(
+                { windowId, output },
+                expectedUserId,
+                options,
+            );
         } catch (error) {
             this.releaseWindow?.();
             this.releaseWindow = undefined;
             this.auth = undefined;
             throw error;
         }
-        if ('error' in result) {
+        if ("error" in result) {
             this.releaseWindow?.();
             this.releaseWindow = undefined;
             this.auth = undefined;
@@ -83,18 +119,27 @@ export class VoiceService {
         const id = this.windows.get(win);
         if (id) this.controller.windowUnloaded(id);
     }
-    authChanged(userId: string | null): void { this.controller.authChanged(userId); }
-    dispose(): void { this.controller.dispose(); }
+    authChanged(userId: string | null): void {
+        this.controller.authChanged(userId);
+    }
+    dispose(): void {
+        this.controller.dispose();
+    }
 }
 
 export function systemClock(): VoiceClock {
-    const timers = ChromeUtils.importESModule('resource://gre/modules/Timer.sys.mjs');
+    const timers = ChromeUtils.importESModule(
+        "resource://gre/modules/Timer.sys.mjs",
+    );
     return {
         setTimeout: (callback, ms) => timers.setTimeout(callback, ms),
-        clearTimeout: handle => timers.clearTimeout(handle),
+        clearTimeout: (handle) => timers.clearTimeout(handle),
     };
 }
 
-export function createVoiceService(adapters?: VoiceAdapters, clock: VoiceClock = systemClock()): VoiceService {
+export function createVoiceService(
+    adapters?: VoiceAdapters,
+    clock: VoiceClock = systemClock(),
+): VoiceService {
     return new VoiceService(clock, adapters);
 }

--- a/tests/fixtures/voice/session.json
+++ b/tests/fixtures/voice/session.json
@@ -1,17 +1,33 @@
 {
-  "version": 1,
-  "sessionId": "fixture-session",
-  "format": { "encoding": "pcm_s16le", "sampleRate": 16000, "channels": 1 },
-  "frames": [
-    { "sequence": 0, "sampleCount": 1600, "byteLength": 3200 },
-    { "sequence": 1, "sampleCount": 640, "byteLength": 1280 }
-  ],
-  "transcript": [
-    { "type": "interim", "sequence": 0, "segmentId": 0, "text": "A short" },
-    { "type": "interim", "sequence": 1, "segmentId": 0, "text": "A short voice" },
-    { "type": "segment_final", "sequence": 2, "segmentId": 0, "text": "A short voice test." },
-    { "type": "complete", "sequence": 3 }
-  ],
-  "endAudio": { "type": "end_audio", "frameCount": 2, "sampleCount": 2240 },
-  "committedText": "A short voice test."
+    "version": 1,
+    "sessionId": "fixture-session",
+    "format": {
+        "encoding": "pcm_s16le",
+        "sampleRate": 16000,
+        "channels": 1
+    },
+    "frames": [
+        {
+            "sequence": 0,
+            "sampleCount": 1600,
+            "byteLength": 3200
+        },
+        {
+            "sequence": 1,
+            "sampleCount": 1600,
+            "byteLength": 3200
+        },
+        {
+            "sequence": 2,
+            "sampleCount": 1600,
+            "byteLength": 3200
+        },
+        {
+            "sequence": 3,
+            "sampleCount": 640,
+            "byteLength": 1280
+        }
+    ],
+    "transcript": "A short voice test.",
+    "sampleCount": 5440
 }

--- a/tests/live/voice.live.test.ts
+++ b/tests/live/voice.live.test.ts
@@ -1,64 +1,106 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
-import { post } from '../helpers/zoteroHttpClient';
-import type { VoiceSnapshot } from '@beaver/agent-core/voice/contracts';
-import fixture from '../fixtures/voice/session.json';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+    isZoteroAvailable,
+    skipIfNoZotero,
+} from "../helpers/zoteroAvailability";
+import { post } from "../helpers/zoteroHttpClient";
+import type { VoiceSnapshot } from "@beaver/agent-core/voice/contracts";
+import fixture from "../fixtures/voice/session.json";
 
 interface HarnessResult {
     state: VoiceSnapshot;
     result?: { sessionId?: string; error?: { code: string } };
-    resources: { sentFrames: number;
-        captureDisposeCount: number; transcriptionDisposeCount: number; endAudio: unknown };
+    resources: {
+        requestCount: number;
+        captureDisposeCount: number;
+        transcriptionDisposeCount: number;
+        transcribedSamples: number;
+    };
 }
-const command = (command: string, data = {}) => post<HarnessResult>('/beaver/test/voice', { command, ...data });
+const command = (command: string, data = {}) =>
+    post<HarnessResult>("/beaver/test/voice", { command, ...data });
 async function phase(expected: string) {
-    let result = await command('state');
+    let result = await command("state");
     for (let i = 0; i < 40 && result.state.phase !== expected; i++) {
-        await new Promise(resolve => setTimeout(resolve, 50)); result = await command('state');
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        result = await command("state");
     }
     expect(result.state.phase).toBe(expected);
     return result;
 }
 let available: boolean;
-beforeAll(async () => { available = await isZoteroAvailable(); });
-beforeEach(async ctx => {
-    skipIfNoZotero(ctx, available);
-    await command('cancel'); await command('enable', { enabled: true });
+beforeAll(async () => {
+    available = await isZoteroAvailable();
 });
-afterAll(async () => { if (available) await command('enable', { enabled: false }); });
+beforeEach(async (ctx) => {
+    skipIfNoZotero(ctx, available);
+    await command("cancel");
+    await command("enable", { enabled: true });
+});
+afterAll(async () => {
+    if (available) await command("enable", { enabled: false });
+});
 
-describe('voice fake harness in Zotero', () => {
-    it('replays the protocol fixture, flushes its tail, and completes without an agent run', async () => {
-        const before = await post('/beaver/test/current-ids', {});
-        const started = await command('start'); expect(started.result?.sessionId).toBeTruthy();
-        await phase('listening');
-        await command('frame');
-        for (const event of fixture.transcript.filter(event => event.type !== 'complete')) {
-            await command(event.type, { segmentId: event.segmentId, text: event.text });
-        }
-        const mid = await command('state');
-        expect(mid.state).toMatchObject({ phase: 'listening', committedText: fixture.committedText, frameCount: 1 });
-        await command('finish'); const done = await phase('completed');
-        expect(done.state).toMatchObject({ committedText: fixture.committedText, sampleCount: 2240, provisionalText: '' });
-        expect(done.resources).toMatchObject({ sentFrames: 2, captureDisposeCount: 1, transcriptionDisposeCount: 1, endAudio: fixture.endAudio });
-        expect(await post('/beaver/test/current-ids', {})).toEqual(before);
+describe("voice fake harness in Zotero", () => {
+    it("replays the protocol fixture, flushes its tail, and completes without an agent run", async () => {
+        const before = await post("/beaver/test/current-ids", {});
+        const started = await command("start");
+        expect(started.result?.sessionId).toBeTruthy();
+        await phase("listening");
+        for (const _frame of fixture.frames.slice(0, -1))
+            await command("frame");
+        await command("transcript", { text: fixture.transcript });
+        const mid = await command("state");
+        expect(mid.state).toMatchObject({
+            phase: "listening",
+            committedText: "",
+            frameCount: 3,
+        });
+        await command("finish");
+        const done = await phase("completed");
+        expect(done.state).toMatchObject({
+            committedText: fixture.transcript,
+            sampleCount: fixture.sampleCount,
+        });
+        expect(done.resources).toMatchObject({
+            requestCount: 1,
+            captureDisposeCount: 1,
+            transcriptionDisposeCount: 1,
+            transcribedSamples: fixture.sampleCount,
+        });
+        expect(await post("/beaver/test/current-ids", {})).toEqual(before);
     });
-    it('locks competing starts and cancels idempotently without committing a hypothesis', async () => {
-        await command('start'); await phase('listening');
-        expect((await command('start')).result?.error?.code).toBe('busy');
-        await command('interim', { segmentId: 0, text: 'Do not commit this' });
-        await command('cancel'); await command('cancel'); await command('finish');
-        const done = await command('state');
-        expect(done.state).toMatchObject({ phase: 'canceled', committedText: '', provisionalText: '' });
-        expect(done.resources).toMatchObject({ captureDisposeCount: 1, transcriptionDisposeCount: 1, endAudio: null });
+    it("locks competing starts and cancels idempotently without committing a hypothesis", async () => {
+        await command("start");
+        await phase("listening");
+        expect((await command("start")).result?.error?.code).toBe("busy");
+        await command("transcript", { text: "Do not commit this" });
+        await command("cancel");
+        await command("cancel");
+        await command("finish");
+        const done = await command("state");
+        expect(done.state).toMatchObject({
+            phase: "canceled",
+            committedText: "",
+        });
+        expect(done.resources).toMatchObject({
+            captureDisposeCount: 1,
+            transcriptionDisposeCount: 1,
+            requestCount: 0,
+        });
     });
-    it('can restart repeatedly and disabling the harness cancels the active session', async () => {
+    it("can restart repeatedly and disabling the harness cancels the active session", async () => {
         for (let i = 0; i < 3; i++) {
-            await command('start'); await phase('listening'); await command('frame');
-            await command('cancel'); await phase('canceled');
+            await command("start");
+            await phase("listening");
+            await command("frame");
+            await command("cancel");
+            await phase("canceled");
         }
-        await command('start'); await phase('listening');
-        await command('enable', { enabled: false }); await phase('canceled');
-        expect((await command('start')).result?.error?.code).toBe('disabled');
+        await command("start");
+        await phase("listening");
+        await command("enable", { enabled: false });
+        await phase("canceled");
+        expect((await command("start")).result?.error?.code).toBe("disabled");
     });
 });

--- a/tests/unit/voice/controller.test.ts
+++ b/tests/unit/voice/controller.test.ts
@@ -1,15 +1,34 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { VoiceController } from '@beaver/agent-core/voice/controller';
-import { FakeVoiceCapture, FakeVoiceTranscription } from '@beaver/agent-core/voice/fakes';
-import { VOICE_FORMAT, VOICE_LIMITS, projectVoice,
-    type VoiceDependencies, type VoiceFrame } from '@beaver/agent-core/voice/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VoiceController } from "@beaver/agent-core/voice/controller";
+import {
+    FakeVoiceCapture,
+    FakeVoiceTranscription,
+} from "@beaver/agent-core/voice/fakes";
+import {
+    VOICE_FORMAT,
+    VOICE_LIMITS,
+    projectVoice,
+    defaultVoiceOptions,
+    type VoiceDependencies,
+    type VoiceFrame,
+    type VoiceRecording,
+    type VoiceTranscript,
+} from "@beaver/agent-core/voice/contracts";
 
-const owner = { windowId: 'main', output: { kind: 'composer' as const, id: 'editor' } };
-const settle = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+const owner = {
+    windowId: "main",
+    output: { kind: "composer" as const, id: "editor" },
+};
+const settle = async () => {
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+};
 function deferred<T = void>() {
     let resolve!: (value: T) => void;
     let reject!: (error: unknown) => void;
-    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
     return { promise, resolve, reject };
 }
 function fixture(overrides: Partial<VoiceDependencies> = {}) {
@@ -17,344 +36,644 @@ function fixture(overrides: Partial<VoiceDependencies> = {}) {
     let transcription!: FakeVoiceTranscription;
     let id = 0;
     const deps: VoiceDependencies = {
-        clock: { setTimeout: (fn, ms) => setTimeout(fn, ms), clearTimeout: h => clearTimeout(h as ReturnType<typeof setTimeout>) },
-        createId: () => `session-${++id}`, getAuth: async () => ({ userId: 'user', credential: 'credential' }),
+        clock: {
+            setTimeout: (fn, ms) => setTimeout(fn, ms),
+            clearTimeout: (h) =>
+                clearTimeout(h as ReturnType<typeof setTimeout>),
+        },
+        createId: () => `session-${++id}`,
+        getAuth: async () => ({ userId: "user", credential: "credential" }),
         capability: () => ({ enabled: true, available: true }),
-        createCapture: (session, emit) => capture = new FakeVoiceCapture(session, emit),
-        createTranscription: (session, emit) => transcription = new FakeVoiceTranscription(session, emit),
+        createCapture: (session, emit) =>
+            (capture = new FakeVoiceCapture(session, emit)),
+        createTranscription: (session) =>
+            (transcription = new FakeVoiceTranscription(session)),
         ...overrides,
     };
     const controller = new VoiceController(deps);
-    return { controller, deps, get capture() { return capture; }, get transcription() { return transcription; },
-        async start() { controller.start(owner, 'user'); await settle(); return controller.getSnapshot().sessionId!; },
+    return {
+        controller,
+        deps,
+        get capture() {
+            return capture;
+        },
+        get transcription() {
+            return transcription;
+        },
+        async start(options = defaultVoiceOptions()) {
+            controller.start(owner, "user", options);
+            await settle();
+            return controller.getSnapshot().sessionId!;
+        },
+        speech() {
+            for (let i = 0; i < 3; i++) capture.frame();
+        },
         frame(overrides: Partial<VoiceFrame> = {}) {
-            capture.emit({ ...capture.session, type: 'frame', frame: {
-                ...capture.session, sequence: controller.getSnapshot().frameCount, sampleCount: 1600,
-                format: VOICE_FORMAT, pcm: new Uint8Array(3200), ...overrides,
-            } });
+            capture.emit({
+                ...capture.session,
+                type: "frame",
+                frame: {
+                    ...capture.session,
+                    sequence: controller.getSnapshot().frameCount,
+                    sampleCount: 1600,
+                    format: VOICE_FORMAT,
+                    pcm: new Uint8Array(3200),
+                    ...overrides,
+                },
+            });
         },
     };
 }
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+});
 
-beforeEach(() => { vi.clearAllMocks(); vi.useFakeTimers(); });
-afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
-
-describe('voice session lifecycle', () => {
-    it('authenticates before starting capture and separates readiness from audio flow', async () => {
+describe("batch lifecycle", () => {
+    it("authenticates before capture, makes no request while listening, and never exposes credentials", async () => {
         const auth = deferred<{ userId: string; credential: string }>();
         const f = fixture({ getAuth: () => auth.promise });
-        f.controller.start(owner, 'user');
+        f.controller.start(owner, "user");
         expect(f.capture).toBeUndefined();
-        auth.resolve({ userId: 'user', credential: 'secret' });
+        auth.resolve({ userId: "user", credential: "secret" });
         await settle();
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'listening', captureReady: true, audioStarted: false });
-        f.capture.frame();
-        await settle();
-        expect(f.controller.getSnapshot()).toMatchObject({ audioStarted: true, frameCount: 1, sampleCount: 1600 });
-        expect(JSON.stringify(f.controller.getSnapshot())).not.toContain('secret');
+        expect(f.controller.getSnapshot()).toMatchObject({
+            phase: "listening",
+            captureReady: true,
+            audioStarted: false,
+        });
+        f.speech();
+        expect(f.transcription.requestCount).toBe(0);
+        expect(f.controller.getSnapshot()).toMatchObject({
+            audioStarted: true,
+            sampleCount: 4800,
+            committedText: "",
+        });
+        expect(JSON.stringify(f.controller.getSnapshot())).not.toContain(
+            "secret",
+        );
     });
-
-    it('flushes the short tail after queued frames, then awaits a distinct completion', async () => {
-        const f = fixture(); const id = await f.start();
-        f.transcription.autoComplete = false;
-        f.capture.frame();
-        f.transcription.text('interim', 0, 'Hel');
-        f.transcription.text('interim', 0, 'Hello');
-        f.transcription.text('segment_final', 0, 'Hello');
-        expect(f.controller.getSnapshot().phase).toBe('listening');
-        f.controller.finish(id); f.controller.finish(id);
+    it("flushes the tail, releases capture, and publishes one atomic result after one request", async () => {
+        const f = fixture();
+        const id = await f.start();
+        const result = deferred<VoiceTranscript>();
+        let recording!: VoiceRecording;
+        let calls = 0;
+        f.transcription.transcribe = async (audio) => {
+            expect(f.capture.disposed).toBe(true);
+            calls++;
+            recording = audio;
+            return result.promise;
+        };
+        f.speech();
+        f.controller.finish(id);
+        f.controller.finish(id);
         await settle();
         expect(f.capture.finishCount).toBe(1);
-        expect(f.transcription.endAudio).toEqual({ type: 'end_audio', version: 1, sessionId: id, frameCount: 2, sampleCount: 2240 });
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'finalizing', committedText: 'Hello', provisionalText: '' });
-        f.transcription.complete();
-        expect(f.controller.getSnapshot().phase).toBe('completed');
-        f.controller.finish(id); f.controller.cancel(id); f.controller.dispose(); f.controller.dispose();
-        expect(f.capture.disposeCount).toBe(1); expect(f.transcription.disposeCount).toBe(1);
-        expect(vi.getTimerCount()).toBe(0);
-    });
-
-    it.each(['cancel', 'finish', 'window', 'logout', 'account', 'dispose', 'timeout'])(
-        'revokes pending authentication on %s, ignoring its eventual result', async operation => {
-            const auth = deferred<{ userId: string; credential: string }>();
-            const f = fixture({ getAuth: () => auth.promise });
-            const id = (f.controller.start(owner, 'user') as { sessionId: string }).sessionId;
-            if (operation === 'cancel') f.controller.cancel(id);
-            if (operation === 'finish') f.controller.finish(id);
-            if (operation === 'window') f.controller.windowUnloaded(owner.windowId);
-            if (operation === 'logout') f.controller.authChanged(null);
-            if (operation === 'account') f.controller.authChanged('replacement');
-            if (operation === 'dispose') f.controller.dispose();
-            if (operation === 'timeout') vi.advanceTimersByTime(VOICE_LIMITS.startupMs);
-            auth.resolve({ userId: 'user', credential: 'secret' }); await settle();
-            expect(f.capture).toBeUndefined(); expect(f.transcription).toBeUndefined();
-            expect(f.controller.getSnapshot().phase).toBe(operation === 'timeout' ? 'error' : 'canceled');
+        expect(calls).toBe(1);
+        expect(recording).toMatchObject({
+            sampleCount: 5440,
+            sessionId: id,
+            format: VOICE_FORMAT,
         });
-
-    it.each(['capture', 'transcription'])('cancels pending %s setup with immediate disposal', async stage => {
-        const ready = deferred(); const f = fixture();
-        const create = stage === 'capture' ? f.deps.createCapture : f.deps.createTranscription;
-        if (stage === 'capture') f.deps.createCapture = (s, emit) => {
-            const result = create(s, emit as never) as FakeVoiceCapture;
-            result.start = () => ready.promise; return result;
-        };
-        else f.deps.createTranscription = (s, emit) => {
-            const result = create(s, emit as never) as FakeVoiceTranscription;
-            result.start = () => ready.promise; return result;
-        };
-        const id = await f.start();
+        expect(recording.pcm.length).toBe(10880);
+        expect(recording.pcm.some((n) => n !== 0)).toBe(true);
+        expect(f.controller.getSnapshot()).toMatchObject({
+            phase: "finalizing",
+            committedText: "",
+        });
+        result.resolve({
+            version: 1,
+            sessionId: id,
+            text: "Bourdieu’s theory.",
+        });
+        await settle();
+        expect(f.controller.getSnapshot()).toMatchObject({
+            phase: "completed",
+            committedText: "Bourdieu’s theory.",
+        });
+        expect(recording.pcm.every((n) => n === 0)).toBe(true);
+        f.controller.finish(id);
         f.controller.cancel(id);
-        expect(f.transcription.disposed).toBe(true);
-        if (stage === 'capture') expect(f.capture.disposed).toBe(true);
-        ready.resolve(); await settle();
-        expect(f.controller.getSnapshot().phase).toBe('canceled');
-    });
-
-    it('keeps one lock across originating windows and rejects stale commands', async () => {
-        const f = fixture(); const id = await f.start();
-        expect(f.controller.start({ ...owner, windowId: 'other' }, 'user')).toEqual({ error: { code: 'busy' } });
-        f.controller.windowUnloaded('other'); f.controller.authChanged('user');
-        expect(f.controller.getSnapshot().phase).toBe('listening');
-        f.controller.windowUnloaded('main');
-        const next = await f.start(); expect(next).not.toBe(id);
-        f.controller.cancel(id); f.controller.finish(id);
-        expect(f.controller.getSnapshot().phase).toBe('listening');
-    });
-
-    it('ignores old session callbacks after a new activation', async () => {
-        const f = fixture(); const id = await f.start();
-        const old = f.transcription;
-        f.controller.cancel(id); await f.start();
-        old.emit({ ...old.session, type: 'segment_final', sequence: 0, segmentId: 0, text: 'stale' });
-        expect(f.controller.getSnapshot().committedText).toBe('');
-    });
-
-    it.each(['startup_timeout', 'finalization_timeout', 'duration_limit'] as const)('enforces %s without timer leaks', async code => {
-        const f = fixture(code === 'startup_timeout' ? { getAuth: () => new Promise(() => {}) } : {});
-        const id = await f.start();
-        if (code === 'finalization_timeout') { f.transcription.autoComplete = false; f.controller.finish(id); await settle(); }
-        vi.advanceTimersByTime(code === 'startup_timeout' ? VOICE_LIMITS.startupMs
-            : code === 'finalization_timeout' ? VOICE_LIMITS.finalizationMs : VOICE_LIMITS.durationMs);
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'error', error: { code } });
-        expect(vi.getTimerCount()).toBe(0);
-        if (f.capture) expect(f.capture.disposed).toBe(true);
-    });
-
-    it('bounds a stalled capture finish and ignores its eventual tail', async () => {
-        const f = fixture(); const id = await f.start(); const stopped = deferred();
-        f.capture.finish = () => stopped.promise;
-        f.controller.finish(id); vi.advanceTimersByTime(VOICE_LIMITS.finalizationMs);
-        stopped.resolve(); await settle();
-        expect(f.transcription.endAudio).toBeUndefined();
-        expect(f.controller.getSnapshot().error?.code).toBe('finalization_timeout');
-    });
-
-    it('disposes both resources even if one disposal throws or observers fail', async () => {
-        const f = fixture(); await f.start();
-        f.controller.subscribe(() => { throw new Error('view failed'); });
-        f.capture.dispose = () => { throw new Error('device failed'); };
-        f.controller.authChanged(null);
-        expect(f.transcription.disposed).toBe(true);
-        expect(f.controller.getSnapshot().phase).toBe('canceled');
-    });
-
-    it('does not create resources when a state observer cancels activation', async () => {
-        const f = fixture();
-        f.controller.subscribe(() => {
-            if (f.controller.getSnapshot().phase === 'starting') f.controller.windowUnloaded('main');
-        });
-        const result = f.controller.start(owner, 'user'); await settle();
-        expect(result).toEqual({ sessionId: f.controller.getSnapshot().sessionId });
-        expect(f.controller.getSnapshot().phase).toBe('canceled');
-        expect(f.capture).toBeUndefined(); expect(vi.getTimerCount()).toBe(0);
-    });
-
-    it.each([
-        [{ enabled: false, available: true }, 'disabled'],
-        [{ enabled: true, available: false }, 'unavailable'],
-    ] as const)('gates activation with %s', (capability, code) => {
-        const f = fixture({ capability: () => capability });
-        expect(f.controller.start(owner, 'user')).toEqual({ error: { code } });
-        expect(f.controller.getSnapshot().phase).toBe('idle');
-    });
-    it('rejects missing auth and a disposed controller', async () => {
-        const f = fixture({ getAuth: async () => null }); await f.start();
-        expect(f.controller.getSnapshot().error?.code).toBe('unauthenticated');
-        expect(f.capture).toBeUndefined(); f.controller.dispose();
-        expect(f.controller.start(owner, 'user')).toEqual({ error: { code: 'disabled' } });
-    });
-});
-
-describe('audio bounds and ordering', () => {
-    it('counts the in-flight send in its bound and stops rather than dropping speech', async () => {
-        const f = fixture(); await f.start();
-        const send = deferred(); f.transcription.send = () => send.promise;
-        for (let i = 0; i < VOICE_LIMITS.queuedBytes / 3200; i++) f.capture.frame();
-        expect(f.controller.getSnapshot().phase).toBe('listening');
-        f.capture.frame();
-        expect(f.controller.getSnapshot().error?.code).toBe('overflow');
-        expect(f.capture.disposed).toBe(true); send.resolve(); await settle();
-        expect(f.transcription.endAudio).toBeUndefined();
-    });
-    it('does not send end-of-audio until the last send resolves', async () => {
-        const f = fixture(); const id = await f.start(); const send = deferred();
-        const frames: number[] = [];
-        f.transcription.send = async frame => { frames.push(frame.sequence); await send.promise; };
-        f.capture.frame(); f.capture.frame(); f.controller.finish(id); await settle();
-        expect(f.transcription.endAudio).toBeUndefined();
-        send.resolve(); await settle();
-        expect(frames).toEqual([0, 1, 2]); expect(f.controller.getSnapshot().phase).toBe('completed');
-    });
-    it('copies bytes before the capture adapter reuses a buffer and calculates levels', async () => {
-        const f = fixture(); await f.start(); let sent!: Uint8Array;
-        f.transcription.send = async frame => { sent = frame.pcm; };
-        const pcm = new Uint8Array(3200); for (let i = 1; i < pcm.length; i += 2) pcm[i] = 64;
-        f.frame({ pcm }); pcm.fill(0);
-        expect(sent[1]).toBe(64); expect(f.controller.getSnapshot().level).toBe(0.5);
-    });
-    it.each([
-        { sequence: 1 }, { sequence: -1 }, { sampleCount: 1601 }, { sampleCount: 0 },
-        { sampleCount: 640, pcm: new Uint8Array(1280) }, { pcm: new Uint8Array(3) },
-        { version: 2 }, { sessionId: 'wrong' }, { format: { ...VOICE_FORMAT, sampleRate: 48000 } },
-    ])('rejects invalid frame %s', async patch => {
-        const f = fixture(); await f.start(); f.frame(patch as Partial<VoiceFrame>);
-        expect(f.controller.getSnapshot().error?.code).toBe('protocol_error');
-    });
-    it('rejects audio after a short final frame', async () => {
-        const f = fixture(); const id = await f.start();
-        f.capture.finish = async () => { f.capture.frame(640); f.capture.frame(); };
-        f.controller.finish(id); await settle();
-        expect(f.controller.getSnapshot().error?.code).toBe('protocol_error');
-    });
-    it('treats silence as audio and discontinuity as a distinct recoverable error', async () => {
-        const f = fixture(); await f.start(); f.capture.frame();
-        expect(f.controller.getSnapshot()).toMatchObject({ audioStarted: true, level: 0, error: null });
-        f.transcription.text('segment_final', 0, 'keep');
-        f.capture.emit({ ...f.capture.session, type: 'error', error: { code: 'discontinuity' } });
-        expect(f.controller.getSnapshot()).toMatchObject({ committedText: 'keep', error: { code: 'discontinuity' } });
-    });
-});
-
-describe('transcript ordering and UI projection', () => {
-    it('replaces hypotheses, commits once, and ignores late updates to finalized segments', async () => {
-        const f = fixture(); await f.start();
-        f.transcription.text('interim', 0, 'a'); f.transcription.text('interim', 0, 'abc');
-        expect(f.controller.getSnapshot().provisionalText).toBe('abc');
-        f.transcription.text('segment_final', 0, 'abc');
-        f.transcription.emit({ ...f.transcription.session, type: 'segment_final', sequence: 2, segmentId: 0, text: 'duplicate' });
-        f.transcription.text('interim', 0, 'late'); f.transcription.text('segment_final', 0, 'late final');
-        f.transcription.text('segment_final', 1, ' def');
-        expect(f.controller.getSnapshot()).toMatchObject({ committedText: 'abc def', provisionalText: '', phase: 'listening' });
-    });
-    it('rejects completion before finish and never promotes provisional text', async () => {
-        const f = fixture(); await f.start();
-        f.transcription.text('segment_final', 0, 'keep'); f.transcription.text('interim', 1, 'discard');
-        f.transcription.complete();
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'error', committedText: 'keep', provisionalText: '', error: { code: 'protocol_error' } });
-    });
-    it('requires the final transcript before the completion acknowledgement', async () => {
-        const f = fixture(); const id = await f.start(); f.transcription.text('interim', 0, 'pending');
-        f.controller.finish(id); await settle();
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'error', committedText: '', error: { code: 'protocol_error' } });
-    });
-    it.each(['disconnected', 'permission_denied', 'device_unavailable'] as const)('preserves committed text on %s', async code => {
-        const f = fixture(); await f.start(); f.transcription.text('segment_final', 0, 'keep');
-        f.transcription.text('interim', 1, 'discard');
-        f.transcription.emit({ ...f.transcription.session, type: 'error', error: { code } });
-        expect(f.controller.getSnapshot()).toMatchObject({ committedText: 'keep', provisionalText: '', error: { code } });
-        expect(f.capture.disposed).toBe(true);
-    });
-    it.each([null, 42])('rejects malformed transcript text %s and disposes adapters', async text => {
-        const f = fixture(); await f.start();
-        f.transcription.text('segment_final', 0, 'keep');
-        f.transcription.text('interim', 1, text as unknown as string);
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'error', committedText: 'keep', error: { code: 'protocol_error' } });
+        f.controller.dispose();
+        f.controller.dispose();
+        expect(calls).toBe(1);
         expect(f.capture.disposeCount).toBe(1);
         expect(f.transcription.disposeCount).toBe(1);
+        expect(vi.getTimerCount()).toBe(0);
     });
-    it('rejects transcript gaps and bounds retained text', async () => {
-        const f = fixture(); await f.start();
-        f.transcription.emit({ ...f.transcription.session, type: 'interim', sequence: 1, segmentId: 0, text: 'gap' });
-        expect(f.controller.getSnapshot().error?.code).toBe('protocol_error');
-        await f.start(); f.transcription.text('segment_final', 1, 'gap');
-        expect(f.controller.getSnapshot().error?.code).toBe('protocol_error');
-        await f.start(); f.transcription.text('interim', 0, 'x'.repeat(VOICE_LIMITS.transcriptCharacters + 1));
-        expect(f.controller.getSnapshot().error?.code).toBe('overflow');
+    it.each([
+        "cancel",
+        "finish",
+        "window",
+        "logout",
+        "account",
+        "dispose",
+        "timeout",
+    ])("revokes pending authentication on %s", async (operation) => {
+        const auth = deferred<{ userId: string; credential: string }>();
+        const f = fixture({ getAuth: () => auth.promise });
+        const id = await f.start();
+        if (operation === "cancel") f.controller.cancel(id);
+        if (operation === "finish") f.controller.finish(id);
+        if (operation === "window") f.controller.windowUnloaded("main");
+        if (operation === "logout") f.controller.authChanged(null);
+        if (operation === "account") f.controller.authChanged("other");
+        if (operation === "dispose") f.controller.dispose();
+        if (operation === "timeout")
+            vi.advanceTimersByTime(VOICE_LIMITS.startupMs);
+        auth.resolve({ userId: "user", credential: "secret" });
+        await settle();
+        expect(f.capture).toBeUndefined();
+        expect(f.transcription).toBeUndefined();
+        expect(f.controller.getSnapshot().phase).toBe(
+            operation === "timeout" ? "error" : "canceled",
+        );
     });
-    it('makes observation shared but insertion ownership explicit and immutable', async () => {
-        const f = fixture(); const mutableOwner = { ...owner, output: { ...owner.output } };
-        f.controller.start(mutableOwner, 'user'); mutableOwner.output.id = 'changed'; await settle();
-        const snapshot = f.controller.getSnapshot();
-        expect(projectVoice(snapshot, owner)).toMatchObject({ ownsOutput: true, busy: true });
-        expect(projectVoice(snapshot, { ...owner, windowId: 'other' })).toMatchObject({ ownsOutput: false, busy: true });
-        expect(Object.isFrozen(snapshot.owner?.output)).toBe(true);
-        let count = 0; const off = f.controller.subscribe(() => count++); off(); f.capture.frame(); expect(count).toBe(0);
+    it("revokes pending capture setup before its eventual readiness callback", async () => {
+        const f = fixture();
+        const ready = deferred();
+        const create = f.deps.createCapture;
+        f.deps.createCapture = (s, emit) => {
+            const c = create(s, emit);
+            c.start = () => ready.promise;
+            return c;
+        };
+        const id = await f.start();
+        f.controller.finish(id);
+        expect(f.capture.disposed).toBe(true);
+        expect(f.transcription.disposed).toBe(true);
+        f.capture.emit({
+            ...f.capture.session,
+            type: "ready",
+            format: VOICE_FORMAT,
+        });
+        ready.resolve();
+        await settle();
+        expect(f.controller.getSnapshot().phase).toBe("canceled");
+    });
+    it.each(["cancel", "window", "logout", "dispose", "timeout"])(
+        "clears borrowed audio and ignores late batch results after %s",
+        async (operation) => {
+            const f = fixture();
+            const id = await f.start();
+            const result = deferred<VoiceTranscript>();
+            let audio!: Uint8Array;
+            f.transcription.transcribe = (recording) => {
+                audio = recording.pcm;
+                return result.promise;
+            };
+            f.speech();
+            f.controller.finish(id);
+            await settle();
+            if (operation === "cancel") f.controller.cancel(id);
+            if (operation === "window") f.controller.windowUnloaded("main");
+            if (operation === "logout") f.controller.authChanged(null);
+            if (operation === "dispose") f.controller.dispose();
+            if (operation === "timeout")
+                vi.advanceTimersByTime(VOICE_LIMITS.transcriptionMs);
+            expect(audio.every((n) => n === 0)).toBe(true);
+            expect(f.transcription.disposed).toBe(true);
+            result.resolve({ version: 1, sessionId: id, text: "stale" });
+            await settle();
+            expect(f.controller.getSnapshot().committedText).toBe("");
+            expect(f.controller.getSnapshot().phase).toBe(
+                operation === "timeout" ? "error" : "canceled",
+            );
+        },
+    );
+    it("does not let an old result overwrite a fresh session", async () => {
+        const f = fixture();
+        const id = await f.start();
+        const result = deferred<VoiceTranscript>();
+        f.transcription.transcribe = () => result.promise;
+        f.speech();
+        f.controller.finish(id);
+        await settle();
+        f.controller.cancel(id);
+        const next = await f.start();
+        result.resolve({ version: 1, sessionId: id, text: "stale" });
+        await settle();
+        expect(f.controller.getSnapshot()).toMatchObject({
+            sessionId: next,
+            phase: "listening",
+            committedText: "",
+        });
+    });
+    it("keeps one lock across windows and ignores stale commands and unrelated unloads", async () => {
+        const f = fixture();
+        const id = await f.start();
+        expect(
+            f.controller.start({ ...owner, windowId: "other" }, "user"),
+        ).toEqual({ error: { code: "busy" } });
+        f.controller.windowUnloaded("other");
+        f.controller.authChanged("user");
+        expect(f.controller.getSnapshot().phase).toBe("listening");
+        f.controller.windowUnloaded("main");
+        await f.start();
+        f.controller.cancel(id);
+        f.controller.finish(id);
+        expect(f.controller.getSnapshot().phase).toBe("listening");
+    });
+    it("bounds capture shutdown separately from transcription", async () => {
+        const f = fixture();
+        const id = await f.start();
+        const stopped = deferred();
+        f.capture.finish = () => stopped.promise;
+        f.controller.finish(id);
+        vi.advanceTimersByTime(VOICE_LIMITS.finalizationMs);
+        stopped.resolve();
+        await settle();
+        expect(f.transcription.requestCount).toBe(0);
+        expect(f.controller.getSnapshot().error?.code).toBe(
+            "finalization_timeout",
+        );
+    });
+    it("keeps the transcription deadline after the native deadline has elapsed", async () => {
+        const f = fixture();
+        const id = await f.start();
+        f.speech();
+        f.transcription.transcribe = () => new Promise(() => {});
+        f.controller.finish(id);
+        await settle();
+        vi.advanceTimersByTime(VOICE_LIMITS.finalizationMs);
+        expect(f.controller.getSnapshot().phase).toBe("finalizing");
+        vi.advanceTimersByTime(
+            VOICE_LIMITS.transcriptionMs - VOICE_LIMITS.finalizationMs,
+        );
+        expect(f.controller.getSnapshot().error?.code).toBe(
+            "transcription_timeout",
+        );
+    });
+    it("bounds listening by wall time independently of audio flow", async () => {
+        const f = fixture();
+        await f.start();
+        vi.advanceTimersByTime(VOICE_LIMITS.durationMs);
+        expect(f.controller.getSnapshot().error?.code).toBe("duration_limit");
+        expect(vi.getTimerCount()).toBe(0);
+    });
+    it("continues cleanup when observers or a capture disposal throw", async () => {
+        const f = fixture();
+        await f.start();
+        f.controller.subscribe(() => {
+            throw new Error("view");
+        });
+        f.capture.dispose = () => {
+            throw new Error("device");
+        };
+        f.controller.authChanged(null);
+        expect(f.transcription.disposed).toBe(true);
+        expect(f.controller.getSnapshot().phase).toBe("canceled");
+    });
+    it("allocates no adapters when an observer cancels starting synchronously", async () => {
+        const f = fixture();
+        f.controller.subscribe(() => {
+            if (f.controller.getSnapshot().phase === "starting")
+                f.controller.windowUnloaded("main");
+        });
+        await f.start();
+        expect(f.capture).toBeUndefined();
+        expect(f.transcription).toBeUndefined();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+    it.each([
+        [false, true, "disabled"],
+        [true, false, "unavailable"],
+    ] as const)("gates activation %#", (enabled, available, code) => {
+        const f = fixture({ capability: () => ({ enabled, available }) });
+        expect(f.controller.start(owner, "user")).toEqual({ error: { code } });
+    });
+    it("rejects missing auth and a disposed controller", async () => {
+        const f = fixture({ getAuth: async () => null });
+        await f.start();
+        expect(f.controller.getSnapshot().error?.code).toBe("unauthenticated");
+        expect(f.capture).toBeUndefined();
+        f.controller.dispose();
+        expect(f.controller.start(owner, "user")).toEqual({
+            error: { code: "disabled" },
+        });
     });
 });
 
-describe('adapter failures and cancellation during upload', () => {
-    it.each(['send', 'finish'] as const)('disposes resources and preserves committed text when transport %s rejects', async operation => {
-        const f = fixture(); const id = await f.start();
-        f.transcription.text('segment_final', 0, 'keep');
-        f.transcription[operation] = async () => { throw new Error('private provider details'); };
-        if (operation === 'send') f.capture.frame();
-        else f.controller.finish(id);
+describe("audio bounds and energy gate", () => {
+    it("accepts exactly the sample limit including a short tail and rejects an extra sample", async () => {
+        const f = fixture();
+        const id = await f.start();
+        for (let i = 0; i < 1199; i++) f.capture.frame();
+        f.capture.tailSamples = 1600;
+        f.controller.finish(id);
         await settle();
-        expect(f.controller.getSnapshot()).toMatchObject({ phase: 'error', committedText: 'keep', error: { code: 'transcription_failed' } });
-        expect(f.capture.disposed).toBe(true); expect(f.transcription.disposed).toBe(true);
-        expect(JSON.stringify(f.controller.getSnapshot())).not.toContain('private provider details');
+        expect(f.transcription.sampleCount).toBe(1920000);
+        expect(f.controller.getSnapshot().phase).toBe("completed");
+        await f.start();
+        for (let i = 0; i < 1200; i++) f.capture.frame();
+        f.capture.frame();
+        expect(f.controller.getSnapshot().error?.code).toBe("duration_limit");
+        expect(f.transcription.requestCount).toBe(0);
     });
-
-    it.each(['auth', 'transcription_factory', 'transcription_start', 'capture_factory', 'capture_start'])(
-        'classifies %s failure and disposes every handle already allocated', async stage => {
+    it("copies incoming PCM before reuse and computes RMS", async () => {
+        const f = fixture();
+        const id = await f.start();
+        const pcm = new Uint8Array(3200);
+        for (let i = 1; i < pcm.length; i += 2) pcm[i] = 64;
+        f.frame({ pcm });
+        pcm.fill(0);
+        expect(f.controller.getSnapshot().level).toBe(0.5);
+        f.capture.sequence = 1;
+        f.capture.frame();
+        f.capture.frame();
+        let firstSample = 0;
+        f.transcription.transcribe = async (recording) => {
+            firstSample = recording.pcm[1];
+            return { ...f.transcription.session, text: "ok" };
+        };
+        f.controller.finish(id);
+        await settle();
+        expect(firstSample).toBe(64);
+    });
+    it.each([
+        { sequence: 1 },
+        { sequence: -1 },
+        { sampleCount: 1601 },
+        { sampleCount: 0 },
+        { sampleCount: 640, pcm: new Uint8Array(1280) },
+        { pcm: new Uint8Array(3) },
+        { version: 2 },
+        { sessionId: "wrong" },
+        { format: { ...VOICE_FORMAT, sampleRate: 48000 } },
+    ])("rejects malformed native frames %#", async (patch) => {
+        const f = fixture();
+        await f.start();
+        f.frame(patch as Partial<VoiceFrame>);
+        expect(f.controller.getSnapshot().error?.code).toBe("protocol_error");
+    });
+    it("rejects frames after a short tail", async () => {
+        const f = fixture();
+        const id = await f.start();
+        f.capture.finish = async () => {
+            f.capture.frame(640);
+            f.capture.frame();
+        };
+        f.controller.finish(id);
+        await settle();
+        expect(f.controller.getSnapshot().error?.code).toBe("protocol_error");
+    });
+    it.each(["empty", "short", "muted", "near-silent", "click"])(
+        "does not transcribe %s input",
+        async (kind) => {
             const f = fixture();
-            const fail = () => { throw new Error('setup failed'); };
-            if (stage === 'auth') f.deps.getAuth = fail;
-            if (stage === 'transcription_factory') f.deps.createTranscription = fail;
-            if (stage === 'capture_factory') f.deps.createCapture = fail;
-            if (stage === 'transcription_start') {
-                const create = f.deps.createTranscription;
-                f.deps.createTranscription = (s, emit) => { const t = create(s, emit); t.start = fail; return t; };
+            const id = await f.start();
+            f.capture.tailSamples = 0;
+            if (kind === "short") f.capture.frame();
+            if (kind === "muted" || kind === "near-silent")
+                for (let i = 0; i < 100; i++)
+                    f.capture.frame(1600, kind === "muted" ? 0 : 0.002);
+            if (kind === "click") {
+                f.capture.frame();
+                for (let i = 0; i < 10; i++) f.capture.frame(1600, 0);
             }
-            if (stage === 'capture_start') {
+            expect(f.controller.getSnapshot().error).toBeNull();
+            f.controller.finish(id);
+            await settle();
+            expect(f.controller.getSnapshot()).toMatchObject({
+                phase: "error",
+                error: { code: "no_speech" },
+                committedText: "",
+            });
+            expect(f.transcription.requestCount).toBe(0);
+        },
+    );
+    it("includes final-tail energy in the gate", async () => {
+        const f = fixture();
+        const id = await f.start();
+        f.capture.frame();
+        f.capture.frame(1600, 0);
+        f.capture.frame(1600, 0);
+        f.capture.tailSamples = 1600;
+        f.controller.finish(id);
+        await settle();
+        expect(f.controller.getSnapshot().phase).toBe("completed");
+        expect(f.transcription.requestCount).toBe(1);
+    });
+});
+
+describe("batch context, results and quality", () => {
+    it("snapshots vocabulary and language and refreshes credentials only for the same user", async () => {
+        const f = fixture();
+        const options = {
+            language: "fr",
+            biasTerms: ["Bourdieu"],
+            correctionVocabulary: ["Actes de la recherche"],
+        };
+        const id = await f.start(options);
+        options.biasTerms[0] = "changed";
+        options.language = "en";
+        f.deps.getAuth = async () => ({
+            userId: "user",
+            credential: "refreshed",
+        });
+        let recorded!: VoiceRecording;
+        f.transcription.transcribe = async (recording, credential) => {
+            expect(credential).toBe("refreshed");
+            recorded = recording;
+            return { ...f.transcription.session, text: "ok" };
+        };
+        f.speech();
+        f.controller.finish(id);
+        await settle();
+        expect(recorded.options).toEqual({
+            language: "fr",
+            biasTerms: ["Bourdieu"],
+            correctionVocabulary: ["Actes de la recherche"],
+        });
+        expect(Object.isFrozen(recorded.options.biasTerms)).toBe(true);
+    });
+    it.each(["logout", "replacement", "pending-cancel"])(
+        "prevents upload after auth %s",
+        async (kind) => {
+            const f = fixture();
+            const id = await f.start();
+            f.speech();
+            f.deps.getAuth =
+                kind === "pending-cancel"
+                    ? () => new Promise(() => {})
+                    : async () =>
+                          kind === "logout"
+                              ? null
+                              : { userId: "other", credential: "new" };
+            f.controller.finish(id);
+            await settle();
+            if (kind === "pending-cancel") f.controller.cancel(id);
+            expect(f.transcription.requestCount).toBe(0);
+            expect(f.controller.getSnapshot().phase).not.toBe("completed");
+        },
+    );
+    it.each([
+        { language: "" },
+        { biasTerms: ["x".repeat(32001)] },
+        { correctionVocabulary: Array(1001).fill("x") },
+    ])("rejects invalid or unbounded context %#", async (patch) => {
+        const f = fixture();
+        expect(
+            f.controller.start(owner, "user", {
+                ...defaultVoiceOptions(),
+                ...patch,
+            }),
+        ).toEqual({ error: { code: "protocol_error" } });
+    });
+    it.each([
+        [{ version: 2, text: "bad" }, "protocol_error"],
+        [{ sessionId: "wrong", text: "bad" }, "protocol_error"],
+        [{ text: 42 }, "protocol_error"],
+        [{ text: "x".repeat(64001) }, "overflow"],
+        [{ error: { code: "transcription_failed" } }, "transcription_failed"],
+    ])("rejects invalid or failed batch result %#", async (patch, code) => {
+        const f = fixture();
+        const id = await f.start();
+        f.transcription.transcribe = async () =>
+            ({ ...f.transcription.session, ...patch }) as VoiceTranscript;
+        f.speech();
+        f.controller.finish(id);
+        await settle();
+        expect(f.controller.getSnapshot()).toMatchObject({
+            phase: "error",
+            committedText: "",
+            error: { code },
+        });
+    });
+    it("accepts an empty successful transcript without inventing text", async () => {
+        const f = fixture();
+        const id = await f.start();
+        f.speech();
+        f.controller.finish(id);
+        await settle();
+        expect(f.controller.getSnapshot()).toMatchObject({
+            phase: "completed",
+            committedText: "",
+        });
+    });
+    it("exposes immutable clipping diagnostics and retains counts on failure", async () => {
+        const f = fixture();
+        await f.start();
+        const quality = {
+            inputPeak: 1,
+            clippedSamples: 32,
+            discontinuityCount: 1,
+        };
+        f.capture.emit({ ...f.capture.session, type: "quality", quality });
+        quality.clippedSamples = 999;
+        f.capture.emit({
+            ...f.capture.session,
+            type: "error",
+            error: { code: "discontinuity" },
+        });
+        expect(f.controller.getSnapshot()).toMatchObject({
+            clipping: true,
+            quality: { clippedSamples: 32, discontinuityCount: 1 },
+            error: { code: "discontinuity" },
+        });
+        expect(Object.isFrozen(f.controller.getSnapshot().quality)).toBe(true);
+    });
+    it.each([
+        { inputPeak: NaN },
+        { clippedSamples: -1 },
+        { discontinuityCount: 0.5 },
+    ])("rejects malformed quality %#", async (patch) => {
+        const f = fixture();
+        await f.start();
+        f.capture.emit({
+            ...f.capture.session,
+            type: "quality",
+            quality: {
+                inputPeak: 0,
+                clippedSamples: 0,
+                discontinuityCount: 0,
+                ...patch,
+            },
+        });
+        expect(f.controller.getSnapshot().error?.code).toBe("protocol_error");
+    });
+    it("keeps output ownership immutable and observations shared", async () => {
+        const f = fixture();
+        const mutable = { ...owner, output: { ...owner.output } };
+        f.controller.start(mutable, "user");
+        mutable.output.id = "other";
+        await settle();
+        expect(projectVoice(f.controller.getSnapshot(), owner)).toMatchObject({
+            ownsOutput: true,
+            busy: true,
+        });
+        expect(
+            projectVoice(f.controller.getSnapshot(), {
+                ...owner,
+                windowId: "other",
+            }),
+        ).toMatchObject({ ownsOutput: false, busy: true });
+        let count = 0;
+        const off = f.controller.subscribe(() => count++);
+        off();
+        f.capture.frame();
+        expect(count).toBe(0);
+    });
+    it.each([
+        "auth",
+        "transcription_factory",
+        "capture_factory",
+        "capture_start",
+        "transcribe",
+    ])(
+        "classifies %s failures without exposing private messages",
+        async (stage) => {
+            const f = fixture();
+            const fail = () => {
+                throw new Error("private details");
+            };
+            if (stage === "auth") f.deps.getAuth = fail;
+            if (stage === "transcription_factory")
+                f.deps.createTranscription = fail;
+            if (stage === "capture_factory") f.deps.createCapture = fail;
+            if (stage === "capture_start") {
                 const create = f.deps.createCapture;
-                f.deps.createCapture = (s, emit) => { const c = create(s, emit); c.start = fail; return c; };
+                f.deps.createCapture = (s, emit) => {
+                    const c = create(s, emit);
+                    c.start = fail;
+                    return c;
+                };
             }
-            await f.start();
-            expect(f.controller.getSnapshot().error?.code).toBe(stage === 'auth' ? 'unauthenticated'
-                : stage.startsWith('capture') ? 'capture_failed' : 'transcription_failed');
+            const id = await f.start();
+            if (stage === "transcribe") {
+                f.transcription.transcribe = fail;
+                f.speech();
+                f.controller.finish(id);
+                await settle();
+            }
+            expect(f.controller.getSnapshot().error?.code).toBe(
+                stage === "auth"
+                    ? "unauthenticated"
+                    : stage.startsWith("capture")
+                      ? "capture_failed"
+                      : "transcription_failed",
+            );
+            expect(JSON.stringify(f.controller.getSnapshot())).not.toContain(
+                "private details",
+            );
             if (f.capture) expect(f.capture.disposed).toBe(true);
             if (f.transcription) expect(f.transcription.disposed).toBe(true);
-            expect(vi.getTimerCount()).toBe(0);
-        });
-
-    it('discards queued frames on cancel and never resumes uploading after a late send resolution', async () => {
-        const f = fixture(); const id = await f.start(); const send = deferred(); let count = 0;
-        f.transcription.send = async () => { count++; await send.promise; };
-        f.capture.frame(); f.capture.frame(); f.capture.frame();
-        f.controller.finish(id); await settle(); f.controller.cancel(id);
-        expect(count).toBe(1); send.resolve(); await settle();
-        expect(count).toBe(1); expect(f.transcription.endAudio).toBeUndefined();
-        expect(f.controller.getSnapshot().phase).toBe('canceled');
+        },
+    );
+    it("keeps pending activation when another window reports the same account", async () => {
+        const auth = deferred<{ userId: string; credential: string }>();
+        const f = fixture({ getAuth: () => auth.promise });
+        await f.start();
+        f.controller.authChanged("user");
+        expect(f.controller.getSnapshot().phase).toBe("starting");
+        auth.resolve({ userId: "other", credential: "credential" });
+        await settle();
+        expect(f.controller.getSnapshot().phase).toBe("canceled");
+        expect(f.capture).toBeUndefined();
     });
-});
-
-it('keeps a pending session when another window reports the expected account', async () => {
-    const auth = deferred<{ userId: string; credential: string }>();
-    const f = fixture({ getAuth: () => auth.promise });
-    f.controller.start(owner, 'user');
-    f.controller.authChanged('user');
-    expect(f.controller.getSnapshot().phase).toBe('starting');
-    auth.resolve({ userId: 'user', credential: 'credential' }); await settle();
-    expect(f.controller.getSnapshot().phase).toBe('listening');
-});
-
-it.each(['notification', 'credentials'])('revokes a bound activation on account replacement via %s', async source => {
-    const auth = deferred<{ userId: string; credential: string }>();
-    const f = fixture({ getAuth: () => auth.promise });
-    f.controller.start(owner, 'user');
-    if (source === 'notification') f.controller.authChanged('other');
-    auth.resolve({ userId: 'other', credential: 'credential' }); await settle();
-    expect(f.controller.getSnapshot().phase).toBe('canceled');
-    expect(f.capture).toBeUndefined(); expect(f.transcription).toBeUndefined();
 });

--- a/tests/unit/voice/fixtures.test.ts
+++ b/tests/unit/voice/fixtures.test.ts
@@ -1,36 +1,47 @@
-import { expect, it } from 'vitest';
-import fixture from '../../fixtures/voice/session.json';
-import { VoiceController } from '@beaver/agent-core/voice/controller';
-import { FakeVoiceCapture, FakeVoiceTranscription } from '@beaver/agent-core/voice/fakes';
-import { VOICE_FORMAT, VOICE_VERSION, type TranscriptEvent } from '@beaver/agent-core/voice/contracts';
+import { expect, it } from "vitest";
+import fixture from "../../fixtures/voice/session.json";
+import { VoiceController } from "@beaver/agent-core/voice/controller";
+import {
+    FakeVoiceCapture,
+    FakeVoiceTranscription,
+} from "@beaver/agent-core/voice/fakes";
+import {
+    VOICE_FORMAT,
+    VOICE_VERSION,
+} from "@beaver/agent-core/voice/contracts";
 
-it('replays the versioned handoff fixture through the controller', async () => {
+it("replays the batch handoff fixture with a single transcript and a flushed tail", async () => {
     let capture!: FakeVoiceCapture, transcription!: FakeVoiceTranscription;
-    const sentFrames: { sequence: number; sampleCount: number; byteLength: number }[] = [];
     const controller = new VoiceController({
         clock: { setTimeout: () => 0, clearTimeout: () => {} },
-        getAuth: async () => ({ userId: 'fixture', credential: 'fake' }),
-        capability: () => ({ enabled: true, available: true }), createId: () => fixture.sessionId,
-        createCapture: (session, emit) => capture = new FakeVoiceCapture(session, emit),
-        createTranscription: (session, emit) => transcription = new FakeVoiceTranscription(session, emit),
+        getAuth: async () => ({ userId: "fixture", credential: "fake" }),
+        capability: () => ({ enabled: true, available: true }),
+        createId: () => fixture.sessionId,
+        createCapture: (session, emit) =>
+            (capture = new FakeVoiceCapture(session, emit)),
+        createTranscription: (session) =>
+            (transcription = new FakeVoiceTranscription(session)),
     });
-    expect(fixture.version).toBe(VOICE_VERSION); expect(fixture.format).toEqual(VOICE_FORMAT);
-    controller.start({ windowId: 'fixture', output: { kind: 'draft', id: 'fixture' } }, 'fixture');
+    expect(fixture.version).toBe(VOICE_VERSION);
+    expect(fixture.format).toEqual(VOICE_FORMAT);
+    controller.start(
+        { windowId: "fixture", output: { kind: "draft", id: "fixture" } },
+        "fixture",
+    );
     for (let i = 0; i < 10; i++) await Promise.resolve();
-    const send = transcription.send.bind(transcription);
-    transcription.send = async frame => {
-        sentFrames.push({ sequence: frame.sequence, sampleCount: frame.sampleCount, byteLength: frame.pcm.byteLength });
-        await send(frame);
-    };
-    capture.frame(fixture.frames[0].sampleCount); capture.tailSamples = fixture.frames[1].sampleCount;
-    transcription.autoComplete = false;
-    for (const event of fixture.transcript.slice(0, -1)) {
-        transcription.emit({ version: VOICE_VERSION, sessionId: fixture.sessionId, ...event } as TranscriptEvent);
-    }
+    for (const frame of fixture.frames.slice(0, -1))
+        capture.frame(frame.sampleCount);
+    capture.tailSamples = fixture.frames.at(-1)!.sampleCount;
+    transcription.resultText = fixture.transcript;
+    expect(transcription.requestCount).toBe(0);
+    expect(controller.getSnapshot().committedText).toBe("");
     controller.finish(fixture.sessionId);
     for (let i = 0; i < 10; i++) await Promise.resolve();
-    expect(sentFrames).toEqual(fixture.frames);
-    expect(transcription.endAudio).toMatchObject(fixture.endAudio);
-    transcription.emit({ version: VOICE_VERSION, sessionId: fixture.sessionId, ...fixture.transcript.at(-1) } as TranscriptEvent);
-    expect(controller.getSnapshot()).toMatchObject({ phase: 'completed', committedText: fixture.committedText });
+    expect(transcription.requestCount).toBe(1);
+    expect(transcription.sampleCount).toBe(fixture.sampleCount);
+    expect(controller.getSnapshot()).toMatchObject({
+        phase: "completed",
+        committedText: fixture.transcript,
+        frameCount: fixture.frames.length,
+    });
 });

--- a/tests/unit/voice/macCapture.test.ts
+++ b/tests/unit/voice/macCapture.test.ts
@@ -22,13 +22,22 @@ function send(type: string, fields = {}, token = "secret") {
             ...(type === "control"
                 ? { sequence: controlSequence++ }
                 : { eventSequence: eventSequence++ }),
+            ...(["frame", "error"].includes(type)
+                ? {
+                      quality: {
+                          inputPeak: 0,
+                          clippedSamples: 0,
+                          discontinuityCount: 0,
+                      },
+                  }
+                : {}),
             ...fields,
         }),
     });
 }
 async function ready() {
     const started = capture.start();
-    send("hello", { helperVersion: 1 });
+    send("hello", { helperVersion: 2 });
     send("permission", { status: "granted" });
     send("ready", { format: VOICE_FORMAT });
     await started;
@@ -71,23 +80,25 @@ describe("macOS capture IPC lease", () => {
         await finished;
         expect(emit.mock.calls.map(([e]) => e.type)).toEqual([
             "ready",
+            "quality",
             "frame",
+            "quality",
             "frame",
         ]);
         expect(send("control").status).toBe(403);
     });
     it("rejects wrong authorization without consuming ordering or failing the legitimate session", async () => {
         capture.start();
-        expect(send("hello", { helperVersion: 1 }, "wrong").status).toBe(403);
+        expect(send("hello", { helperVersion: 2 }, "wrong").status).toBe(403);
         eventSequence = 0;
-        expect(send("hello", { helperVersion: 1 }).status).toBe(200);
+        expect(send("hello", { helperVersion: 2 }).status).toBe(200);
         expect(emit).not.toHaveBeenCalled();
     });
-    it.each([{ version: 2 }, { sessionId: "other" }, { helperVersion: 2 }])(
+    it.each([{ version: 2 }, { sessionId: "other" }, { helperVersion: 99 }])(
         "fails authenticated incompatible handshakes: %j",
         (fields) => {
             capture.start();
-            send("hello", { helperVersion: 1, ...fields });
+            send("hello", { helperVersion: 2, ...fields });
             expect(emit).toHaveBeenCalledWith(
                 expect.objectContaining({ error: { code: "protocol_error" } }),
             );
@@ -97,7 +108,7 @@ describe("macOS capture IPC lease", () => {
         "reports explicit %s permission without inferring it from silence",
         (status) => {
             capture.start();
-            send("hello", { helperVersion: 1 });
+            send("hello", { helperVersion: 2 });
             send("permission", { status });
             send("error", { code: "permission_denied" });
             expect(service.permission).toBe(status);
@@ -110,7 +121,7 @@ describe("macOS capture IPC lease", () => {
     );
     it("revokes canceled permission setup and allows a fresh session", async () => {
         const started = capture.start();
-        send("hello", { helperVersion: 1 });
+        send("hello", { helperVersion: 2 });
         send("permission", { status: "not_determined" });
         capture.dispose();
         capture.dispose();
@@ -125,7 +136,7 @@ describe("macOS capture IPC lease", () => {
         capture.dispose();
         capture = service.preparePermission(session) as any;
         const setup = capture.start();
-        send("hello", { helperVersion: 1 });
+        send("hello", { helperVersion: 2 });
         send("permission", { status: "not_determined" });
         expect(
             send("permission_done", { status: "granted" }).body,
@@ -138,7 +149,7 @@ describe("macOS capture IPC lease", () => {
         capture.dispose();
         capture = service.preparePermission(session) as any;
         const setup = capture.start();
-        send("hello", { helperVersion: 1 });
+        send("hello", { helperVersion: 2 });
         expect(send("ready", { format: VOICE_FORMAT }).status).toBe(400);
         await expect(setup).rejects.toThrow();
     });
@@ -262,5 +273,85 @@ describe("bounded native HTTP framing", () => {
         ]) {
             expect(() => new VoiceHttpParser(12345).push(wire)).toThrow();
         }
+    });
+});
+
+it("forwards cumulative clipping diagnostics and discontinuities before terminal errors", async () => {
+    await ready();
+    const quality = {
+        inputPeak: 1.2,
+        clippedSamples: 20,
+        discontinuityCount: 0,
+    };
+    send("frame", {
+        sequence: 0,
+        sampleCount: 1600,
+        pcm: Buffer.alloc(3200).toString("base64"),
+        quality,
+    });
+    send("error", {
+        code: "discontinuity",
+        quality: { ...quality, discontinuityCount: 1 },
+    });
+    expect(emit.mock.calls.slice(-2).map(([event]) => event)).toEqual([
+        {
+            ...session,
+            type: "quality",
+            quality: { ...quality, discontinuityCount: 1 },
+        },
+        { ...session, type: "error", error: { code: "discontinuity" } },
+    ]);
+});
+
+it.each([
+    undefined,
+    null,
+    { inputPeak: -1, clippedSamples: 0, discontinuityCount: 0 },
+    { inputPeak: 1, clippedSamples: 0.5, discontinuityCount: 0 },
+])("rejects missing or malformed capture quality %#", async (quality) => {
+    await ready();
+    send("frame", {
+        sequence: 0,
+        sampleCount: 1600,
+        pcm: Buffer.alloc(3200).toString("base64"),
+        quality,
+    });
+    expect(emit).toHaveBeenLastCalledWith({
+        ...session,
+        type: "error",
+        error: { code: "protocol_error" },
+    });
+    expect(emit.mock.calls.some(([event]) => event.type === "frame")).toBe(
+        false,
+    );
+});
+
+it("rejects decreasing quality counters", async () => {
+    await ready();
+    send("frame", {
+        sequence: 0,
+        sampleCount: 1600,
+        pcm: Buffer.alloc(3200).toString("base64"),
+        quality: { inputPeak: 1, clippedSamples: 20, discontinuityCount: 0 },
+    });
+    frame(1600, 1);
+    expect(emit).toHaveBeenLastCalledWith({
+        ...session,
+        type: "error",
+        error: { code: "protocol_error" },
+    });
+});
+
+it("enforces the complete utterance sample bound independently of controller and wall time", async () => {
+    await ready();
+    for (let i = 0; i < 1200; i++) frame(1600, i);
+    expect(emit).not.toHaveBeenLastCalledWith(
+        expect.objectContaining({ type: "error" }),
+    );
+    frame(1600, 1200);
+    expect(emit).toHaveBeenLastCalledWith({
+        ...session,
+        type: "error",
+        error: { code: "duration_limit" },
     });
 });

--- a/tests/unit/voice/nativeHarness.test.ts
+++ b/tests/unit/voice/nativeHarness.test.ts
@@ -224,7 +224,10 @@ it("bounds opted-in retention to the capture duration even with extra frames", a
         await settle();
     }
     expect(h.nativeState()?.retainedBytes).toBe(3840000);
-    expect(h.service.controller.getSnapshot().phase).toBe("listening");
+    expect(h.service.controller.getSnapshot()).toMatchObject({
+        phase: "error",
+        error: { code: "duration_limit" },
+    });
 });
 
 it("reports canceled permission setup as unavailable without a second explanation", async () => {

--- a/tests/unit/voice/nativeVoice.test.ts
+++ b/tests/unit/voice/nativeVoice.test.ts
@@ -139,7 +139,7 @@ it("invalidates granted permission on same-path registration without opening ano
     const token = launch[launch.indexOf("--token") + 1];
     expect(launch).toContain("--permission-only");
     for (const [eventSequence, event] of [
-        { type: "hello", helperVersion: 1 },
+        { type: "hello", helperVersion: 2 },
         { type: "permission", status: "granted" },
         { type: "permission_done", status: "granted" },
     ].entries()) {

--- a/tests/unit/voice/service.test.ts
+++ b/tests/unit/voice/service.test.ts
@@ -1,184 +1,327 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import { VoiceService } from '../../../src/services/voice/voiceService';
-import { DevelopmentVoiceHarness, type VoiceHarnessRequest } from '../../../src/services/voice/developmentHarness';
-import { VOICE_LIMITS, type VoiceClock } from '@beaver/agent-core/voice/contracts';
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { VoiceService } from "../../../src/services/voice/voiceService";
+import {
+    DevelopmentVoiceHarness,
+    type VoiceHarnessRequest,
+} from "../../../src/services/voice/developmentHarness";
+import {
+    VOICE_LIMITS,
+    type VoiceClock,
+} from "@beaver/agent-core/voice/contracts";
 
-const settle = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
-const auth = async () => ({ userId: 'user', credential: 'fake' });
-const output = { kind: 'draft' as const, id: 'draft' };
+const settle = async () => {
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+};
+const auth = async () => ({ userId: "user", credential: "fake" });
+const output = { kind: "draft" as const, id: "draft" };
 function hostWindow() {
     const events = new Map<string, Set<(event: { target: unknown }) => void>>();
     const win = {
         closed: false,
         document: { hasFocus: () => true },
-        addEventListener(type: string, listener: (event: { target: unknown }) => void) {
-            if (!events.has(type)) events.set(type, new Set()); events.get(type)!.add(listener);
+        addEventListener(
+            type: string,
+            listener: (event: { target: unknown }) => void,
+        ) {
+            if (!events.has(type)) events.set(type, new Set());
+            events.get(type)!.add(listener);
         },
-        removeEventListener(type: string, listener: (event: { target: unknown }) => void) { events.get(type)?.delete(listener); },
-        dispatch(type: string, target?: unknown): void { for (const listener of events.get(type) ?? []) listener({ target: target ?? win }); },
-        listenerCount() { return [...events.values()].reduce((n, set) => n + set.size, 0); },
+        removeEventListener(
+            type: string,
+            listener: (event: { target: unknown }) => void,
+        ) {
+            events.get(type)?.delete(listener);
+        },
+        dispatch(type: string, target?: unknown): void {
+            for (const listener of events.get(type) ?? [])
+                listener({ target: target ?? win });
+        },
+        listenerCount() {
+            return [...events.values()].reduce((n, set) => n + set.size, 0);
+        },
     };
     return win;
 }
 const clock: VoiceClock = {
-    setTimeout: (fn, ms) => setTimeout(fn, ms), clearTimeout: h => clearTimeout(h as ReturnType<typeof setTimeout>),
+    setTimeout: (fn, ms) => setTimeout(fn, ms),
+    clearTimeout: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
 };
 const createHarness = () => new DevelopmentVoiceHarness(clock);
 
 beforeEach(() => {
-    vi.clearAllMocks(); vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
     let id = 0;
     (Zotero.Utilities as any).randomString = () => `voice-${++id}`;
 });
-afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+});
 
-describe('plugin voice ownership', () => {
-    it('requires explicit development enablement and never enables production', async () => {
-        const win = hostWindow(); const harness = createHarness(); const service = harness.service;
-        expect(service.start(win as unknown as Window, output, auth, 'user')).toEqual({ error: { code: 'disabled' } });
+describe("plugin voice ownership", () => {
+    it("requires explicit development enablement and never enables production", async () => {
+        const win = hostWindow();
+        const harness = createHarness();
+        const service = harness.service;
+        expect(
+            service.start(win as unknown as Window, output, auth, "user"),
+        ).toEqual({ error: { code: "disabled" } });
         expect(win.listenerCount()).toBe(0);
         const production = new VoiceService(clock);
-        expect(production.start(win as unknown as Window, output, auth, 'user')).toEqual({ error: { code: 'disabled' } });
+        expect(
+            production.start(win as unknown as Window, output, auth, "user"),
+        ).toEqual({ error: { code: "disabled" } });
         expect(win.listenerCount()).toBe(0);
     });
 
-    it.each(['unload', 'blur', 'logout', 'shutdown', 'disable'])('releases resources and window closures on %s', async event => {
-        const win = hostWindow(); const harness = createHarness(); const service = harness.service;
-        harness.run({ command: 'enable', enabled: true });
-        service.start(win as unknown as Window, output, auth, 'user'); await settle();
-        expect(win.listenerCount()).toBe(2);
-        if (event === 'unload' || event === 'blur') win.dispatch(event);
-        if (event === 'logout') service.authChanged(null);
-        if (event === 'shutdown') service.dispose();
-        if (event === 'disable') harness.run({ command: 'enable', enabled: false });
-        expect(service.controller.getSnapshot().phase).toBe('canceled');
-        expect(harness.run({ command: 'state' }).resources).toMatchObject({ captureDisposeCount: 1, transcriptionDisposeCount: 1 });
-        expect(win.listenerCount()).toBe(0);
-    });
+    it.each(["unload", "blur", "logout", "shutdown", "disable"])(
+        "releases resources and window closures on %s",
+        async (event) => {
+            const win = hostWindow();
+            const harness = createHarness();
+            const service = harness.service;
+            harness.run({ command: "enable", enabled: true });
+            service.start(win as unknown as Window, output, auth, "user");
+            await settle();
+            expect(win.listenerCount()).toBe(2);
+            if (event === "unload" || event === "blur") win.dispatch(event);
+            if (event === "logout") service.authChanged(null);
+            if (event === "shutdown") service.dispose();
+            if (event === "disable")
+                harness.run({ command: "enable", enabled: false });
+            expect(service.controller.getSnapshot().phase).toBe("canceled");
+            expect(harness.run({ command: "state" }).resources).toMatchObject({
+                captureDisposeCount: 1,
+                transcriptionDisposeCount: 1,
+            });
+            expect(win.listenerCount()).toBe(0);
+        },
+    );
 
-    it('ignores internal focus changes and rejects another window without replacing ownership', async () => {
-        const win = hostWindow(), other = hostWindow(); const harness = createHarness(); const service = harness.service;
-        harness.run({ command: 'enable', enabled: true });
-        service.start(win as unknown as Window, output, auth, 'user'); await settle();
+    it("ignores internal focus changes and rejects another window without replacing ownership", async () => {
+        const win = hostWindow(),
+            other = hostWindow();
+        const harness = createHarness();
+        const service = harness.service;
+        harness.run({ command: "enable", enabled: true });
+        service.start(win as unknown as Window, output, auth, "user");
+        await settle();
         other.document.hasFocus = () => false;
-        win.dispatch('blur', {});
-        expect(service.controller.getSnapshot().phase).toBe('listening');
-        expect(service.start(other as unknown as Window, output, auth, 'user')).toEqual({ error: { code: 'busy' } });
+        win.dispatch("blur", {});
+        expect(service.controller.getSnapshot().phase).toBe("listening");
+        expect(
+            service.start(other as unknown as Window, output, auth, "user"),
+        ).toEqual({ error: { code: "busy" } });
         expect(other.listenerCount()).toBe(0);
         service.windowUnloaded(other as unknown as Window);
-        expect(service.controller.getSnapshot().phase).toBe('listening');
+        expect(service.controller.getSnapshot().phase).toBe("listening");
         service.windowUnloaded(win as unknown as Window);
         other.document.hasFocus = () => true;
-        service.start(other as unknown as Window, output, auth, 'user'); await settle();
-        expect(service.controller.getSnapshot().owner?.windowId).toBe(service.windowId(other as unknown as Window));
+        service.start(other as unknown as Window, output, auth, "user");
+        await settle();
+        expect(service.controller.getSnapshot().owner?.windowId).toBe(
+            service.windowId(other as unknown as Window),
+        );
     });
 
-    it('flushes and completes a synthetic session with no audio persistence or sends', async () => {
-        const win = hostWindow(); const harness = createHarness(); const service = harness.service; harness.run({ command: 'enable', enabled: true });
-        service.start(win as unknown as Window, output, auth, 'user'); await settle();
-        harness.run({ command: 'frame' });
-        harness.run({ command: 'interim', segmentId: 0, text: 'Hel' });
-        harness.run({ command: 'segment_final', segmentId: 0, text: 'Hello' });
-        harness.run({ command: 'finish' }); await settle();
-        const result = harness.run({ command: 'state' });
-        expect(result.state).toMatchObject({ phase: 'completed', committedText: 'Hello', sampleCount: 2240 });
-        expect(result.resources).toMatchObject({ sentFrames: 2, captureDisposeCount: 1, transcriptionDisposeCount: 1 });
+    it("flushes and completes a synthetic session with no audio persistence or sends", async () => {
+        const win = hostWindow();
+        const harness = createHarness();
+        const service = harness.service;
+        harness.run({ command: "enable", enabled: true });
+        service.start(win as unknown as Window, output, auth, "user");
+        await settle();
+        for (let i = 0; i < 3; i++) harness.run({ command: "frame" });
+        harness.run({ command: "transcript", text: "Hello" });
+        harness.run({ command: "finish" });
+        await settle();
+        const result = harness.run({ command: "state" });
+        expect(result.state).toMatchObject({
+            phase: "completed",
+            committedText: "Hello",
+            sampleCount: 5440,
+        });
+        expect(result.resources).toMatchObject({
+            requestCount: 1,
+            captureDisposeCount: 1,
+            transcriptionDisposeCount: 1,
+        });
         expect(win.listenerCount()).toBe(0);
     });
 });
 
-it('starts diagnostics afresh while the next session waits for auth', async () => {
-    const win = hostWindow(); const harness = createHarness(); const service = harness.service;
-    harness.run({ command: 'enable', enabled: true });
-    service.start(win as unknown as Window, output, auth, 'user'); await settle();
-    harness.run({ command: 'frame' }); harness.run({ command: 'finish' }); await settle();
-    expect(harness.run({ command: 'state' }).resources.sentFrames).toBe(2);
-    service.start(win as unknown as Window, output, () => new Promise(() => {}), 'user');
-    const pending = harness.run({ command: 'state' });
-    expect(pending.state.phase).toBe('starting');
-    expect(pending.resources).toEqual({ captureDisposeCount: 0, transcriptionDisposeCount: 0, sentFrames: 0, endAudio: null });
+it("starts diagnostics afresh while the next session waits for auth", async () => {
+    const win = hostWindow();
+    const harness = createHarness();
+    const service = harness.service;
+    harness.run({ command: "enable", enabled: true });
+    service.start(win as unknown as Window, output, auth, "user");
+    await settle();
+    for (let i = 0; i < 3; i++) harness.run({ command: "frame" });
+    harness.run({ command: "finish" });
+    await settle();
+    expect(harness.run({ command: "state" }).resources.requestCount).toBe(1);
+    service.start(
+        win as unknown as Window,
+        output,
+        () => new Promise(() => {}),
+        "user",
+    );
+    const pending = harness.run({ command: "state" });
+    expect(pending.state.phase).toBe("starting");
+    expect(pending.resources).toEqual({
+        captureDisposeCount: 0,
+        transcriptionDisposeCount: 0,
+        requestCount: 0,
+        transcribedSamples: 0,
+    });
     service.dispose();
 });
 
-it('rejects closed or absent windows before registering listeners', () => {
-    const harness = createHarness(); const service = harness.service; const win = hostWindow(); win.closed = true;
-    harness.run({ command: 'enable', enabled: true });
+it("rejects closed or absent windows before registering listeners", () => {
+    const harness = createHarness();
+    const service = harness.service;
+    const win = hostWindow();
+    win.closed = true;
+    harness.run({ command: "enable", enabled: true });
     for (const value of [win, null, undefined]) {
-        expect(service.start(value as Window | null | undefined, output, auth, 'user')).toEqual({ error: { code: 'unavailable' } });
+        expect(
+            service.start(
+                value as Window | null | undefined,
+                output,
+                auth,
+                "user",
+            ),
+        ).toEqual({ error: { code: "unavailable" } });
     }
     expect(win.listenerCount()).toBe(0);
 });
 
 it.each([
-    { command: 'unknown' }, { command: 'interim', text: 5, segmentId: 0 },
-    { command: 'interim', text: 'x'.repeat(VOICE_LIMITS.transcriptCharacters + 1), segmentId: 0 },
-    { command: 'segment_final', text: 'test', segmentId: -1 },
-    { command: 'segment_final', text: 'test', segmentId: 0.5 },
-])('rejects invalid harness input %#', request => {
+    { command: "unknown" },
+    { command: "transcript", text: 5 },
+    {
+        command: "transcript",
+        text: "x".repeat(VOICE_LIMITS.transcriptCharacters + 1),
+    },
+    { command: "transcript" },
+    { command: "interim", text: "unsupported" },
+])("rejects invalid harness input %#", (request) => {
     const harness = createHarness();
     expect(() => harness.run(request as VoiceHarnessRequest)).toThrow();
 });
 
-it('does not allocate identities for unrelated unloading windows', () => {
+it("does not allocate identities for unrelated unloading windows", () => {
     const service = new VoiceService(clock);
     service.windowUnloaded(hostWindow() as unknown as Window);
-    expect(service.windowId(hostWindow() as unknown as Window)).toBe('voice-window-1');
+    expect(service.windowId(hostWindow() as unknown as Window)).toBe(
+        "voice-window-1",
+    );
 });
 
-it.each(['starting', 'finalizing'])('preserves owner listeners on a rejected start while %s', async phase => {
-    const harness = createHarness(); const service = harness.service;
-    const owner = hostWindow(), other = hostWindow();
-    harness.run({ command: 'enable', enabled: true });
-    service.start(owner as unknown as Window, output, phase === 'starting' ? () => new Promise(() => {}) : auth, 'user');
-    if (phase === 'finalizing') { await settle(); harness.run({ command: 'finish' }); }
-    expect(service.controller.getSnapshot().phase).toBe(phase);
-    expect(service.start(other as unknown as Window, output, auth, 'user')).toEqual({ error: { code: 'busy' } });
-    expect(owner.listenerCount()).toBe(2); expect(other.listenerCount()).toBe(0);
-    owner.dispatch('unload');
-    expect(service.controller.getSnapshot().phase).toBe('canceled');
-    expect(owner.listenerCount()).toBe(0);
-});
+it.each(["starting", "finalizing"])(
+    "preserves owner listeners on a rejected start while %s",
+    async (phase) => {
+        const harness = createHarness();
+        const service = harness.service;
+        const owner = hostWindow(),
+            other = hostWindow();
+        harness.run({ command: "enable", enabled: true });
+        service.start(
+            owner as unknown as Window,
+            output,
+            phase === "starting" ? () => new Promise(() => {}) : auth,
+            "user",
+        );
+        if (phase === "finalizing") {
+            await settle();
+            harness.run({ command: "finish" });
+        }
+        expect(service.controller.getSnapshot().phase).toBe(phase);
+        expect(
+            service.start(other as unknown as Window, output, auth, "user"),
+        ).toEqual({ error: { code: "busy" } });
+        expect(owner.listenerCount()).toBe(2);
+        expect(other.listenerCount()).toBe(0);
+        owner.dispatch("unload");
+        expect(service.controller.getSnapshot().phase).toBe("canceled");
+        expect(owner.listenerCount()).toBe(0);
+    },
+);
 
-it('rejects activation from an unfocused window', () => {
-    const harness = createHarness(), win = hostWindow();
+it("rejects activation from an unfocused window", () => {
+    const harness = createHarness(),
+        win = hostWindow();
     win.document.hasFocus = () => false;
-    harness.run({ command: 'enable', enabled: true });
-    expect(harness.service.start(win as unknown as Window, output, auth, 'user')).toEqual({ error: { code: 'unavailable' } });
+    harness.run({ command: "enable", enabled: true });
+    expect(
+        harness.service.start(win as unknown as Window, output, auth, "user"),
+    ).toEqual({ error: { code: "unavailable" } });
     expect(win.listenerCount()).toBe(0);
 });
 
-it('requires fresh activation after focus loss during setup, even if permission later resolves', async () => {
-    const harness = createHarness(), win = hostWindow();
+it("requires fresh activation after focus loss during setup, even if permission later resolves", async () => {
+    const harness = createHarness(),
+        win = hostWindow();
     let resolveAuth!: (auth: { userId: string; credential: string }) => void;
-    const pending = new Promise<{ userId: string; credential: string }>(resolve => { resolveAuth = resolve; });
-    harness.run({ command: 'enable', enabled: true });
-    harness.service.start(win as unknown as Window, output, () => pending, 'user');
-    harness.service.authChanged('user');
-    expect(harness.service.controller.getSnapshot().phase).toBe('starting');
-    win.dispatch('blur'); resolveAuth({ userId: 'user', credential: 'fake' }); await settle();
-    expect(harness.service.controller.getSnapshot().phase).toBe('canceled');
-    expect(harness.run({ command: 'state' }).resources.sentFrames).toBe(0);
+    const pending = new Promise<{ userId: string; credential: string }>(
+        (resolve) => {
+            resolveAuth = resolve;
+        },
+    );
+    harness.run({ command: "enable", enabled: true });
+    harness.service.start(
+        win as unknown as Window,
+        output,
+        () => pending,
+        "user",
+    );
+    harness.service.authChanged("user");
+    expect(harness.service.controller.getSnapshot().phase).toBe("starting");
+    win.dispatch("blur");
+    resolveAuth({ userId: "user", credential: "fake" });
+    await settle();
+    expect(harness.service.controller.getSnapshot().phase).toBe("canceled");
+    expect(harness.run({ command: "state" }).resources.requestCount).toBe(0);
     expect(win.listenerCount()).toBe(0);
 });
 
-it('runs synthetic sessions without consulting the desktop window', async () => {
+it("runs synthetic sessions without consulting the desktop window", async () => {
     const harness = createHarness();
-    const mainWindow = vi.spyOn(Zotero, 'getMainWindow').mockImplementation(() => { throw new Error('No desktop window'); });
+    const mainWindow = vi
+        .spyOn(Zotero, "getMainWindow")
+        .mockImplementation(() => {
+            throw new Error("No desktop window");
+        });
     try {
-        harness.run({ command: 'enable', enabled: true });
-        expect(harness.start('user', auth)).toHaveProperty('sessionId'); await settle();
-        expect(harness.service.controller.getSnapshot().phase).toBe('listening');
-        harness.run({ command: 'cancel' });
-        expect(harness.run({ command: 'state' }).resources).toMatchObject({ captureDisposeCount: 1, transcriptionDisposeCount: 1 });
+        harness.run({ command: "enable", enabled: true });
+        expect(harness.start("user", auth)).toHaveProperty("sessionId");
+        await settle();
+        expect(harness.service.controller.getSnapshot().phase).toBe(
+            "listening",
+        );
+        harness.run({ command: "cancel" });
+        expect(harness.run({ command: "state" }).resources).toMatchObject({
+            captureDisposeCount: 1,
+            transcriptionDisposeCount: 1,
+        });
         expect(mainWindow).not.toHaveBeenCalled();
-    } finally { mainWindow.mockRestore(); }
+    } finally {
+        mainWindow.mockRestore();
+    }
 });
 
-it('releases owner listeners if allocating a session fails synchronously', () => {
-    const harness = createHarness(), win = hostWindow();
-    harness.run({ command: 'enable', enabled: true });
-    (Zotero.Utilities as any).randomString = () => { throw new Error('Allocation failed'); };
-    expect(() => harness.service.start(win as unknown as Window, output, auth, 'user')).toThrow('Allocation failed');
+it("releases owner listeners if allocating a session fails synchronously", () => {
+    const harness = createHarness(),
+        win = hostWindow();
+    harness.run({ command: "enable", enabled: true });
+    (Zotero.Utilities as any).randomString = () => {
+        throw new Error("Allocation failed");
+    };
+    expect(() =>
+        harness.service.start(win as unknown as Window, output, auth, "user"),
+    ).toThrow("Allocation failed");
     expect(win.listenerCount()).toBe(0);
-    expect(harness.service.controller.getSnapshot().phase).toBe('idle');
+    expect(harness.service.controller.getSnapshot().phase).toBe("idle");
 });


### PR DESCRIPTION
## Summary

- Replace streaming transcription with bounded batched recordings and an energy gate.
- Add corrected transcript handling, credential refresh, vocabulary options, and lifecycle safeguards.
- Add macOS gain control, peak limiting, clipping metrics, and timestamp discontinuity detection.
- Update voice protocol documentation, native harnesses, fixtures, and tests.

## Testing

- `npx vitest run tests/unit/voice`
- `ZOTERO_HTTP_PORT="$VOICE_HTTP_PORT" npx vitest run --config vitest.live.config.ts tests/live/voice.live.test.ts`
- `native/voice/macos/test.sh`
- `npm run typecheck:core`
- `npm run typecheck:ui`
- `npm run check:bundle`