### PR TITLE
feat(voice): package and release universal native helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,36 @@ permissions:
   pull-requests: write
 
 jobs:
+  voice:
+    if: vars.VOICE_RELEASE_ENABLED == 'true'
+    runs-on: macos-15
+    environment: voice-release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: native/voice/macos/build.sh
+      - name: Sign, notarize, staple and package
+        env:
+          VOICE_CERTIFICATE_BASE64: ${{ secrets.VOICE_CERTIFICATE_BASE64 }}
+          VOICE_CERTIFICATE_PASSWORD: ${{ secrets.VOICE_CERTIFICATE_PASSWORD }}
+          VOICE_SIGNING_IDENTITY: ${{ secrets.VOICE_SIGNING_IDENTITY }}
+          VOICE_TEAM_ID: ${{ secrets.VOICE_TEAM_ID }}
+          VOICE_APPLE_ID: ${{ secrets.VOICE_APPLE_ID }}
+          VOICE_APP_PASSWORD: ${{ secrets.VOICE_APP_PASSWORD }}
+        run: bash native/voice/macos/ci-sign.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: voice-macos
+          path: addon/content/voice/
+          if-no-files-found: error
   release:
+    needs: voice
+    if: always() && (needs.voice.result == 'success' || needs.voice.result == 'skipped')
     runs-on: ubuntu-latest
     env:
+      VOICE_PACKAGE_REQUIRED: ${{ needs.voice.result == 'success' && '1' || '0' }}
       GITHUB_TOKEN: ${{ secrets.GitHub_TOKEN }}
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
@@ -30,12 +57,17 @@ jobs:
         with:
           node-version: 20
 
+      - uses: actions/download-artifact@v4
+        if: needs.voice.result == 'success'
+        with:
+          name: voice-macos
+          path: addon/content/voice/
+
       - name: Install deps
         run: npm install
 
-      # - name: Build
-      #   run: |
-      #     npm run build
+      - name: Build and verify XPI
+        run: npm run build
 
       - name: Release to GitHub
         run: |

--- a/.github/workflows/voice.yml
+++ b/.github/workflows/voice.yml
@@ -1,0 +1,33 @@
+name: Native voice
+on:
+    pull_request:
+        paths:
+            - "native/voice/**"
+            - "src/services/voice/**"
+            - "tests/unit/voice/**"
+            - "scripts/pack-xpi.mjs"
+            - "zotero-plugin.config.ts"
+            - ".github/workflows/voice.yml"
+    workflow_dispatch:
+permissions:
+    contents: read
+jobs:
+    macos:
+        strategy:
+            matrix:
+                runner: [macos-15, macos-15-intel]
+        runs-on: ${{ matrix.runner }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            - run: native/voice/macos/build.sh
+            - run: native/voice/macos/test.sh
+            - run: node native/voice/macos/package.mjs --development
+            - run: python3 native/voice/macos/Tests/packaging.py
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: voice-development-${{ matrix.runner }}
+                  path: addon/content/voice/
+                  if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ docs-zotero
 # BeaverExtract benchmarks
 /tests/live/.bench-results/
 /.bench-corpus/
+
+# Opaque native helper release assets
+/addon/content/voice/

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -11,6 +11,7 @@ pref("authMethod", "otp");
 
 // Microphone helper explanation
 pref("voice.helperExplained", false);
+pref("voice.nativeEnabled", false);
 
 // App settings
 pref("keyboardShortcut", "j");

--- a/docs/native-voice-packaging.md
+++ b/docs/native-voice-packaging.md
@@ -1,0 +1,211 @@
+# Packaged macOS voice helper
+
+Voice remains disabled by default (`extensions.zotero.beaver.voice.nativeEnabled`).
+The native service object is plugin-owned; constructing it opens no socket, extracts no
+files, and launches no process. `ensurePackagedHelper()` performs installation on the first
+explicit native activation. Product dictation and the backend adapter are separate work.
+The development harness can use this same packaged path without `setDevelopmentHelper()`.
+
+## Compatibility and release status
+
+| Component       | Target compatibility                  | Validation                                                                            |
+| --------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| macOS           | 14.0 or later                         | Local checks on 14.7; macOS 15 CI configured                                          |
+| Zotero          | 7.x–10.x                              | Live packaged checks on 10.0.1-beta.1; older majors still require release-matrix runs |
+| CPU             | arm64 and x86_64 in one universal app | Local arm64 and forced Intel/Rosetta microphone capture; native Intel CI configured   |
+| Windows / Linux | Disabled                              | No packaged adapter                                                                   |
+
+This is a target compatibility matrix, not evidence that every combination has passed.
+Production enablement must wait for the unverified combinations, Developer ID signing,
+notarization, and the remaining voice product integration. An OS below macOS 14, an
+unlisted CPU, or a Zotero major outside 7–10 is rejected before extraction or launch.
+
+## Build and package
+
+On macOS with Xcode command-line tools:
+
+```sh
+npm run voice:build
+npm run voice:package:dev
+npm run build:dev
+```
+
+The generated XPI includes `content/voice/manifest.json` and `content/voice/macos.zip`.
+There is no manual app placement. The inner zip is made with `ditto`, preserving bundle
+contents, executable modes, symlinks, resources, and signatures. Both scaffold assembly and
+`pack-xpi.mjs` verify that the archive digest/length match its manifest. Production builds
+reject a development package. Ordinary builds can omit voice assets while the feature is
+unreleased; `VOICE_PACKAGE_REQUIRED=1` makes missing assets a build failure.
+
+`build.sh` cleans the app directory, builds arm64 and x86_64 slices with a macOS 14.0
+minimum, combines them using `lipo`, and ad-hoc signs the app with hardened runtime and
+the microphone entitlement. `VOICE_TESTING=1` builds a separate fixture identity in
+`build/tests/`; packaging rejects fixture helpers. `--voice-info` reads protocol metadata
+without initializing AppKit or requesting microphone access.
+
+`package.mjs` verifies the signature and app identity before executing metadata inspection,
+requires both slices and the supported protocol, and records SHA-256 hashes for the archive,
+executable, and plist. `VOICE_APP` and `VOICE_PACKAGE_DIR` select staging inputs/outputs.
+Archive bytes are preserved unchanged through XPI assembly. Signed artifacts contain
+signing timestamps and notarization tickets; reproduce the build recipe and retain its
+manifest/digests, rather than expecting separately signed builds to be byte-identical.
+
+The manifest retains schema, protocol/helper versions, and bundle identity as compatibility
+assertions so incompatible artifacts can be rejected before extraction or execution. The
+OS/Zotero/CPU matrix is installer policy in `native/voice/macos/contract.json`, not per-build
+manifest configuration. That contract also supplies the shared signing requirement and build
+constants; `build.sh` generates Swift protocol constants from it. A unit check keeps the
+native protocol version aligned with the portable voice contract.
+
+## Installation, upgrades, and recovery
+
+The installer uses the current Zotero profile's `beaver/voice/<archive-sha256>/` directory.
+Each profile has an independent cache. It verifies the packaged manifest, platform, archive
+size and SHA-256, then extracts into a private staging directory. It checks executable/plist
+hashes, all signature slices, the expected bundle identity, and the executable's protocol.
+Production requires the expected Developer ID team and Gatekeeper assessment. Only a
+verified staging directory is atomically moved into its immutable destination.
+
+Every launch revalidates executable/plist hashes and the complete code signature. Successful
+Gatekeeper assessment and protocol metadata checks are cached per exact artifact and path for
+the plugin lifetime; OS/CPU discovery is also cached. Directory timestamps are not treated as proof that bundle contents are unchanged.
+All native utility calls, including LaunchServices and development signature checks, drain
+both output pipes and have a 15-second kill deadline. Concurrent install requests share one promise;
+failed attempts clean staging and leave older versions intact. Plugin disposal prevents a
+late install from activating native resources. Runtime hello validation independently checks
+the IPC protocol and helper version. Capture still launches through `/usr/bin/open`, not the
+inner executable; the direct executable invocation is metadata-only.
+
+Plugin replacement revokes the active native lease synchronously. The old helper exits on
+its next control contact or its independent watchdog. A replacement plugin owns a new service,
+resets permission to unknown, and lazily installs its own artifact. Registration cannot replace
+a helper during an active native lease. Recent versions remain available for rollback;
+cleanup removes only recognized cache entries unused for seven days, far beyond a native
+lease's maximum lifetime. Reinstalling an identical XPI reuses and verifies the same directory.
+A rollback XPI selects its original digest without modifying the newer directory.
+
+A corrupt cached version triggers one fresh extraction and verification attempt. The damaged
+directory is removed only after the staged replacement passes verification; a failed repair
+never launches it. Installing a new artifact uses a different directory automatically. A changed
+artifact detected during launch refreshes the selected path and requires a fresh activation,
+including permission setup. Disabling the preference
+prevents subsequent packaged launches; plugin disable/uninstall revokes active capture.
+
+## Verification
+
+```sh
+npx vitest run tests/unit/voice
+native/voice/macos/test.sh
+python3 native/voice/macos/Tests/packaging.py
+VOICE_TESTING=1 native/voice/macos/build.sh
+python3 native/voice/macos/Tests/lifecycle.py
+# In the isolated Zotero instance: generated capture beyond the launcher timeout
+python3 native/voice/tests/zotero-native.py --long
+```
+
+The packaging test uses real codesign and ditto, round-trips through the actual XPI packer,
+checks executable and resource modes and symlinks, and rejects tampered content and ad-hoc
+production packages. CI runs native build/converter/packaging checks on `macos-15` (arm64)
+and `macos-15-intel`, uploading explicitly labeled development archives. Those jobs do not
+claim microphone or Zotero validation on a hosted runner.
+
+After installing the generated development XPI into an isolated, logged-in worktree Zotero:
+
+```sh
+# Fresh plugin, no helper registered:
+python3 native/voice/tests/zotero-process.py
+python3 native/voice/tests/zotero-packaging.py
+# Rejects deliberately corrupted/incompatible packaged XPIs, then restores the original:
+python3 native/voice/tests/zotero-invalid-packages.py
+# Creates an upgraded artifact, installs/reinstalls it, then restores the original XPI:
+python3 native/voice/tests/zotero-upgrades.py
+# Optional actual microphone: includes replacement during active capture; saves no audio:
+python3 native/voice/tests/zotero-upgrades.py --microphone
+# Real microphone PCM, normal launch and forced Intel slice (Rosetta on Apple Silicon):
+python3 native/voice/tests/zotero-packaged-capture.py
+python3 native/voice/tests/zotero-packaged-capture.py --intel
+ZOTERO_HTTP_PORT=<isolated-port> npm run test:live -- tests/live/voice.live.test.ts
+```
+
+These scripts validate the worktree metadata and operate only on its RDP port/profile.
+The packaging test corrupts the extracted test executable and verifies automatic repair, and
+creates disposable cache entries. The microphone upgrade test uses a synthetic focus owner
+in the development harness so RDP can drive it without stealing desktop focus; it does not
+validate physical focus interaction. The original XPI is restored in a `finally` block.
+No recording or transcript is persisted or sent to a provider.
+
+## Local verification record (2026-09-08)
+
+On macOS 14.7 / Apple Silicon with an isolated Zotero 10.0.1-beta.1 profile:
+
+- Full unit suite: 419 files passed, 6,947 tests passed, three existing skips. An initial
+  duplicate-detection timing assertion failed under concurrent load; its isolated rerun and
+  the full suite with four workers passed. Two additional feature-revocation race tests were
+  then added; the final voice suite passed all 184 tests.
+- Development and production builds passed typechecks, both package closure gates, and the
+  production bundle guard. Changed TypeScript files passed ESLint and formatting checks.
+- Installed production XPI: native service present, development harness absent, no listener,
+  and missing optional voice assets rejected safely.
+- Converter checks, 19 microphone-free lifecycle scenarios, real Zotero IPC, three generated
+  audio sessions, and originating-window unload passed. The three live fake-controller tests
+  passed against the explicitly selected isolated HTTP port.
+- Generated-XPI extraction, concurrent activation, cache verification, corruption/recovery,
+  old-cache cleanup, identical reinstall, upgrade, and rollback passed. Replacing the XPI
+  during real packaged capture terminated the previous helper. Four deliberately invalid
+  XPIs failed before native listener construction.
+- XPI/archive round-trip preserved modes, symlinks, bundle resources, and signatures.
+  Corruption and ad-hoc production packaging were rejected.
+- Actual packaged microphone sessions passed on arm64 and forced x86_64 through LaunchServices
+  under Rosetta, without saving or uploading audio. Native startup was 289–406 ms, first PCM
+  561–901 ms, and stop 126–156 ms in three repeated sessions. The first forced Intel session
+  started in 1,535 ms, delivered PCM in 1,827 ms, and stopped in 85 ms.
+- These quiet-room captures exercised the expected `no_speech` result. A spoken-speech quality
+  check, native Intel hardware, other target OS/Zotero combinations, and actual GitHub CI runs
+  remain unverified. Developer ID, notarization, stapling, and downloaded/offline Gatekeeper
+  validation are pending the Apple setup below.
+
+Subsequent cleanup verification passed 6,957 unit tests (three existing skips), including
+192 voice tests, with no ESLint errors. The regenerated universal helper passed archive
+round-trip and converter checks, 19 native lifecycle scenarios, live invalid-artifact and
+cache-corruption checks, and three live controller tests. An 18-second generated capture
+also completed successfully, verifying that the utility timeout does not end a healthy
+recording. The rebuilt ad-hoc helper requires renewed macOS microphone permission before
+repeating physical-microphone checks; permission results and signed distribution validation
+must not be inferred from generated capture.
+
+A further review regression run passed 6,964 unit tests (three existing skips), including
+199 voice tests, and the development build, typechecks, bundle isolation, ESLint, and changed-file
+formatting checks. In isolated Zotero, the utility runner drained 300,000 stdout characters
+alongside stderr, enforced its output bound, and killed a stalled utility at 15 seconds.
+Automatic corrupt-install repair, reinstall/upgrade/rollback, five invalid-XPI cases (including
+a malformed version), three generated captures (one lasting 18 seconds), and originating-window
+unload passed. Physical microphone and signed distribution checks remain pending as above.
+
+## Apple release setup (pending)
+
+1. Enroll the distributing person or organization in the
+   [Apple Developer Program](https://developer.apple.com/programs/enroll/).
+2. Create a **Developer ID Application** certificate, retain its private key, and export a
+   password-protected `.p12`. Keep the stable `ai.beaverapp.voice` bundle identity and team.
+3. Create a protected GitHub environment named `voice-release`. Add secrets:
+   `VOICE_CERTIFICATE_BASE64`, `VOICE_CERTIFICATE_PASSWORD`, `VOICE_SIGNING_IDENTITY`,
+   `VOICE_TEAM_ID`, `VOICE_APPLE_ID`, and an app-specific `VOICE_APP_PASSWORD` for notarytool.
+   The signing identity is the full Developer ID Application certificate name.
+4. Set repository variable `VOICE_RELEASE_ENABLED=true` only after credentials and release
+   validation are ready. Until then the ordinary release omits the helper. The runtime
+   preference stays disabled independently of this release variable.
+5. Run the signed release workflow and validate a downloaded, quarantined XPI on fresh Macs
+   across the supported matrix, including offline launch, first-use permission, upgrade,
+   rollback, and microphone release. Do not enable the product until these checks pass.
+
+The macOS release job builds the universal app, imports credentials into a temporary keychain,
+signs with hardened runtime/entitlements and a secure timestamp, submits to notarytool,
+staples and validates the ticket, assesses with Gatekeeper, then packages the finalized app.
+Only that archive is passed to the Linux XPI assembly job. A failed native release blocks
+publication; temporary keychains and certificate files are removed on exit. This workflow is
+implemented but cannot be validated without the Apple account and certificate.
+
+For local signed release preparation, configure a notarytool keychain profile, export
+`VOICE_SIGNING_IDENTITY`, `VOICE_TEAM_ID`, and `VOICE_NOTARY_PROFILE`, then run
+`bash native/voice/macos/sign-release.sh` after the build. See Apple's
+[notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow).

--- a/native/voice/README.md
+++ b/native/voice/README.md
@@ -7,16 +7,18 @@ fixtures, but have independent launch mechanisms, transports, and build tools.
 
 The helper does not contain backend credentials, transcription, billing, or editor code.
 The plugin owns those responsibilities and the active-session lock. Production voice
-activation remains disabled. Native adapters exist only in development builds. The loopback listener opens after
-a helper is verified and registered; production opens no voice port.
+activation remains disabled. Packaged native capture is available behind a disabled-by-default feature gate. The loopback
+listener opens only after an explicit activation verifies and installs a helper. See
+[packaging and release setup](../../docs/native-voice-packaging.md) for the compatibility
+matrix, generated-XPI installation, upgrades, and pending Apple release requirements.
 
 ## macOS development
 
 Requirements: macOS, Xcode command-line tools (Swift and the macOS SDK), and a development
 Zotero instance. The build uses system frameworks only, targets the build machine's
-architecture with a macOS 14.0 deployment target, and creates an ad-hoc-signed local app. This is not a distribution artifact.
-Developer ID signing, notarization, universal builds, verified extraction and upgrades are
-separate release work.
+architecture and Intel as a universal binary with a macOS 14.0 deployment target, and creates an ad-hoc-signed local app. This is not a distribution artifact.
+Universal packaging and verified extraction are implemented; Developer ID signing and
+notarization require the Apple release environment described above.
 
 ```sh
 native/voice/macos/build.sh

--- a/native/voice/macos/Sources/main.swift
+++ b/native/voice/macos/Sources/main.swift
@@ -3,9 +3,21 @@ import AVFoundation
 
 private var now: Double { ProcessInfo.processInfo.systemUptime }
 
+let args = CommandLine.arguments
+
+// Metadata inspection never initializes AppKit or requests microphone access.
+if args.count == 2 && args[1] == "--voice-info" {
+    #if VOICE_TESTING
+    let testing = true
+    #else
+    let testing = false
+    #endif
+    print(#"{"protocolVersion":\#(voiceProtocolVersion),"helperVersion":\#(voiceHelperVersion),"testing":\#(testing)}"#)
+    exit(0)
+}
+
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
-let args = CommandLine.arguments
 func argument(_ name: String) -> String? {
     guard let i = args.firstIndex(of: name), i + 1 < args.count else { return nil }
     return args[i + 1]
@@ -87,7 +99,7 @@ final class Helper {
 
     func post(_ fields: [String: Any]) -> String? {
         var envelope = fields
-        envelope["version"] = 1; envelope["sessionId"] = sessionID
+        envelope["version"] = voiceProtocolVersion; envelope["sessionId"] = sessionID
         guard let data = try? JSONSerialization.data(withJSONObject: envelope), data.count <= 6144 else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"; request.httpBody = data
@@ -97,7 +109,7 @@ final class Helper {
         guard let (data, response) = http.execute(request) else { return nil }
         if response.statusCode != 200 { return "cancel" }
         guard let reply = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              reply["version"] as? Int == 1, reply["sessionId"] as? String == sessionID,
+              reply["version"] as? Int == voiceProtocolVersion, reply["sessionId"] as? String == sessionID,
               let command = reply["command"] as? String,
               ["continue", "finish", "cancel", "exit"].contains(command) else { return nil }
         return command
@@ -125,7 +137,7 @@ final class Helper {
         }
         self.watchdog = watchdog; watchdog.resume()
         eventQueue.async { [self] in
-            guard event(["type": "hello", "helperVersion": 2, "pid": getpid()]) == "continue" else { act("cancel"); return }
+            guard event(["type": "hello", "helperVersion": voiceHelperVersion, "pid": getpid()]) == "continue" else { act("cancel"); return }
             state.touchControl()
             startControl()
             DispatchQueue.main.async { self.permission() }

--- a/native/voice/macos/Tests/packaging.py
+++ b/native/voice/macos/Tests/packaging.py
@@ -1,0 +1,73 @@
+"""Local distribution checks with real codesign, ditto, universal binaries and the XPI packer."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[4]
+CONTRACT = json.loads((ROOT / 'native/voice/macos/contract.json').read_text())
+APP = ROOT / 'native/voice/macos/build/Beaver Voice Input.app'
+def run(*args, env=None, success=True):
+    result = subprocess.run(args, text=True, capture_output=True, env=env)
+    if success and result.returncode:
+        raise AssertionError(result.stderr + result.stdout)
+    if not success:
+        assert result.returncode != 0, args
+    return result.stdout.strip()
+
+with tempfile.TemporaryDirectory(prefix='voice-package-') as tmp:
+    tmp = Path(tmp)
+    app = tmp / APP.name
+    run('/usr/bin/ditto', str(APP), str(app))
+    resources = app / 'Contents/Resources'
+    resources.mkdir(exist_ok=True)
+    (resources / 'payload').write_bytes(b'preserve contents\x00\xff')
+    (resources / 'payload').chmod(0o640)
+    (resources / 'link').symlink_to('payload')
+    run('/usr/bin/codesign', '--force', '--sign', '-', '--options', 'runtime', '--entitlements',
+        str(ROOT / 'native/voice/macos/entitlements.plist'), str(app))
+    output = tmp / 'package'
+    env = dict(os.environ, VOICE_APP=str(app), VOICE_PACKAGE_DIR=str(output))
+    run('node', str(ROOT / 'native/voice/macos/package.mjs'), '--development', env=env)
+    run('node', str(ROOT / 'native/voice/macos/package.mjs'), env=env, success=False)
+    m = json.loads((output / 'manifest.json').read_text())
+    assert hashlib.sha256((output / 'macos.zip').read_bytes()).hexdigest() == m['archiveSha256']
+    assert sorted(run('/usr/bin/lipo', '-archs', str(app / 'Contents/MacOS/BeaverVoice')).split()) == ['arm64', 'x86_64']
+    # Assemble a minimal XPI with the actual packer, then extract its opaque inner archive.
+    repo = tmp / 'repo'
+    (repo / 'scripts').mkdir(parents=True)
+    (repo / 'native/voice/macos').mkdir(parents=True)
+    shutil.copy(ROOT / 'scripts/pack-xpi.mjs', repo / 'scripts')
+    shutil.copy(ROOT / 'native/voice/macos/check-package.mjs', repo / 'native/voice/macos')
+    shutil.copy(ROOT / 'native/voice/macos/contract.json', repo / 'native/voice/macos')
+    (repo / 'package.json').write_text('{"name":"beaver"}')
+    assets = repo / '.scaffold/build/addon/content/voice'
+    shutil.copytree(output, assets)
+    run('node', str(repo / 'scripts/pack-xpi.mjs'), env=dict(os.environ, NODE_ENV='production'), success=False)
+    run('node', str(repo / 'scripts/pack-xpi.mjs'), env=dict(os.environ, NODE_ENV='development'))
+    for patch in [{'version': '1.0'}, {'version': None}, {'executableSha256': ''}, {'plistSha256': 'bad'}]:
+        (assets / 'manifest.json').write_text(json.dumps(dict(m, **patch)))
+        run('node', str(repo / 'scripts/pack-xpi.mjs'), env=dict(os.environ, NODE_ENV='development'), success=False)
+    (assets / 'manifest.json').write_text(json.dumps(m))
+    with zipfile.ZipFile(repo / '.scaffold/build/beaver.xpi') as xpi:
+        archive = tmp / 'roundtrip.zip'
+        archive.write_bytes(xpi.read('content/voice/macos.zip'))
+    assert archive.read_bytes() == (output / 'macos.zip').read_bytes()
+    unpacked = tmp / 'installed'
+    run('/usr/bin/ditto', '-x', '-k', str(archive), str(unpacked))
+    installed = unpacked / APP.name
+    run('/usr/bin/codesign', '--verify', '--strict', '--all-architectures', str(installed))
+    assert (installed / 'Contents/Resources/link').is_symlink()
+    assert (installed / 'Contents/Resources/payload').stat().st_mode & 0o777 == 0o640
+    assert (installed / 'Contents/MacOS/BeaverVoice').stat().st_mode & 0o111
+    assert json.loads(run(str(installed / 'Contents/MacOS/BeaverVoice'), '--voice-info')) == {
+        'protocolVersion': CONTRACT['protocolVersion'], 'helperVersion': CONTRACT['helperVersion'], 'testing': False}
+    (installed / 'Contents/Resources/payload').write_text('tampered')
+    run('/usr/bin/codesign', '--verify', '--strict', str(installed), success=False)
+    (assets / 'macos.zip').write_bytes(b'tampered')
+    run('node', str(repo / 'scripts/pack-xpi.mjs'), env=dict(os.environ, NODE_ENV='development'), success=False)
+    print('PASS universal archive, XPI roundtrip, executable modes, symlinks, signature and corruption rejection; production rejects ad-hoc package')

--- a/native/voice/macos/build.sh
+++ b/native/voice/macos/build.sh
@@ -7,12 +7,29 @@ else
   VOICE_BUILD_DIR="${VOICE_BUILD_DIR:-$PWD/build}"
 fi
 VOICE_APP="$VOICE_BUILD_DIR/Beaver Voice Input.app"
+rm -rf "$VOICE_APP"
 mkdir -p "$VOICE_APP/Contents/MacOS" "$VOICE_BUILD_DIR/module-cache"
 VOICE_FLAGS=(-DVOICE_PRODUCTION)
 if [[ "${VOICE_TESTING:-0}" == "1" ]]; then VOICE_FLAGS=(-DVOICE_TESTING); fi
-xcrun swiftc "${VOICE_FLAGS[@]}" -swift-version 5 -O -target "$(uname -m)-apple-macosx14.0" -module-cache-path "$VOICE_BUILD_DIR/module-cache" \
-  Sources/PCMConverter.swift Sources/VoiceHTTPClient.swift Sources/main.swift -o "$VOICE_APP/Contents/MacOS/BeaverVoice" \
-  -framework AppKit -framework AVFoundation
+# Generate native protocol constants from the same contract consumed by packaging and Zotero.
+python3 - "$VOICE_BUILD_DIR/VoiceContract.swift" <<'PYTHON'
+import json, pathlib, sys
+contract = json.loads(pathlib.Path("contract.json").read_text())
+pathlib.Path(sys.argv[1]).write_text(
+    f"let voiceProtocolVersion = {int(contract['protocolVersion'])}\n"
+    f"let voiceHelperVersion = {int(contract['helperVersion'])}\n"
+)
+PYTHON
+# Compile each slice separately; lipo retains both deployment targets.
+VOICE_SLICES=()
+for arch in arm64 x86_64; do
+  slice="$VOICE_BUILD_DIR/BeaverVoice-$arch"
+  xcrun swiftc "${VOICE_FLAGS[@]}" -swift-version 5 -O -target "$arch-apple-macosx14.0" -module-cache-path "$VOICE_BUILD_DIR/module-cache" \
+    "$VOICE_BUILD_DIR/VoiceContract.swift" Sources/PCMConverter.swift Sources/VoiceHTTPClient.swift Sources/main.swift -o "$slice" \
+    -framework AppKit -framework AVFoundation
+  VOICE_SLICES+=("$slice")
+done
+xcrun lipo -create "${VOICE_SLICES[@]}" -output "$VOICE_APP/Contents/MacOS/BeaverVoice"
 cp Info.plist "$VOICE_APP/Contents/Info.plist"
 if [[ "${VOICE_TESTING:-0}" == "1" ]]; then
   /usr/libexec/PlistBuddy -c 'Set CFBundleIdentifier ai.beaverapp.voice.tests' "$VOICE_APP/Contents/Info.plist"

--- a/native/voice/macos/check-package.mjs
+++ b/native/voice/macos/check-package.mjs
@@ -1,0 +1,41 @@
+import contract from "./contract.json" with { type: "json" };
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Check the opaque archive at the final asset boundary, before XPI assembly. */
+export function checkVoicePackage(addon, development, required = false) {
+    const dir = join(addon, "content/voice");
+    if (!existsSync(dir)) {
+        if (required) throw new Error("Required voice package missing");
+        return;
+    }
+    const m = JSON.parse(readFileSync(join(dir, "manifest.json"), "utf8"));
+    const bytes = readFileSync(join(dir, "macos.zip"));
+    if (
+        !m ||
+        typeof m.version !== "string" ||
+        !/^\d+\.\d+\.\d+$/.test(m.version) ||
+        !Number.isInteger(m.archiveBytes) ||
+        m.archiveBytes < 1 ||
+        m.archiveBytes > 32 * 1024 * 1024 ||
+        ![m.executableSha256, m.plistSha256].every(
+            (value) =>
+                typeof value === "string" && /^[a-f0-9]{64}$/.test(value),
+        ) ||
+        m.schema !== contract.schema ||
+        m.protocolVersion !== contract.protocolVersion ||
+        m.helperVersion !== contract.helperVersion ||
+        m.bundleId !== contract.bundleId ||
+        m.archiveBytes !== bytes.length ||
+        m.archiveSha256 !== createHash("sha256").update(bytes).digest("hex") ||
+        !(
+            (m.signing === "developer-id" &&
+                /^[A-Z0-9]{10}$/.test(m.teamId || "")) ||
+            (development && m.signing === "development" && m.teamId === null)
+        )
+    )
+        throw new Error(
+            "Invalid voice package or development helper in production build",
+        );
+}

--- a/native/voice/macos/ci-sign.sh
+++ b/native/voice/macos/ci-sign.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Secrets are scoped to the protected voice-release environment; never enable shell tracing.
+set -euo pipefail
+: "${VOICE_CERTIFICATE_BASE64:?}"
+: "${VOICE_CERTIFICATE_PASSWORD:?}"
+: "${VOICE_APPLE_ID:?}"
+: "${VOICE_APP_PASSWORD:?}"
+: "${VOICE_TEAM_ID:?}"
+VOICE_TEMP="$(mktemp -d)"
+export VOICE_KEYCHAIN="$VOICE_TEMP/voice.keychain-db"
+VOICE_KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+trap 'security delete-keychain "$VOICE_KEYCHAIN" >/dev/null 2>&1 || true; rm -rf "$VOICE_TEMP"' EXIT
+printf '%s' "$VOICE_CERTIFICATE_BASE64" | base64 --decode > "$VOICE_TEMP/identity.p12"
+security create-keychain -p "$VOICE_KEYCHAIN_PASSWORD" "$VOICE_KEYCHAIN"
+security set-keychain-settings -lut 21600 "$VOICE_KEYCHAIN"
+security unlock-keychain -p "$VOICE_KEYCHAIN_PASSWORD" "$VOICE_KEYCHAIN"
+security import "$VOICE_TEMP/identity.p12" -k "$VOICE_KEYCHAIN" -P "$VOICE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign >/dev/null
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$VOICE_KEYCHAIN_PASSWORD" "$VOICE_KEYCHAIN" >/dev/null
+security list-keychains -d user -s "$VOICE_KEYCHAIN" login.keychain-db
+export VOICE_NOTARY_PROFILE=beaver-voice-release
+xcrun notarytool store-credentials "$VOICE_NOTARY_PROFILE" --keychain "$VOICE_KEYCHAIN" --apple-id "$VOICE_APPLE_ID" --team-id "$VOICE_TEAM_ID" --password "$VOICE_APP_PASSWORD" >/dev/null
+# Pass the temporary keychain explicitly to the notarization client.
+bash native/voice/macos/sign-release.sh

--- a/native/voice/macos/contract.json
+++ b/native/voice/macos/contract.json
@@ -1,0 +1,11 @@
+{
+    "schema": 1,
+    "protocolVersion": 1,
+    "helperVersion": 2,
+    "bundleId": "ai.beaverapp.voice",
+    "minMacOS": 14,
+    "architectures": ["arm64", "x86_64"],
+    "zoteroMajors": [7, 8, 9, 10],
+    "identityRequirement": "=identifier \"ai.beaverapp.voice\"",
+    "developerIdRequirement": " and anchor apple generic and certificate leaf[subject.OU] = \"{teamId}\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+}

--- a/native/voice/macos/package.mjs
+++ b/native/voice/macos/package.mjs
@@ -1,0 +1,101 @@
+import contract from "./contract.json" with { type: "json" };
+import process from "node:process";
+import console from "node:console";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const development = process.argv.includes("--development");
+const app = resolve(
+    process.env.VOICE_APP ||
+        `${root}/native/voice/macos/build/Beaver Voice Input.app`,
+);
+const output = resolve(
+    process.env.VOICE_PACKAGE_DIR || `${root}/addon/content/voice`,
+);
+const run = (command, args) =>
+    execFileSync(command, args, { encoding: "utf8" }).trim();
+const hash = (path) =>
+    createHash("sha256").update(readFileSync(path)).digest("hex");
+const binary = `${app}/Contents/MacOS/BeaverVoice`;
+const architectures = run("/usr/bin/lipo", ["-archs", binary])
+    .split(/\s+/)
+    .sort();
+if (architectures.join(",") !== contract.architectures.join(","))
+    throw new Error("Universal helper required");
+const bundleId = run("/usr/libexec/PlistBuddy", [
+    "-c",
+    "Print CFBundleIdentifier",
+    `${app}/Contents/Info.plist`,
+]);
+if (bundleId !== contract.bundleId)
+    throw new Error("Unexpected helper identity");
+const version = run("/usr/libexec/PlistBuddy", [
+    "-c",
+    "Print CFBundleShortVersionString",
+    `${app}/Contents/Info.plist`,
+]);
+if (!/^\d+\.\d+\.\d+$/.test(version))
+    throw new Error("Expected a three-part helper version");
+const teamId = development ? null : process.env.VOICE_TEAM_ID;
+if (!development && !/^[A-Z0-9]{10}$/.test(teamId || ""))
+    throw new Error("VOICE_TEAM_ID required");
+const requirement =
+    contract.identityRequirement +
+    (development
+        ? ""
+        : contract.developerIdRequirement.replace("{teamId}", teamId));
+run("/usr/bin/codesign", [
+    "--verify",
+    "--strict",
+    "--all-architectures",
+    "-R",
+    requirement,
+    app,
+]);
+if (!development) {
+    run("/usr/bin/xcrun", ["stapler", "validate", app]);
+    run("/usr/sbin/spctl", ["--assess", "--type", "execute", app]);
+}
+const info = JSON.parse(run(binary, ["--voice-info"]));
+if (
+    info.protocolVersion !== contract.protocolVersion ||
+    info.helperVersion !== contract.helperVersion ||
+    info.testing !== false
+)
+    throw new Error("Only the compatible production helper can be packaged");
+mkdirSync(output, { recursive: true });
+const archive = `${output}/macos.zip`;
+rmSync(archive, { force: true });
+// The inner archive is opaque to the XPI packer: ditto preserves modes and symlinks.
+run("/usr/bin/ditto", [
+    "-c",
+    "-k",
+    "--sequesterRsrc",
+    "--keepParent",
+    app,
+    archive,
+]);
+const manifest = {
+    schema: contract.schema,
+    protocolVersion: contract.protocolVersion,
+    helperVersion: contract.helperVersion,
+    bundleId,
+    version,
+    signing: development ? "development" : "developer-id",
+    teamId,
+    archiveSha256: hash(archive),
+    archiveBytes: readFileSync(archive).length,
+    executableSha256: hash(binary),
+    plistSha256: hash(`${app}/Contents/Info.plist`),
+};
+writeFileSync(
+    `${output}/manifest.json`,
+    JSON.stringify(manifest, null, 2) + "\n",
+);
+console.log(
+    `Packaged ${manifest.signing} universal voice helper: ${manifest.archiveSha256}`,
+);

--- a/native/voice/macos/sign-release.sh
+++ b/native/voice/macos/sign-release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run only in the configured macOS release environment, before package.mjs.
+set -euo pipefail
+cd "$(dirname "$0")"
+: "${VOICE_SIGNING_IDENTITY:?Developer ID Application identity required}"
+: "${VOICE_NOTARY_PROFILE:?notarytool keychain profile required}"
+VOICE_APP="${VOICE_APP:-$PWD/build/Beaver Voice Input.app}"
+codesign --force --sign "$VOICE_SIGNING_IDENTITY" --timestamp --options runtime --entitlements entitlements.plist "$VOICE_APP"
+codesign --verify --strict --all-architectures "$VOICE_APP"
+VOICE_SUBMISSION="$(mktemp -d)"
+trap 'rm -rf "$VOICE_SUBMISSION"' EXIT
+ditto -c -k --sequesterRsrc --keepParent "$VOICE_APP" "$VOICE_SUBMISSION/voice.zip"
+VOICE_NOTARY_ARGS=()
+if [[ -n "${VOICE_KEYCHAIN:-}" ]]; then VOICE_NOTARY_ARGS=(--keychain "$VOICE_KEYCHAIN"); fi
+xcrun notarytool submit "$VOICE_SUBMISSION/voice.zip" --keychain-profile "$VOICE_NOTARY_PROFILE" "${VOICE_NOTARY_ARGS[@]}" --wait
+xcrun stapler staple "$VOICE_APP"
+xcrun stapler validate "$VOICE_APP"
+node package.mjs

--- a/native/voice/tests/zotero-invalid-packages.py
+++ b/native/voice/tests/zotero-invalid-packages.py
@@ -1,0 +1,50 @@
+"""Install deliberately invalid test XPIs; verify rejection before opening native resources."""
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import zipfile
+
+ROOT = Path.cwd()
+META = json.loads((ROOT / '.worktree-meta.json').read_text())
+assert Path(META['worktree']).resolve() == ROOT.resolve()
+assert 'beaver-dev-' in Path(META['profile']).name
+XPI = ROOT / '.scaffold/build/beaver.xpi'
+
+def call(tool, args):
+    return subprocess.run(['node', 'scripts/worktree/zotero-rdp-exec.mjs', str(META['rdpPort']),
+        tool, json.dumps(args)], capture_output=True, text=True, check=True).stdout
+
+def install(path):
+    call('zotero_plugin_install', {'path': str(path)})
+    time.sleep(1)
+
+with tempfile.TemporaryDirectory(prefix='voice-invalid-xpi-') as tmp:
+    try:
+        for name, patch in [
+            ('invalid-version', {'version': '1.0'}),
+            ('incompatible-protocol', {'protocolVersion': 2}),
+            ('incompatible-helper', {'helperVersion': 999}),
+            ('invalid-archive', {'archiveSha256': 'f' * 64}),
+            ('untrusted-signer', {'signing': 'unsigned'}),
+        ]:
+            target = Path(tmp) / (name + '.xpi')
+            with zipfile.ZipFile(XPI) as source, zipfile.ZipFile(target, 'w', zipfile.ZIP_DEFLATED) as dest:
+                for entry in source.infolist():
+                    data = source.read(entry.filename)
+                    if entry.filename == 'content/voice/manifest.json':
+                        m = json.loads(data); m.update(patch); data = json.dumps(m).encode()
+                    dest.writestr(entry, data)
+            install(target)
+            report = json.loads(call('zotero_execute_js', {'code': '''
+const n=Zotero.Beaver.voiceNative;
+Zotero.Prefs.set('extensions.zotero.beaver.voice.nativeEnabled', true, true);
+let rejected=false;
+try { await n.ensurePackagedHelper(); } catch { rejected=true; }
+return JSON.stringify({rejected, available:n.available, socket:!!n.socket});
+'''}).split('Result:\n', 1)[1].strip())
+            assert report == {'rejected': True, 'available': False, 'socket': False}, report
+            print('PASS invalid XPI rejected before native listener:', name, flush=True)
+    finally:
+        install(XPI)

--- a/native/voice/tests/zotero-native.py
+++ b/native/voice/tests/zotero-native.py
@@ -24,14 +24,14 @@ if (Zotero.Beaver.voiceNative.permission === 'unknown') {
 const reports=[];
 for (let i=0;i<3;i++) {
     const started=await h.startNative(owner);
-    await wait(1600);
+    await wait(i === 0 && LONG_CAPTURE ? 18000 : 1600);
     const active=h.nativeState();
     h.service.controller.finish(started.sessionId);
     await wait(1200);
     reports.push({active,done:h.nativeState()});
 }
 return JSON.stringify(reports);
-'''.replace('APP_PATH',json.dumps(app)))
+'''.replace('APP_PATH',json.dumps(app)).replace('LONG_CAPTURE', 'true' if '--long' in sys.argv else 'false'))
 for i,report in enumerate(result):
     assert report['active']['state']['phase']=='listening',report
     assert report['active']['state']['frameCount']>5,report

--- a/native/voice/tests/zotero-packaged-capture.py
+++ b/native/voice/tests/zotero-packaged-capture.py
@@ -1,0 +1,53 @@
+"""Opt-in real microphone smoke test for the packaged app; never saves or uploads audio."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path.cwd()
+META = json.loads((ROOT / '.worktree-meta.json').read_text())
+assert Path(META['worktree']).resolve() == ROOT.resolve()
+assert 'beaver-dev-' in Path(META['profile']).name
+
+def rdp(code):
+    p = subprocess.run(['node', 'scripts/worktree/zotero-rdp-exec.mjs', str(META['rdpPort']),
+        'zotero_execute_js', json.dumps({'code': code})], capture_output=True, text=True, check=True)
+    if 'Result:\n' not in p.stdout:
+        raise AssertionError(p.stdout)
+    return json.loads(p.stdout.split('Result:\n', 1)[1].strip())
+
+setup = rdp('''
+const n=Zotero.Beaver.voiceNative;
+Zotero.Prefs.set('extensions.zotero.beaver.voice.nativeEnabled',true,true);
+await n.ensurePackagedHelper();
+if(!n.packaged) throw new Error('Reload plugin to clear development helper registration');
+if(n.permission==='unknown') await Zotero.Beaver.voiceHarness.startNative(Zotero.getMainWindow());
+return JSON.stringify({permission:n.permission});
+''')
+assert setup['permission'] == 'granted', 'Grant permission in the isolated instance before capture'
+code = '''(async () => {
+const n=Zotero.Beaver.voiceNative, h=Zotero.Beaver.voiceHarness;
+const original=n.capture.host.launch;
+if(FORCE_INTEL) n.capture.host.launch=async(port,token,sessionId,permissionOnly)=>{
+ const {Subprocess}=ChromeUtils.importESModule('resource://gre/modules/Subprocess.sys.mjs');
+ const child=await Subprocess.call({command:'/usr/bin/open',arguments:['-n','-g','--arch','x86_64',n.helperPath,'--args','--port',String(port),'--token',token,'--session',sessionId,...(permissionOnly?['--permission-only']:[])]});
+ if((await child.wait()).exitCode!==0)throw new Error('Intel launch failed');
+};
+const owner={closed:false,document:{hasFocus:()=>true},addEventListener:()=>{},removeEventListener:()=>{}};
+const t=ChromeUtils.importESModule('resource://gre/modules/Timer.sys.mjs');
+const wait=ms=>new Promise(r=>t.setTimeout(r,ms));
+try {
+ const started=await h.startNative(owner);await wait(2200);
+ const active=h.nativeState();h.service.controller.finish(started.sessionId);await wait(1200);
+ return JSON.stringify({active,done:h.nativeState()});
+} finally {
+ n.capture.host.launch=original;
+ h.service.controller.cancel(h.service.controller.getSnapshot().sessionId);
+}
+})()'''.replace('FORCE_INTEL', 'true' if '--intel' in sys.argv else 'false')
+report = rdp(code)
+assert report['active']['state']['phase'] == 'listening' and report['active']['state']['frameCount'] > 0, report
+final = report['done']['state']
+assert final['phase'] == 'completed' or final['phase'] == 'error' and final['error']['code'] == 'no_speech', report
+assert report['done']['retainedBytes'] == 0, report
+print('PASS packaged microphone PCM and clean stop', 'Intel/Rosetta' if '--intel' in sys.argv else 'native', json.dumps(report['done']['metrics']))

--- a/native/voice/tests/zotero-packaging.py
+++ b/native/voice/tests/zotero-packaging.py
@@ -1,0 +1,55 @@
+"""Verify packaged installation in the isolated worktree; no microphone is opened."""
+import json
+from pathlib import Path
+import subprocess
+
+ROOT = Path.cwd()
+META = json.loads((ROOT / '.worktree-meta.json').read_text())
+assert Path(META['worktree']).resolve() == ROOT.resolve()
+assert 'beaver-dev-' in Path(META['profile']).name
+
+def rdp(code):
+    code = '(async()=>{try{' + code + '}catch(error){return JSON.stringify({testError:String(error)});}})()'
+    result = subprocess.run(['node', 'scripts/worktree/zotero-rdp-exec.mjs', str(META['rdpPort']),
+        'zotero_execute_js', json.dumps({'code': code})], capture_output=True, text=True, check=True)
+    report = json.loads(result.stdout.split('Result:\n', 1)[1].strip())
+    assert 'testError' not in report, report
+    return report
+
+report = rdp('''
+const n = Zotero.Beaver.voiceNative;
+if (!n || n.available || n.socket) throw new Error('Reload the plugin before this test');
+Zotero.Prefs.set('extensions.zotero.beaver.voice.nativeEnabled', false, true);
+let disabled = false;
+try { await n.ensurePackagedHelper(); } catch { disabled = true; }
+if (!disabled || n.socket) throw new Error('Feature gate failed');
+Zotero.Prefs.set('extensions.zotero.beaver.voice.nativeEnabled', true, true);
+await Promise.all([n.ensurePackagedHelper(), n.ensurePackagedHelper()]);
+const path = n.helperPath;
+const root = PathUtils.parent(path);
+const executable = PathUtils.join(path, 'Contents', 'MacOS', 'BeaverVoice');
+const expected = await IOUtils.computeHexDigest(executable, 'sha256');
+await n.installer.ensure();
+const samePath = n.helperPath === path;
+await IOUtils.write(executable, new Uint8Array([0,1,2]));
+await n.installer.ensure();
+const corruptRepaired = expected === await IOUtils.computeHexDigest(executable, 'sha256');
+const old = PathUtils.join(PathUtils.parent(root), 'd'.repeat(64));
+const recent = PathUtils.join(PathUtils.parent(root), 'e'.repeat(64));
+await IOUtils.makeDirectory(old, {ignoreExisting: true});
+await IOUtils.writeUTF8(PathUtils.join(old, 'last-used'), String(Date.now() - 8 * 86400000));
+await IOUtils.makeDirectory(recent, {ignoreExisting: true});
+await IOUtils.writeUTF8(PathUtils.join(recent, 'last-used'), String(Date.now()));
+await n.installer.ensure();
+const oldRemoved = !await IOUtils.exists(old), recentKept = await IOUtils.exists(recent);
+await IOUtils.remove(recent, {recursive: true});
+return JSON.stringify({path, samePath, corruptRepaired, oldRemoved, recentKept,
+    restored: expected === await IOUtils.computeHexDigest(executable, 'sha256'),
+    permission: n.permission, busy: n.capture.busy, profile: Zotero.Profile.dir});
+''')
+assert Path(report['profile']).resolve() == Path(META['profile']).resolve(), report
+assert all(report[k] for k in ['samePath', 'corruptRepaired', 'oldRemoved', 'recentKept', 'restored']), report
+assert report['permission'] == 'unknown' and not report['busy'], report
+assert str(Path(META['profile']) / 'beaver/voice') in report['path'], report
+print('PASS lazy packaged install, concurrent activation, cached verification, automatic corruption recovery, safe cleanup; no permission request or capture')
+print(json.dumps(report))

--- a/native/voice/tests/zotero-process.py
+++ b/native/voice/tests/zotero-process.py
@@ -1,0 +1,31 @@
+"""Exercise the actual utility runner against Zotero's chunked subprocess pipes."""
+import json
+from pathlib import Path
+import subprocess
+
+ROOT = Path.cwd()
+META = json.loads((ROOT / '.worktree-meta.json').read_text())
+assert Path(META['worktree']).resolve() == ROOT.resolve()
+assert 'beaver-dev-' in Path(META['profile']).name
+compiled = subprocess.run(['node', '-e', "const ts=require('typescript'); const fs=require('fs'); process.stdout.write(ts.transpileModule(fs.readFileSync('src/services/voice/voiceProcess.ts','utf8'), {compilerOptions:{target:ts.ScriptTarget.ES2022,module:ts.ModuleKind.CommonJS}}).outputText)"], capture_output=True, text=True, check=True).stdout
+code = "(async()=>{try{const exports={};" + compiled + """
+if (Zotero.Profile.dir !== PROFILE) throw new Error('Wrong profile');
+const run = exports.runVoiceProcess;
+const result = await run('/usr/bin/awk', ['BEGIN {for(i=0;i<30000;i++){printf "abcdefghij"; printf "diagnostic" > "/dev/stderr"}}']);
+if (result !== 'abcdefghij'.repeat(30000)) throw new Error('Truncated output');
+let bounded = false;
+try { await run('/usr/bin/awk', ['BEGIN {for(i=0;i<120000;i++)printf "abcdefghij"}']); }
+catch(error) { bounded = error.message === 'Voice helper output exceeded limit'; }
+if (!bounded) throw new Error('Output bound failed');
+const start = Date.now();
+let timedOut = false;
+try { await run('/bin/sleep', ['30']); }
+catch(error) { timedOut = error.message === 'Voice helper process failed'; }
+if (!timedOut || Date.now()-start > 20000) throw new Error('Deadline failed');
+return JSON.stringify({passed:true, bytes:result.length, elapsed:Date.now()-start});
+}catch(error){return JSON.stringify({error:String(error)});}})()
+""".replace('PROFILE', json.dumps(META['profile']))
+result = subprocess.run(['node', 'scripts/worktree/zotero-rdp-exec.mjs', str(META['rdpPort']), 'zotero_execute_js', json.dumps({'code':code})], capture_output=True, text=True, check=True)
+report = json.loads(result.stdout.split('Result:\n', 1)[1].strip())
+assert report.get('passed'), report
+print('PASS real chunked stdout/stderr, bounded output, utility deadline', json.dumps(report))

--- a/native/voice/tests/zotero-upgrades.py
+++ b/native/voice/tests/zotero-upgrades.py
@@ -1,0 +1,104 @@
+"""Reinstall/upgrade/rollback generated XPIs in the isolated worktree. Optional real microphone."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+
+ROOT = Path.cwd()
+META = json.loads((ROOT / '.worktree-meta.json').read_text())
+assert Path(META['worktree']).resolve() == ROOT.resolve()
+assert 'beaver-dev-' in Path(META['profile']).name
+XPI = ROOT / '.scaffold/build/beaver.xpi'
+
+def run(*args, env=None):
+    p = subprocess.run(args, capture_output=True, text=True, check=True, env=env)
+    return p.stdout
+
+def call(tool, args):
+    return run('node', 'scripts/worktree/zotero-rdp-exec.mjs', str(META['rdpPort']), tool, json.dumps(args))
+
+def rdp(code):
+    code = '(async()=>{try{' + code + '}catch(error){return JSON.stringify({testError:String(error)});}})()'
+    report = json.loads(call('zotero_execute_js', {'code': code}).split('Result:\n', 1)[1].strip())
+    assert 'testError' not in report, report
+    return report
+
+def install(path):
+    call('zotero_plugin_install', {'path': str(path)})
+    time.sleep(1)
+
+def initialize():
+    return rdp('''
+const n=Zotero.Beaver.voiceNative;
+if(n.available || n.socket) throw new Error('Replacement must be lazy');
+Zotero.Prefs.set('extensions.zotero.beaver.voice.nativeEnabled',true,true);
+await n.ensurePackagedHelper();
+return JSON.stringify({path:n.helperPath, permission:n.permission});
+''')
+
+def start_microphone():
+    report = rdp('''
+const h=Zotero.Beaver.voiceHarness;
+const owner={closed:false,document:{hasFocus:()=>true},addEventListener:()=>{},removeEventListener:()=>{}};
+if(Zotero.Beaver.voiceNative.permission==='unknown') {
+ const setup=await h.startNative(Zotero.getMainWindow());
+ if(setup.permission!=='granted') throw new Error('Grant permission before microphone upgrade testing');
+}
+const start=await h.startNative(owner);
+const timer=ChromeUtils.importESModule('resource://gre/modules/Timer.sys.mjs');
+await new Promise(r=>timer.setTimeout(r,1200));
+return JSON.stringify(h.service.controller.getSnapshot());
+''')
+    assert report['phase'] == 'listening' and report['frameCount'] > 0, report
+    pids = run('pgrep', '-f', 'BeaverVoice.*' + report['sessionId']).split()
+    assert len(pids) == 1, pids
+    return int(pids[0])
+
+def check_exit(pid):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try: os.kill(pid, 0)
+        except ProcessLookupError: return
+        time.sleep(.05)
+    raise AssertionError('Old helper survived plugin replacement')
+
+with tempfile.TemporaryDirectory(prefix='voice-upgrade-') as tmp:
+    tmp = Path(tmp)
+    app = tmp / 'Beaver Voice Input.app'
+    run('/usr/bin/ditto', str(ROOT / 'native/voice/macos/build/Beaver Voice Input.app'), str(app))
+    run('/usr/libexec/PlistBuddy', '-c', 'Set CFBundleShortVersionString 0.1.1', str(app / 'Contents/Info.plist'))
+    run('/usr/bin/codesign', '--force', '--sign', '-', '--options', 'runtime', '--entitlements',
+        str(ROOT / 'native/voice/macos/entitlements.plist'), str(app))
+    package = tmp / 'package'
+    run('node', 'native/voice/macos/package.mjs', '--development',
+        env=dict(os.environ, VOICE_APP=str(app), VOICE_PACKAGE_DIR=str(package)))
+    upgraded = tmp / 'upgrade.xpi'
+    with zipfile.ZipFile(XPI) as source, zipfile.ZipFile(upgraded, 'w', zipfile.ZIP_DEFLATED) as target:
+        for entry in source.infolist():
+            data = source.read(entry.filename)
+            if entry.filename in ['content/voice/manifest.json', 'content/voice/macos.zip']:
+                data = (package / Path(entry.filename).name).read_bytes()
+            target.writestr(entry, data)
+    try:
+        install(XPI)
+        first = initialize()
+        install(XPI)
+        again = initialize()
+        assert first['path'] == again['path'] and again['permission'] == 'unknown'
+        helper = start_microphone() if '--microphone' in sys.argv else None
+        install(upgraded)
+        if helper: check_exit(helper)
+        newer = initialize()
+        assert newer['path'] != first['path'] and newer['permission'] == 'unknown'
+        assert Path(first['path']).exists() and Path(newer['path']).exists()
+        print('PASS identical reinstall, immutable upgraded version, permission reset, retained rollback version', flush=True)
+        if helper: print('PASS XPI replacement revokes active packaged microphone helper', flush=True)
+    finally:
+        install(XPI)
+    rolled_back = initialize()
+    assert rolled_back['path'] == first['path']
+    print('PASS rollback to original packaged XPI without manual helper placement', flush=True)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "scripts": {
         "start": "npm run copy:agent-ui-css && concurrently \"zotero-plugin serve\" \"npm run watch-react\"",
         "build": "npm run copy:agent-ui-css && NODE_ENV=production npm run build-react:prod && NODE_ENV=production zotero-plugin build && tsc --noEmit && npm run typecheck:core && npm run typecheck:ui && npm run check:bundle",
-        "build:dev": "npm run copy:agent-ui-css && NODE_ENV=development npm run build-react:dev && NODE_ENV=development zotero-plugin build --dev && npm run pack:xpi && tsc --noEmit && npm run typecheck:core && npm run typecheck:ui && npm run check:bundle",
+        "build:dev": "npm run copy:agent-ui-css && NODE_ENV=development npm run build-react:dev && NODE_ENV=development zotero-plugin build --dev && NODE_ENV=development npm run pack:xpi && tsc --noEmit && npm run typecheck:core && npm run typecheck:ui && npm run check:bundle",
         "build:staging": "npm run copy:agent-ui-css && BUILD_ENV=staging npm run build-react:staging && BUILD_ENV=staging zotero-plugin build && tsc --noEmit && npm run typecheck:core && npm run typecheck:ui && npm run check:bundle",
         "check:bundle": "node scripts/check-esbuild-graph.mjs",
         "lint:check": "prettier --check . && eslint .",
@@ -41,6 +41,8 @@
         "build-react:prod": "webpack --config webpack.config.js --mode=production",
         "build-react:staging": "BUILD_ENV=staging webpack --config webpack.config.js --mode=production",
         "watch-react": "webpack --config webpack.config.js --watch",
+        "voice:build": "native/voice/macos/build.sh",
+        "voice:package:dev": "node native/voice/macos/package.mjs --development",
         "pack:xpi": "node scripts/pack-xpi.mjs",
         "copy:agent-ui-css": "node scripts/copy-agent-ui-css.mjs",
         "beaver-extract": "tsx src/beaver-extract/cli/main.ts",

--- a/scripts/check-esbuild-graph.mjs
+++ b/scripts/check-esbuild-graph.mjs
@@ -78,12 +78,14 @@ const PRODUCTION_VOICE_INPUTS = [
     'packages/agent-core/src/voice/contracts.ts',
     'packages/agent-core/src/voice/controller.ts',
     'src/services/voice/voiceService.ts',
-];
-const DEVELOPMENT_VOICE_INPUTS = [
+    'src/services/voice/helperInstaller.ts',
+    'src/services/voice/voiceProcess.ts',
     'src/services/voice/nativeVoice.ts',
     'src/services/voice/macCapture.ts',
     'src/services/voice/voiceHttp.ts',
     'src/services/voice/voiceSocket.ts',
+];
+const DEVELOPMENT_VOICE_INPUTS = [
     'src/services/voice/nativeCaptureHarness.ts',
     'packages/agent-core/src/voice/fakes.ts',
     'src/services/voice/developmentHarness.ts',

--- a/scripts/pack-xpi.mjs
+++ b/scripts/pack-xpi.mjs
@@ -2,6 +2,7 @@ import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deflateRawSync } from "node:zlib";
+import { checkVoicePackage } from "../native/voice/macos/check-package.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const pkg = JSON.parse(await readFile(join(repoRoot, "package.json"), "utf8"));
@@ -109,6 +110,7 @@ async function collectFiles(dir) {
 }
 
 async function pack() {
+    checkVoicePackage(addonDir, process.env.NODE_ENV === "development", process.env.VOICE_PACKAGE_REQUIRED === "1");
     const addonStats = await stat(addonDir).catch(() => null);
     if (!addonStats?.isDirectory()) {
         throw new Error(`Cannot find scaffold addon directory: ${addonDir}`);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -294,8 +294,8 @@ async function onStartup() {
 
         // Voice is optional: its initialization must not prevent the rest of Beaver loading.
         try {
+            if (Zotero.isMac) addon.voiceNative = new NativeVoice();
             if (__env__ === 'development') {
-                if (Zotero.isMac) addon.voiceNative = new NativeVoice();
                 addon.voiceHarness = new DevelopmentVoiceHarness(undefined, addon.voiceNative);
                 addon.voice = addon.voiceHarness.service;
             } else {

--- a/src/services/voice/helperInstaller.ts
+++ b/src/services/voice/helperInstaller.ts
@@ -1,0 +1,261 @@
+import contract from "../../../native/voice/macos/contract.json";
+import { runVoiceProcess as run } from "./voiceProcess";
+
+/** Build identity and asserted protocol compatibility; platform policy lives in contract.json. */
+export interface HelperManifest extends Pick<
+    typeof contract,
+    "schema" | "protocolVersion" | "helperVersion" | "bundleId"
+> {
+    version: string;
+    signing: "development" | "developer-id";
+    teamId: string | null;
+    archiveSha256: string;
+    archiveBytes: number;
+    executableSha256: string;
+    plistSha256: string;
+}
+
+export function validateHelperManifest(
+    value: unknown,
+    development: boolean,
+): HelperManifest {
+    const m = value as HelperManifest;
+    const digest = (s: unknown) =>
+        typeof s === "string" && /^[a-f0-9]{64}$/.test(s);
+    if (
+        !m ||
+        m.schema !== contract.schema ||
+        m.protocolVersion !== contract.protocolVersion ||
+        m.helperVersion !== contract.helperVersion ||
+        m.bundleId !== contract.bundleId ||
+        typeof m.version !== "string" ||
+        !/^\d+\.\d+\.\d+$/.test(m.version) ||
+        !Number.isInteger(m.archiveBytes) ||
+        m.archiveBytes < 1 ||
+        m.archiveBytes > 32 * 1024 * 1024 ||
+        !digest(m.archiveSha256) ||
+        !digest(m.executableSha256) ||
+        !digest(m.plistSha256) ||
+        !(
+            (m.signing === "developer-id" &&
+                /^[A-Z0-9]{10}$/.test(m.teamId ?? "")) ||
+            (development && m.signing === "development" && m.teamId === null)
+        )
+    ) {
+        throw new Error("Incompatible or untrusted voice helper manifest");
+    }
+    return m;
+}
+
+export interface HelperInstallerHost {
+    manifest(): Promise<unknown>;
+    checkPlatform(): Promise<void>;
+    exists(path: string): Promise<boolean>;
+    stage(path: string, manifest: HelperManifest): Promise<void>;
+    verify(path: string, manifest: HelperManifest): Promise<void>;
+    move(from: string, to: string): Promise<void>;
+    remove(path: string): Promise<void>;
+    touch(path: string): Promise<void>;
+    cleanup(current: string): Promise<void>;
+    unique(): string;
+}
+
+/** Publishes only verified, immutable versions. Failed installs leave previous versions intact. */
+export class HelperInstaller {
+    private pending?: Promise<string>;
+    private disposed = false;
+    constructor(
+        private readonly host: HelperInstallerHost,
+        private readonly root: string,
+        private readonly development: boolean,
+    ) {}
+
+    ensure(): Promise<string> {
+        if (this.disposed)
+            return Promise.reject(new Error("Voice installer disposed"));
+        if (this.pending) return this.pending;
+        this.pending = this.install().finally(() => {
+            this.pending = undefined;
+        });
+        return this.pending;
+    }
+    dispose() {
+        this.disposed = true;
+    }
+    private check() {
+        if (this.disposed) throw new Error("Voice installer disposed");
+    }
+    private async install(): Promise<string> {
+        const m = validateHelperManifest(
+            await this.host.manifest(),
+            this.development,
+        );
+        await this.host.checkPlatform();
+        this.check();
+        const destination = `${this.root}/${m.archiveSha256}`;
+        const exists = await this.host.exists(destination);
+        let valid = false;
+        if (exists) {
+            try {
+                await this.host.verify(destination, m);
+                valid = true;
+            } catch {
+                this.check();
+            }
+        }
+        if (!valid) {
+            const staging = `${this.root}/staging-${this.host.unique()}`;
+            try {
+                await this.host.stage(staging, m);
+                this.check();
+                await this.host.verify(staging, m);
+                this.check();
+                // Keep the damaged install until its replacement has passed every check.
+                if (exists) await this.host.remove(destination);
+                await this.host.move(staging, destination);
+            } finally {
+                await this.host.remove(staging);
+            }
+        }
+        this.check();
+        await this.host.touch(destination);
+        // Cleanup failure must not prevent use of an otherwise valid installation.
+        await this.host.cleanup(destination).catch(() => {});
+        this.check();
+        return `${destination}/Beaver Voice Input.app`;
+    }
+}
+
+export function createPackagedHelperInstaller(): HelperInstaller {
+    const root = PathUtils.join(Zotero.Profile.dir, "beaver", "voice");
+    const asset = "chrome://beaver/content/voice/";
+    let platform: Promise<void> | undefined;
+    const assessed = new Set<string>();
+    const host: HelperInstallerHost = {
+        async manifest() {
+            const response = await fetch(`${asset}manifest.json`);
+            if (!response.ok) throw new Error("Packaged voice helper missing");
+            return response.json();
+        },
+        checkPlatform() {
+            // OS/CPU and Zotero version are constant for this plugin lifetime.
+            return (platform ??= (async () => {
+                const [os, arch] = await Promise.all([
+                    run("/usr/bin/sw_vers", ["-productVersion"]),
+                    run("/usr/bin/uname", ["-m"]),
+                ]);
+                if (
+                    !Zotero.isMac ||
+                    Number(os.split(".")[0]) < contract.minMacOS ||
+                    !contract.architectures.includes(arch) ||
+                    !contract.zoteroMajors.includes(parseInt(Zotero.version))
+                )
+                    throw new Error(
+                        "Voice capture is unsupported on this system",
+                    );
+            })().catch((error) => {
+                platform = undefined;
+                throw error;
+            }));
+        },
+        exists: (path) => IOUtils.exists(path),
+        async stage(path, m) {
+            await IOUtils.makeDirectory(path, {
+                permissions: 0o700,
+                createAncestors: true,
+            });
+            const archive = `${path}/helper.zip`;
+            const response = await fetch(`${asset}macos.zip`);
+            if (!response.ok) throw new Error("Packaged voice helper missing");
+            const bytes = new Uint8Array(await response.arrayBuffer());
+            if (bytes.length !== m.archiveBytes)
+                throw new Error("Invalid voice archive size");
+            await IOUtils.write(archive, bytes, { mode: "create" });
+            if (
+                (await IOUtils.computeHexDigest(archive, "sha256")) !==
+                m.archiveSha256
+            )
+                throw new Error("Invalid voice archive digest");
+            // Only the authenticated archive is passed to ditto, retaining bundle modes and links.
+            await run("/usr/bin/ditto", ["-x", "-k", archive, path]);
+            await IOUtils.remove(archive);
+        },
+        async verify(path, m) {
+            const app = `${path}/Beaver Voice Input.app`;
+            const executable = `${app}/Contents/MacOS/BeaverVoice`;
+            if (
+                (await IOUtils.computeHexDigest(executable, "sha256")) !==
+                    m.executableSha256 ||
+                (await IOUtils.computeHexDigest(
+                    `${app}/Contents/Info.plist`,
+                    "sha256",
+                )) !== m.plistSha256
+            )
+                throw new Error("Invalid installed voice helper digest");
+            const requirement =
+                contract.identityRequirement +
+                (m.signing === "developer-id"
+                    ? contract.developerIdRequirement.replace(
+                          "{teamId}",
+                          m.teamId!,
+                      )
+                    : "");
+            await run("/usr/bin/codesign", [
+                "--verify",
+                "--strict",
+                "--all-architectures",
+                "-R",
+                requirement,
+                app,
+            ]);
+            // Digests and the complete code signature are checked on every use.
+            // Cache policy/metadata only for this exact artifact in this plugin session.
+            const key = JSON.stringify([path, m]);
+            if (assessed.has(key)) return;
+            if (m.signing === "developer-id")
+                await run("/usr/sbin/spctl", [
+                    "--assess",
+                    "--type",
+                    "execute",
+                    app,
+                ]);
+            const info = JSON.parse(await run(executable, ["--voice-info"]));
+            if (
+                info.protocolVersion !== m.protocolVersion ||
+                info.helperVersion !== m.helperVersion ||
+                info.testing !== false
+            )
+                throw new Error("Incompatible voice helper protocol");
+            assessed.add(key);
+        },
+        move: (from, to) => IOUtils.move(from, to, { noOverwrite: true }),
+        remove: (path) =>
+            IOUtils.remove(path, { recursive: true, ignoreAbsent: true }),
+        touch: (path) =>
+            IOUtils.writeUTF8(`${path}/last-used`, String(Date.now())).then(
+                () => {},
+            ),
+        async cleanup(current) {
+            for (const path of await IOUtils.getChildren(root)) {
+                if (
+                    path === current ||
+                    !/\/(?:[a-f0-9]{64}|staging-[A-Za-z0-9-]+)$/.test(path)
+                )
+                    continue;
+                const marker = `${path}/last-used`;
+                const age = (await IOUtils.exists(marker))
+                    ? Number(await IOUtils.readUTF8(marker))
+                    : (await IOUtils.stat(path)).lastModified;
+                // Keep recent versions for rollback and beyond every possible native lease lifetime.
+                if (
+                    typeof age === "number" &&
+                    Number.isFinite(age) &&
+                    Date.now() - age > 7 * 86400000
+                )
+                    await IOUtils.remove(path, { recursive: true });
+            }
+        },
+        unique: () => Zotero.Utilities.randomString(32),
+    };
+    return new HelperInstaller(host, root, __env__ === "development");
+}

--- a/src/services/voice/macCapture.ts
+++ b/src/services/voice/macCapture.ts
@@ -1,3 +1,4 @@
+import nativeContract from "../../../native/voice/macos/contract.json";
 import {
     VOICE_FORMAT,
     VOICE_LIMITS,
@@ -69,6 +70,10 @@ export class MacCaptureService {
         private readonly host: MacCaptureHost,
         readonly port: number,
     ) {}
+
+    get busy(): boolean {
+        return !!this.active;
+    }
 
     createCapture(
         session: VoiceEnvelope,
@@ -267,7 +272,7 @@ class MacCapture implements VoiceCapture {
                 throw new Error("event_order");
             switch (m.type) {
                 case "hello":
-                    if (this.hello || m.helperVersion !== 2)
+                    if (this.hello || m.helperVersion !== nativeContract.helperVersion)
                         throw new Error("hello");
                     this.hello = true;
                     this.lastControl = this.host.now();

--- a/src/services/voice/nativeCaptureHarness.ts
+++ b/src/services/voice/nativeCaptureHarness.ts
@@ -22,6 +22,7 @@ function recordingFormat() {
 
 export type NativeCaptureHost = Pick<
     NativeVoice,
+    | "ensurePackagedHelper"
     | "available"
     | "permission"
     | "prepareMicrophone"
@@ -62,8 +63,34 @@ export class NativeCaptureHarness {
     }
 
     async start(win: Window, retainAudio = false) {
-        if (!this.native.available)
-            throw new Error("Configure the development helper first");
+        if (
+            this.settingUp ||
+            isBusyPhase(this.service.controller.getSnapshot().phase)
+        )
+            return { error: { code: "busy" as const } };
+        if (!this.native.available) {
+            this.settingUp = true;
+            try {
+                await this.native.ensurePackagedHelper();
+                if (!this.native.available)
+                    throw new Error("Native helper unavailable");
+            } catch (error) {
+                Zotero.logError(
+                    error instanceof Error ? error : new Error(String(error)),
+                );
+                return {
+                    error: { code: "unavailable" as const },
+                    help:
+                        error instanceof Error &&
+                        error.message ===
+                            "Voice capture is unsupported on this system"
+                            ? error.message
+                            : microphoneHelp("unavailable"),
+                };
+            } finally {
+                this.settingUp = false;
+            }
+        }
         // Guard before setup or changing the recording buffers of an existing session.
         if (
             this.settingUp ||

--- a/src/services/voice/nativeVoice.ts
+++ b/src/services/voice/nativeVoice.ts
@@ -6,6 +6,11 @@ import type {
 import { getPref, setPref } from "../../utils/prefs";
 import { MacCaptureService } from "./macCapture";
 import { VoiceSocket } from "./voiceSocket";
+import {
+    createPackagedHelperInstaller,
+    type HelperInstaller,
+} from "./helperInstaller";
+import { runVoiceProcess } from "./voiceProcess";
 import { systemClock } from "./voiceService";
 
 /** Native resources live in the plugin realm, independently of React and login state. */
@@ -14,6 +19,39 @@ export class NativeVoice {
     private socket?: VoiceSocket;
     private helperPath?: string;
     private disposed = false;
+    private installer?: HelperInstaller;
+    private packaged = false;
+    private preparing?: Promise<void>;
+
+    /** No extraction or listener until an explicitly gated native activation. */
+    ensurePackagedHelper(): Promise<void> {
+        if (this.available && !this.packaged) return Promise.resolve();
+        if (this.capture?.busy)
+            return Promise.reject(new Error("Native helper busy"));
+        if (this.disposed || !Zotero.isMac || !getPref("voice.nativeEnabled"))
+            return Promise.reject(new Error("Packaged voice capture disabled"));
+        if (this.preparing) return this.preparing;
+        this.installer ??= createPackagedHelperInstaller();
+        this.preparing = this.installer
+            .ensure()
+            .then((path) => {
+                if (
+                    this.disposed ||
+                    this.capture?.busy ||
+                    !getPref("voice.nativeEnabled")
+                )
+                    throw new Error("Native helper unavailable");
+                this.initialize();
+                if (this.helperPath !== path)
+                    this.capture!.permission = "unknown";
+                this.helperPath = path;
+                this.packaged = true;
+            })
+            .finally(() => {
+                this.preparing = undefined;
+            });
+        return this.preparing;
+    }
 
     private initialize(): void {
         if (this.capture) return;
@@ -43,31 +81,41 @@ export class NativeVoice {
                         const path = this.helperPath;
                         if (!path || this.disposed)
                             throw new Error("Native helper unavailable");
-                        const { Subprocess } = ChromeUtils.importESModule(
-                            "resource://gre/modules/Subprocess.sys.mjs",
-                        );
-                        const child = await Subprocess.call({
-                            command: "/usr/bin/open",
-                            arguments: [
-                                "-n",
-                                "-g",
-                                path,
-                                "--args",
-                                "--port",
-                                String(port),
-                                "--token",
-                                token,
-                                "--session",
-                                sessionId,
-                                ...(permissionOnly
-                                    ? ["--permission-only"]
-                                    : []),
-                            ],
-                            stderr: "pipe",
-                        });
-                        const result = await child.wait();
-                        if (result.exitCode !== 0)
-                            throw new Error("Helper launch failed");
+                        if (this.packaged) {
+                            // Fail fast when disabled; recheck after verification in case it changed.
+                            if (!getPref("voice.nativeEnabled"))
+                                throw new Error(
+                                    "Packaged voice helper unavailable",
+                                );
+                            const verified = await this.installer!.ensure();
+                            if (
+                                this.disposed ||
+                                !getPref("voice.nativeEnabled")
+                            )
+                                throw new Error(
+                                    "Packaged voice helper unavailable",
+                                );
+                            if (verified !== path) {
+                                this.helperPath = verified;
+                                this.capture!.permission = "unknown";
+                                throw new Error(
+                                    "Voice helper changed; start again",
+                                );
+                            }
+                        }
+                        await runVoiceProcess("/usr/bin/open", [
+                            "-n",
+                            "-g",
+                            path,
+                            "--args",
+                            "--port",
+                            String(port),
+                            "--token",
+                            token,
+                            "--session",
+                            sessionId,
+                            ...(permissionOnly ? ["--permission-only"] : []),
+                        ]);
                     },
                 },
                 socket.port,
@@ -84,25 +132,25 @@ export class NativeVoice {
         if (
             __env__ !== "development" ||
             this.disposed ||
+            this.capture?.busy ||
+            this.preparing ||
             !path.startsWith("/") ||
             !path.endsWith(".app")
         ) {
             throw new Error("Development helper unavailable");
         }
-        const { Subprocess } = ChromeUtils.importESModule(
-            "resource://gre/modules/Subprocess.sys.mjs",
-        );
-        const child = await Subprocess.call({
-            command: "/usr/bin/codesign",
-            arguments: ["--verify", "--strict", path],
-            stderr: "pipe",
-        });
-        if ((await child.wait()).exitCode !== 0 || this.disposed)
+        await runVoiceProcess("/usr/bin/codesign", [
+            "--verify",
+            "--strict",
+            path,
+        ]);
+        if (this.disposed || this.capture?.busy || this.preparing)
             throw new Error("Helper verification failed");
         this.initialize();
         // A verified path may contain a rebuilt/re-signed app with different OS permission state.
         this.capture!.permission = "unknown";
         this.helperPath = path;
+        this.packaged = false;
     }
     get available(): boolean {
         return (
@@ -150,6 +198,7 @@ export class NativeVoice {
     dispose(): void {
         if (this.disposed) return;
         this.disposed = true;
+        this.installer?.dispose();
         try {
             this.capture?.dispose();
         } finally {

--- a/src/services/voice/voiceProcess.ts
+++ b/src/services/voice/voiceProcess.ts
@@ -1,0 +1,52 @@
+/** Run a native voice utility with drained output and a bounded lifetime. */
+export async function runVoiceProcess(
+    command: string,
+    args: string[],
+): Promise<string> {
+    const { Subprocess } = ChromeUtils.importESModule(
+        "resource://gre/modules/Subprocess.sys.mjs",
+    );
+    const child = await Subprocess.call({
+        command,
+        arguments: args,
+        stderr: "pipe",
+    });
+    const timer = ChromeUtils.importESModule(
+        "resource://gre/modules/Timer.sys.mjs",
+    );
+    let expired = false;
+    const deadline = timer.setTimeout(() => {
+        expired = true;
+        void Promise.resolve(child.kill()).catch(() => {});
+    }, 15000);
+    try {
+        // Drain both pipes while the process runs to avoid a full-pipe deadlock.
+        const [stdout, , result] = await Promise.all([
+            drain(child.stdout, true),
+            drain(child.stderr, false),
+            child.wait(),
+        ]);
+        if (expired || result.exitCode !== 0)
+            throw new Error("Voice helper process failed");
+        return stdout.trim();
+    } catch (error) {
+        // A pipe-read failure must not orphan the utility after its deadline is cleared.
+        void Promise.resolve(child.kill()).catch(() => {});
+        await child.wait().catch(() => {});
+        throw error;
+    } finally {
+        timer.clearTimeout(deadline);
+    }
+}
+
+async function drain(pipe: { readString(): Promise<string> }, retain: boolean) {
+    let output = "";
+    for (let chunk; (chunk = await pipe.readString()); ) {
+        if (retain) {
+            if (output.length + chunk.length > 1024 * 1024)
+                throw new Error("Voice helper output exceeded limit");
+            output += chunk;
+        }
+    }
+    return output;
+}

--- a/tests/unit/voice/helperInstaller.test.ts
+++ b/tests/unit/voice/helperInstaller.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import {
+    HelperInstaller,
+    validateHelperManifest,
+    type HelperInstallerHost,
+} from "../../../src/services/voice/helperInstaller";
+
+const manifest = () => ({
+    schema: 1,
+    protocolVersion: 1,
+    helperVersion: 2,
+    bundleId: "ai.beaverapp.voice",
+    version: "0.1.0",
+    signing: "development",
+    teamId: null,
+    archiveSha256: "a".repeat(64),
+    archiveBytes: 4096,
+    executableSha256: "b".repeat(64),
+    plistSha256: "c".repeat(64),
+});
+let host: HelperInstallerHost;
+let installer: HelperInstaller;
+beforeEach(() => {
+    host = {
+        manifest: vi.fn(async () => manifest()),
+        checkPlatform: vi.fn(async () => {}),
+        exists: vi.fn(async () => false),
+        stage: vi.fn(async () => {}),
+        verify: vi.fn(async () => {}),
+        move: vi.fn(async () => {}),
+        remove: vi.fn(async () => {}),
+        touch: vi.fn(async () => {}),
+        cleanup: vi.fn(async () => {}),
+        unique: () => "unique",
+    };
+    installer = new HelperInstaller(host, "/voice", true);
+});
+it("publishes only after verification and coalesces simultaneous requests", async () => {
+    const first = installer.ensure();
+    expect(installer.ensure()).toBe(first);
+    expect(await first).toBe(`/voice/${"a".repeat(64)}/Beaver Voice Input.app`);
+    expect(host.verify).toHaveBeenCalledWith(
+        "/voice/staging-unique",
+        manifest(),
+    );
+    expect(vi.mocked(host.verify).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(host.move).mock.invocationCallOrder[0],
+    );
+    expect(host.remove).toHaveBeenCalledWith("/voice/staging-unique");
+});
+it("revalidates cached installs without overwriting them", async () => {
+    vi.mocked(host.exists).mockResolvedValue(true);
+    await installer.ensure();
+    await installer.ensure();
+    expect(host.verify).toHaveBeenCalledTimes(2);
+    expect(host.stage).not.toHaveBeenCalled();
+    expect(host.move).not.toHaveBeenCalled();
+});
+it.each(["stage", "verify", "move"] as const)(
+    "cleans staging and permits retry after %s fails",
+    async (method) => {
+        vi.mocked(host[method]).mockRejectedValueOnce(new Error("invalid"));
+        await expect(installer.ensure()).rejects.toThrow("invalid");
+        expect(host.remove).toHaveBeenCalledExactlyOnceWith(
+            "/voice/staging-unique",
+        );
+        expect(host.touch).not.toHaveBeenCalled();
+        await expect(installer.ensure()).resolves.toContain(
+            "Beaver Voice Input.app",
+        );
+    },
+);
+it("rejects a corrupt cached helper without deleting previous versions", async () => {
+    vi.mocked(host.exists).mockResolvedValue(true);
+    vi.mocked(host.verify).mockRejectedValue(new Error("corrupt"));
+    await expect(installer.ensure()).rejects.toThrow("corrupt");
+    expect(host.remove).toHaveBeenCalledExactlyOnceWith(
+        "/voice/staging-unique",
+    );
+    expect(host.cleanup).not.toHaveBeenCalled();
+});
+it("does not publish or activate after disposal during extraction", async () => {
+    vi.mocked(host.stage).mockImplementation(async () => {
+        installer.dispose();
+    });
+    await expect(installer.ensure()).rejects.toThrow("disposed");
+    expect(host.move).not.toHaveBeenCalled();
+    expect(host.touch).not.toHaveBeenCalled();
+    expect(host.remove).toHaveBeenCalled();
+    await expect(installer.ensure()).rejects.toThrow("disposed");
+});
+it("keeps a valid install usable when obsolete-version cleanup fails", async () => {
+    vi.mocked(host.cleanup).mockRejectedValue(new Error("locked"));
+    await expect(installer.ensure()).resolves.toContain(
+        "Beaver Voice Input.app",
+    );
+});
+it("fails closed on ad-hoc signing in production", () => {
+    expect(() => validateHelperManifest(manifest(), false)).toThrow();
+    expect(
+        validateHelperManifest(
+            { ...manifest(), signing: "developer-id", teamId: "ABCDE12345" },
+            false,
+        ),
+    ).toHaveProperty("signing", "developer-id");
+});
+it.each([
+    { protocolVersion: 2 },
+    { helperVersion: 1 },
+    { schema: 2 },
+    { archiveSha256: "../escape" },
+    { archiveBytes: 33 * 1024 * 1024 },
+    { archiveBytes: -1 },
+    { bundleId: "ai.beaverapp.voice.tests" },
+    { signing: "unsigned" },
+    { version: "../1" },
+    { signing: "developer-id", teamId: '" or true' },
+    { plistSha256: "" },
+])("rejects incompatible metadata %j before extraction", async (patch) => {
+    vi.mocked(host.manifest).mockResolvedValue({ ...manifest(), ...patch });
+    await expect(installer.ensure()).rejects.toThrow();
+    expect(host.stage).not.toHaveBeenCalled();
+});
+
+it("rejects an unsupported platform before extracting or checking an installation", async () => {
+    vi.mocked(host.checkPlatform).mockRejectedValue(new Error("unsupported"));
+    await expect(installer.ensure()).rejects.toThrow("unsupported");
+    expect(host.stage).not.toHaveBeenCalled();
+    expect(host.exists).not.toHaveBeenCalled();
+});
+
+it("repairs a damaged install only after verifying one fresh extraction", async () => {
+    vi.mocked(host.exists).mockResolvedValue(true);
+    vi.mocked(host.verify).mockRejectedValueOnce(new Error("corrupt"));
+    await expect(installer.ensure()).resolves.toContain(
+        "Beaver Voice Input.app",
+    );
+    expect(host.verify).toHaveBeenCalledTimes(2);
+    expect(host.stage).toHaveBeenCalledOnce();
+    expect(host.remove).toHaveBeenCalledWith(`/voice/${"a".repeat(64)}`);
+    expect(vi.mocked(host.verify).mock.invocationCallOrder[1]).toBeLessThan(
+        vi.mocked(host.remove).mock.invocationCallOrder[0],
+    );
+});

--- a/tests/unit/voice/helperPlatform.test.ts
+++ b/tests/unit/voice/helperPlatform.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createPackagedHelperInstaller } from "../../../src/services/voice/helperInstaller";
+import { VOICE_VERSION } from "@beaver/agent-core/voice/contracts";
+import contract from "../../../native/voice/macos/contract.json";
+
+const run = vi.hoisted(() => vi.fn());
+vi.mock("../../../src/services/voice/voiceProcess", () => ({
+    runVoiceProcess: run,
+}));
+beforeEach(() => {
+    run.mockReset().mockImplementation(async (command: string) => {
+        if (command.endsWith("sw_vers")) return "14.7";
+        if (command.endsWith("uname")) return "arm64";
+        if (command.endsWith("BeaverVoice"))
+            return JSON.stringify({ ...contract, testing: false });
+        return "";
+    });
+    vi.stubGlobal("__env__", "development");
+    vi.stubGlobal("Zotero", {
+        ...Zotero,
+        Profile: { dir: "/profile" },
+        version: "10.0",
+        isMac: true,
+    });
+    vi.stubGlobal("PathUtils", {
+        join: (...paths: string[]) => paths.join("/"),
+    });
+    vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                schema: contract.schema,
+                protocolVersion: contract.protocolVersion,
+                helperVersion: contract.helperVersion,
+                bundleId: contract.bundleId,
+                version: "0.1.0",
+                signing: "development",
+                teamId: null,
+                archiveBytes: 100,
+                archiveSha256: "a".repeat(64),
+                executableSha256: "b".repeat(64),
+                plistSha256: "b".repeat(64),
+            }),
+        })),
+    );
+    vi.stubGlobal("IOUtils", {
+        exists: async () => true,
+        computeHexDigest: async () => "b".repeat(64),
+        writeUTF8: async () => {},
+        getChildren: async () => [],
+    });
+});
+afterEach(() => vi.unstubAllGlobals());
+it("memoizes platform discovery while revalidating the installed bundle on every launch", async () => {
+    const installer = createPackagedHelperInstaller();
+    await installer.ensure();
+    await installer.ensure();
+    const calls = (suffix: string) =>
+        run.mock.calls.filter(([command]) => command.endsWith(suffix));
+    expect(calls("sw_vers")).toHaveLength(1);
+    expect(calls("uname")).toHaveLength(1);
+    expect(calls("codesign")).toHaveLength(2);
+    expect(calls("BeaverVoice")).toHaveLength(1);
+});
+it("retries failed platform discovery", async () => {
+    run.mockRejectedValueOnce(new Error("process failed"));
+    const installer = createPackagedHelperInstaller();
+    await expect(installer.ensure()).rejects.toThrow("process failed");
+    await expect(installer.ensure()).resolves.toContain(
+        "Beaver Voice Input.app",
+    );
+});
+it("keeps native protocol generation aligned with the portable wire protocol", () => {
+    expect(contract.protocolVersion).toBe(VOICE_VERSION);
+});
+
+it("caches Gatekeeper only after full assessment and still verifies signatures", async () => {
+    const response = await fetch("manifest");
+    const manifest = await response.json();
+    manifest.signing = "developer-id";
+    manifest.teamId = "ABCDE12345";
+    vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => manifest,
+    } as Response);
+    const installer = createPackagedHelperInstaller();
+    await installer.ensure();
+    await installer.ensure();
+    expect(
+        run.mock.calls.filter(([command]) => command.endsWith("spctl")),
+    ).toHaveLength(1);
+    expect(
+        run.mock.calls.filter(([command]) => command.endsWith("codesign")),
+    ).toHaveLength(2);
+});

--- a/tests/unit/voice/nativeHarness.test.ts
+++ b/tests/unit/voice/nativeHarness.test.ts
@@ -17,11 +17,13 @@ const settle = async () => {
     for (let i = 0; i < 12; i++) await Promise.resolve();
 };
 beforeEach(() => {
+    vi.stubGlobal("Zotero", { ...Zotero, logError: vi.fn() });
     vi.stubGlobal("Cu", { now: Date.now });
     let id = 0;
     Zotero.Utilities.randomString = () => `native-test-${++id}`;
     native = {
         available: true,
+        ensurePackagedHelper: vi.fn(async () => {}),
         permission: "granted",
         explain: vi.fn(() => true),
         prepareMicrophone: vi.fn(async () => "granted" as const),
@@ -239,4 +241,55 @@ it("reports canceled permission setup as unavailable without a second explanatio
     expect(native.explain).not.toHaveBeenCalled();
     expect(native.createCapture).not.toHaveBeenCalled();
     expect(h.start("fake-user", auth)).toEqual({ error: { code: "disabled" } });
+});
+
+it.each(["rejects", "resolves unavailable"])(
+    "returns the same actionable result when helper setup %s",
+    async (mode) => {
+        Object.assign(native, { available: false });
+        if (mode === "rejects")
+            vi.mocked(native.ensurePackagedHelper).mockRejectedValue(
+                new Error("missing"),
+            );
+        await expect(h.startNative(win)).resolves.toMatchObject({
+            error: { code: "unavailable" },
+            help: expect.stringContaining("helper is installed"),
+        });
+        expect(native.prepareMicrophone).not.toHaveBeenCalled();
+        expect(native.createCapture).not.toHaveBeenCalled();
+    },
+);
+
+it("reserves setup admission while installation is pending", async () => {
+    native.available = false;
+    let ready!: () => void;
+    vi.mocked(native.ensurePackagedHelper).mockImplementation(
+        () =>
+            new Promise<void>((resolve) => {
+                ready = resolve;
+            }),
+    );
+    const first = h.startNative(win);
+    await expect(h.startNative(win)).resolves.toHaveProperty(
+        "error.code",
+        "busy",
+    );
+    native.available = true;
+    ready();
+    await first;
+    expect(native.ensurePackagedHelper).toHaveBeenCalledOnce();
+    expect(native.createCapture).toHaveBeenCalledOnce();
+});
+it("preserves unsupported-platform help and logs installation failures", async () => {
+    native.available = false;
+    const error = new Error("Voice capture is unsupported on this system");
+    vi.mocked(native.ensurePackagedHelper).mockRejectedValueOnce(error);
+    await expect(h.startNative(win)).resolves.toEqual({
+        error: { code: "unavailable" },
+        help: error.message,
+    });
+    expect(Zotero.logError).toHaveBeenCalledWith(error);
+    native.available = true;
+    await h.startNative(win);
+    expect(native.createCapture).toHaveBeenCalledOnce();
 });

--- a/tests/unit/voice/nativeVoice.test.ts
+++ b/tests/unit/voice/nativeVoice.test.ts
@@ -2,6 +2,19 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { NativeVoice } from "../../../src/services/voice/nativeVoice";
 import { DevelopmentVoiceHarness } from "../../../src/services/voice/developmentHarness";
 
+const packaged = vi.hoisted(() => ({
+    enabled: false,
+    create: vi.fn(),
+    ensure: vi.fn(),
+    dispose: vi.fn(),
+}));
+vi.mock("../../../src/services/voice/helperInstaller", () => ({
+    createPackagedHelperInstaller: () => {
+        packaged.create();
+        return { ensure: packaged.ensure, dispose: packaged.dispose };
+    },
+}));
+
 const socket = vi.hoisted(() => ({
     create: vi.fn(),
     dispose: vi.fn(),
@@ -20,7 +33,8 @@ vi.mock("../../../src/services/voice/voiceSocket", () => ({
     },
 }));
 vi.mock("../../../src/utils/prefs", () => ({
-    getPref: () => true,
+    getPref: (key: string) =>
+        key === "voice.nativeEnabled" ? packaged.enabled : true,
     setPref: vi.fn(),
 }));
 
@@ -41,6 +55,10 @@ const settle = async () => {
 
 beforeEach(() => {
     vi.useFakeTimers();
+    packaged.enabled = false;
+    packaged.create.mockReset();
+    packaged.ensure.mockReset().mockResolvedValue(path);
+    packaged.dispose.mockReset();
     socket.create.mockReset();
     socket.dispose.mockReset();
     launchFails = verifyFails = false;
@@ -75,6 +93,9 @@ beforeEach(() => {
                                   options.command === "/usr/bin/open";
                               if (opening) launch = options.arguments;
                               return {
+                                  stdout: { readString: async () => "" },
+                                  stderr: { readString: async () => "" },
+                                  kill: vi.fn(),
                                   wait: async () => ({
                                       exitCode: (
                                           opening ? launchFails : verifyFails
@@ -107,7 +128,7 @@ it("opens no socket at startup or for an unverified helper", async () => {
     expect(socket.create).not.toHaveBeenCalled();
     verifyFails = true;
     await expect(native.setDevelopmentHelper(path)).rejects.toThrow(
-        "verification failed",
+        "process failed",
     );
     expect(socket.create).not.toHaveBeenCalled();
 });
@@ -184,3 +205,127 @@ it.each(["launch failure", "startup timeout", "owner unload"])(
         expect(await retry).toHaveProperty("error.code", "unavailable");
     },
 );
+
+it("refuses helper replacement while a native lease is active", async () => {
+    await native.setDevelopmentHelper(path);
+    const capture = native.createCapture(
+        { version: 1, sessionId: "active" },
+        () => {},
+    );
+    await expect(native.setDevelopmentHelper(path)).rejects.toThrow(
+        "unavailable",
+    );
+    capture.dispose();
+    await expect(native.setDevelopmentHelper(path)).resolves.toBeUndefined();
+});
+
+it("keeps packaged installation lazy and gated, then initializes it once", async () => {
+    expect(packaged.create).not.toHaveBeenCalled();
+    await expect(native.ensurePackagedHelper()).rejects.toThrow("disabled");
+    expect(packaged.create).not.toHaveBeenCalled();
+    expect(socket.create).not.toHaveBeenCalled();
+    packaged.enabled = true;
+    await Promise.all([
+        native.ensurePackagedHelper(),
+        native.ensurePackagedHelper(),
+    ]);
+    expect(packaged.create).toHaveBeenCalledTimes(1);
+    expect(packaged.ensure).toHaveBeenCalledTimes(1);
+    expect(socket.create).toHaveBeenCalledTimes(1);
+    expect(native.permission).toBe("unknown");
+});
+
+it("does not open a socket after disposal during packaged extraction", async () => {
+    packaged.enabled = true;
+    let complete!: (path: string) => void;
+    packaged.ensure.mockImplementation(
+        () =>
+            new Promise((resolve) => {
+                complete = resolve;
+            }),
+    );
+    const pending = native.ensurePackagedHelper();
+    native.dispose();
+    complete(path);
+    await expect(pending).rejects.toThrow("unavailable");
+    expect(socket.create).not.toHaveBeenCalled();
+    expect(packaged.dispose).toHaveBeenCalledOnce();
+});
+
+it("retries failed packaged extraction without native resources leaking", async () => {
+    packaged.enabled = true;
+    packaged.ensure.mockRejectedValueOnce(new Error("corrupt"));
+    await expect(native.ensurePackagedHelper()).rejects.toThrow("corrupt");
+    expect(socket.create).not.toHaveBeenCalled();
+    await native.ensurePackagedHelper();
+    expect(native.available).toBe(true);
+});
+
+it("rechecks the package and feature gate before each native launch", async () => {
+    packaged.enabled = true;
+    await native.ensurePackagedHelper();
+    packaged.enabled = false;
+    const setup = harness.startNative(owner);
+    await settle();
+    expect(await setup).toHaveProperty("error.code", "unavailable");
+    expect(launch).toEqual([]);
+    packaged.enabled = true;
+    packaged.ensure.mockRejectedValueOnce(new Error("corrupt cache"));
+    const second = harness.startNative(owner);
+    await settle();
+    expect(await second).toHaveProperty("error.code", "unavailable");
+    expect(launch).toEqual([]);
+});
+
+it("does not initialize after the feature is disabled during extraction", async () => {
+    packaged.enabled = true;
+    packaged.ensure.mockImplementation(async () => {
+        packaged.enabled = false;
+        return path;
+    });
+    await expect(native.ensurePackagedHelper()).rejects.toThrow("unavailable");
+    expect(socket.create).not.toHaveBeenCalled();
+});
+
+it("does not launch after the feature is disabled during cached verification", async () => {
+    packaged.enabled = true;
+    await native.ensurePackagedHelper();
+    packaged.ensure.mockImplementation(async () => {
+        packaged.enabled = false;
+        return path;
+    });
+    const setup = harness.startNative(owner);
+    await settle();
+    expect(await setup).toHaveProperty("error.code", "unavailable");
+    expect(launch).toEqual([]);
+});
+
+it("refreshes a packaged path between sessions without creating another listener", async () => {
+    packaged.enabled = true;
+    await native.ensurePackagedHelper();
+    packaged.ensure.mockResolvedValue("/updated/Beaver Voice Input.app");
+    await native.ensurePackagedHelper();
+    expect((native as any).helperPath).toBe("/updated/Beaver Voice Input.app");
+    expect(socket.create).toHaveBeenCalledOnce();
+    const lease = native.createCapture(
+        { version: 1, sessionId: "busy" },
+        () => {},
+    );
+    await expect(native.ensurePackagedHelper()).rejects.toThrow("busy");
+    lease.dispose();
+});
+
+it("recovers on the next start when the artifact changes during launch", async () => {
+    packaged.enabled = true;
+    await native.ensurePackagedHelper();
+    packaged.ensure.mockResolvedValue("/updated/Beaver Voice Input.app");
+    await expect(harness.startNative(owner)).resolves.toHaveProperty(
+        "error.code",
+        "unavailable",
+    );
+    const retry = harness.startNative(owner);
+    await settle();
+    expect(launch).toContain("/updated/Beaver Voice Input.app");
+    owner.dispatchEvent(new Event("unload"));
+    await retry;
+});

--- a/tests/unit/voice/voiceProcess.test.ts
+++ b/tests/unit/voice/voiceProcess.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { runVoiceProcess } from "../../../src/services/voice/voiceProcess";
+
+let child: {
+    stdout: { readString: ReturnType<typeof vi.fn> };
+    stderr: { readString: ReturnType<typeof vi.fn> };
+    wait: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+};
+let exit: (result: { exitCode: number }) => void;
+beforeEach(() => {
+    vi.useFakeTimers();
+    const result = new Promise((resolve) => {
+        exit = resolve;
+    });
+    child = {
+        stdout: {
+            readString: vi
+                .fn()
+                .mockResolvedValueOnce(" out")
+                .mockResolvedValueOnce("put \n")
+                .mockResolvedValue(""),
+        },
+        stderr: {
+            readString: vi
+                .fn()
+                .mockResolvedValueOnce("diagnostic")
+                .mockResolvedValueOnce(" more")
+                .mockResolvedValue(""),
+        },
+        wait: vi.fn(() => result),
+        kill: vi.fn(() => exit({ exitCode: -9 })),
+    };
+    vi.stubGlobal("ChromeUtils", {
+        importESModule: (name: string) =>
+            name.includes("Timer.sys")
+                ? { setTimeout, clearTimeout }
+                : { Subprocess: { call: async () => child } },
+    });
+});
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+it("drains both streams before waiting for exit and clears its deadline", async () => {
+    const promise = runVoiceProcess("/usr/bin/open", []);
+    await Promise.resolve();
+    expect(child.stdout.readString).toHaveBeenCalledOnce();
+    expect(child.stderr.readString).toHaveBeenCalledOnce();
+    exit({ exitCode: 0 });
+    await expect(promise).resolves.toBe("output");
+    expect(child.stdout.readString).toHaveBeenCalledTimes(3);
+    expect(child.stderr.readString).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(child.kill).not.toHaveBeenCalled();
+});
+it("kills a stuck utility at the deadline", async () => {
+    const promise = expect(
+        runVoiceProcess("/usr/bin/codesign", []),
+    ).rejects.toThrow("process failed");
+    await vi.advanceTimersByTimeAsync(15000);
+    await promise;
+    expect(child.kill).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+});
+it("releases the process after a pipe read fails", async () => {
+    child.stderr.readString.mockRejectedValue(new Error("read failed"));
+    await expect(runVoiceProcess("/usr/bin/open", [])).rejects.toThrow(
+        "read failed",
+    );
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+});
+it("does not include utility output or command arguments in failure messages", async () => {
+    const promise = runVoiceProcess("/usr/bin/open", ["private-token"]);
+    exit({ exitCode: 1 });
+    await expect(promise).rejects.toThrow(/^Voice helper process failed$/);
+});
+
+it("bounds retained output and tolerates a rejected kill after exit", async () => {
+    child.stdout.readString
+        .mockReset()
+        .mockResolvedValueOnce("x".repeat(1024 * 1024 + 1))
+        .mockResolvedValue("");
+    child.kill.mockRejectedValue(new Error("already exited"));
+    exit({ exitCode: 0 });
+    await expect(runVoiceProcess("/test", [])).rejects.toThrow(
+        "output exceeded limit",
+    );
+    expect(vi.getTimerCount()).toBe(0);
+});

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -15,6 +15,7 @@ declare namespace _ZoteroTypes {
       "showHighTokenUsageWarningMessage": boolean;
       "authMethod": string;
       "voice.helperExplained": boolean;
+      "voice.nativeEnabled": boolean;
       "keyboardShortcut": string;
       "statefulChat": boolean;
       "addSelectedItemsOnOpen": boolean;

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -2,6 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { defineConfig } from "zotero-plugin-scaffold";
 import pkg from "./package.json";
+import { checkVoicePackage } from "./native/voice/macos/check-package.mjs";
 
 // Zotero UI locales (mirrors chrome/locale/* in the Zotero source tree)
 const ZOTERO_LOCALES = [
@@ -81,6 +82,9 @@ export default defineConfig({
       },
     ],
     hooks: {
+      "build:copyAssets": async (ctx) => {
+        checkVoicePackage(join(ctx.dist, "addon"), process.env.NODE_ENV === "development", process.env.VOICE_PACKAGE_REQUIRED === "1");
+      },
       "build:fluent": async (ctx) => {
         const enUsDir = join(ctx.dist, "addon/locale/en-US");
         if (!existsSync(enUsDir)) return;


### PR DESCRIPTION
## Summary

- Build and package a universal macOS voice helper for arm64 and x86_64.
- Add manifest, archive integrity, signature, protocol, and compatibility validation.
- Add verified installation, upgrades, rollback, corruption recovery, and lifecycle handling.
- Add macOS CI packaging checks and gated signed release automation.
- Keep native voice activation disabled by default and document release requirements.

## Testing

- Passed 6,964 unit tests, including 199 voice tests, with three existing skips.
- Passed development builds, typechecks, bundle isolation, ESLint, and changed-file formatting checks.
- Passed universal archive/XPI round-trip, signature, symlink, executable-mode, and corruption checks.
- Passed native lifecycle, cache recovery, reinstall, upgrade, rollback, invalid-package, and live controller checks.
- Passed generated packaged captures, including an 18-second capture and forced Intel/Rosetta execution.
- Not run: signed distribution validation, notarization, downloaded/offline Gatekeeper checks, physical microphone checks, and GitHub CI runs.