### PR TITLE
feat(quick-prompt): add collapsed composer for closed sidebar

### DIFF
--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -387,7 +387,6 @@
 .beaver-run-status-popup__rows {
     display: flex;
     flex-direction: column;
-    margin-left: 30px;
     border: 1px solid var(--beaver-border-subtle);
     border-radius: 8px;
     background: var(--beaver-fill-subtle);
@@ -460,6 +459,122 @@
 
 .beaver-run-status-popup__row:hover .beaver-run-status-popup__row-arrow {
     opacity: 1;
+}
+
+/* Quick prompt: a composer for a new chat, in the corner of the main window
+ * while the sidebar is closed (react/components/quickPrompt). Sits inside
+ * #beaver-pane-floating-popup above the run status popup, in the same frame. */
+.beaver-quick-prompt {
+    position: relative;
+    align-self: flex-end;
+    width: 324px;
+    max-width: 100%;
+    margin: 0 4px 12px 0;
+    cursor: default;
+    text-align: left;
+}
+
+.beaver-quick-prompt__card {
+    position: relative;
+    box-sizing: border-box;
+    border: 1px solid var(--beaver-border-strong);
+    border-radius: 12px;
+    background: var(--beaver-surface-overlay);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14), 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.beaver-quick-prompt__dismiss {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+/* The close button only appears while the pointer is on the card, or when
+ * it has keyboard focus itself. */
+.beaver-quick-prompt__card:hover .beaver-quick-prompt__dismiss,
+.beaver-quick-prompt__dismiss:focus-within {
+    opacity: 1;
+}
+
+/* Room in the corner for the close button: the chips wrap before it, and
+ * the text does not run under it. A margin on the scroll host, not padding
+ * on the contenteditable: that one is `width: 100%` in the content box, so
+ * padding would push it past the host and raise a horizontal scrollbar. */
+.beaver-quick-prompt__composer .composer-attachments {
+    padding-right: 28px;
+}
+
+.beaver-quick-prompt__composer .beaver-lexical-scroll {
+    margin-right: 24px;
+}
+
+/* The composer's popup messages (an item removed, a summary of what was
+ * attached) anchor above the card, as they do above the sidebar's composer. */
+.beaver-quick-prompt__composer {
+    position: relative;
+}
+
+/* The popup is the frame, so the composer gives up its own. */
+.beaver-quick-prompt__composer > .user-message-display {
+    margin: 0;
+    border: 0;
+    border-radius: 12px;
+    background: transparent;
+    box-shadow: none;
+}
+
+.beaver-quick-prompt__notice {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 10px;
+    min-width: 0;
+    padding: 10px 36px 0 12px;
+}
+
+.beaver-quick-prompt__notice-mark {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+}
+
+.beaver-quick-prompt__notice-text {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: 2px;
+    /* Lines up with the close button beside it. */
+    padding-top: 2px;
+}
+
+.beaver-quick-prompt__notice-title {
+    font-size: 0.95rem;
+    font-weight: 500;
+    line-height: 20px;
+}
+
+.beaver-quick-prompt__notice-detail {
+    font-size: 0.875rem;
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.beaver-quick-prompt__footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px 10px 12px;
 }
 
 /* The onboarding tip's visual: the real card's top-left corner, run off the

--- a/packages/agent-ui/src/chat/BatchApprovalCard.tsx
+++ b/packages/agent-ui/src/chat/BatchApprovalCard.tsx
@@ -148,8 +148,8 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
 
     // The footer's buttons never wrap; when the row is too narrow for them,
     // the mode trigger drops to its icon.
-    const footerRef = useRef<HTMLDivElement>(null);
-    const modeIconOnly = useOverflowCollapse(footerRef, 1) >= 1;
+    const footer = useOverflowCollapse(1);
+    const modeIconOnly = footer.level >= 1;
 
     return (
         <div
@@ -320,7 +320,7 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
                     run alive, so neither is an escape hatch and the destructive
                     one is not given a leading position. */}
                 <div
-                    ref={footerRef}
+                    ref={footer.ref}
                     className="display-flex flex-row items-center gap-2 min-w-0"
                     style={{ borderTop: '1px solid var(--fill-quinary)', paddingTop: '0.7rem' }}
                 >

--- a/packages/agent-ui/src/utils/useOverflowCollapse.ts
+++ b/packages/agent-ui/src/utils/useOverflowCollapse.ts
@@ -1,69 +1,102 @@
-import { useRef, useState } from 'react';
-import type { RefObject } from 'react';
-import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useCallback, useRef, useState } from 'react';
+
+/** What {@link useOverflowCollapse} hands back to a row of controls. */
+export interface OverflowCollapse {
+    /** `0` for everything shown in full, up to the `maxLevel` the row asked for. */
+    level: number;
+    /** Attach to the row's container. Measurement follows the element, not renders. */
+    ref: (element: HTMLElement | null) => void;
+}
 
 /**
  * How far a row of controls has had to collapse to fit its container.
  *
- * Returns a level from `0` (everything shown in full) up to `maxLevel`. The
- * caller decides what each level drops — typically a label that turns into
+ * The caller decides what each level drops — typically a label that turns into
  * its icon — and must lay the row out so that its items overflow instead of
  * shrinking (`flex: none` + `white-space: nowrap`), since overflow is what
  * this measures: the level rises while the container's content is wider than
  * the container, and falls back once the container is at least as wide as the
- * content was when that level was needed.
+ * content was when that level was needed. Remembering that width is what keeps
+ * the result stable: without it, collapsing would make the row fit, which would
+ * expand it again, which would overflow again.
  *
- * Remembering the width each level was needed at is what keeps the result
- * stable: without it, collapsing would make the row fit, which would expand it
- * again, which would overflow again. The row is re-measured after every render
- * (its content changes without its box changing) and whenever the container
- * resizes. The container may mount later than the component, or be swapped,
- * so the resize observer follows whatever element the ref currently holds.
+ * Measurement is subscribed to the element rather than run after renders. A
+ * `ResizeObserver` reports the container changing size — the one event that may
+ * let the row expand again — and a `MutationObserver` reports its content
+ * changing under a fixed box (an item's name arriving in a label, a button
+ * appearing), which may need it to collapse further. Both fire from the
+ * browser, outside React's commit, so a level change here is an ordinary
+ * update. The one exception is the measurement taken when the element attaches,
+ * so a row that is already too narrow is drawn collapsed on its first paint.
+ *
+ * The state setter is called only when the level actually changes. A setter
+ * called with the current value is not always free: while the component holds
+ * a lower-priority update it has not rendered yet (a store subscription that
+ * fired a moment ago), React cannot take its early exit and schedules a
+ * synchronous re-render instead. Combined with a measurement that ran after
+ * every render, that once looped until React aborted the tree. The level is
+ * mirrored in a ref so the comparison happens before React is involved.
  */
-export function useOverflowCollapse(ref: RefObject<HTMLElement | null>, maxLevel: number): number {
+export function useOverflowCollapse(maxLevel: number): OverflowCollapse {
     const [level, setLevel] = useState(0);
+    // The level as last decided here, so consecutive observer callbacks build
+    // on the decision before React has rendered it.
+    const levelRef = useRef(0);
     // Content width at which each level overflowed; index = the level that
     // was showing at the time.
     const neededWidths = useRef<number[]>([]);
     const maxLevelRef = useRef(maxLevel);
     maxLevelRef.current = maxLevel;
-    const observed = useRef<{ element: HTMLElement; observer: ResizeObserver } | null>(null);
+    const subscription = useRef<{ element: HTMLElement; disconnect: () => void } | null>(null);
 
-    const measure = (element: HTMLElement) => {
-        const available = element.clientWidth;
-        const needed = element.scrollWidth;
-        if (available === 0) return;
-        setLevel((current) => {
+    const ref = useCallback((element: HTMLElement | null) => {
+        if (subscription.current?.element === element) return;
+        subscription.current?.disconnect();
+        subscription.current = null;
+        if (!element) return;
+        const win = element.ownerDocument.defaultView;
+        if (!win) return;
+
+        const measure = (canLower: boolean) => {
+            const available = element.clientWidth;
+            const needed = element.scrollWidth;
+            if (available === 0) return;
+            const current = levelRef.current;
+            let next = current;
             if (needed > available && current < maxLevelRef.current) {
                 neededWidths.current[current] = needed;
-                return current + 1;
+                next = current + 1;
+            } else if (canLower && current > 0 && available >= (neededWidths.current[current - 1] ?? Infinity)) {
+                next = current - 1;
+            } else if (current > maxLevelRef.current) {
+                next = maxLevelRef.current;
             }
-            if (current > 0 && available >= (neededWidths.current[current - 1] ?? Infinity)) {
-                return current - 1;
-            }
-            if (current > maxLevelRef.current) return maxLevelRef.current;
-            return current;
+            if (next === current) return;
+            levelRef.current = next;
+            setLevel(next);
+        };
+
+        measure(false);
+
+        const resize = new win.ResizeObserver(() => measure(true));
+        resize.observe(element);
+        const mutation = new win.MutationObserver(() => measure(false));
+        mutation.observe(element, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+            attributes: true,
+            attributeFilter: ['class', 'style', 'hidden'],
         });
-    };
 
-    useIsomorphicLayoutEffect(() => {
-        const element = ref.current;
-        if (element) measure(element);
-        if (observed.current?.element === element) return;
-        observed.current?.observer.disconnect();
-        observed.current = null;
-        if (!element) return;
-        const ResizeObserverCtor = element.ownerDocument.defaultView?.ResizeObserver;
-        if (!ResizeObserverCtor) return;
-        const observer = new ResizeObserverCtor(() => measure(element));
-        observer.observe(element);
-        observed.current = { element, observer };
-    });
-
-    useIsomorphicLayoutEffect(() => () => {
-        observed.current?.observer.disconnect();
-        observed.current = null;
+        subscription.current = {
+            element,
+            disconnect: () => {
+                resize.disconnect();
+                mutation.disconnect();
+            },
+        };
     }, []);
 
-    return level;
+    return { level, ref };
 }

--- a/react/atoms/chatAccess.ts
+++ b/react/atoms/chatAccess.ts
@@ -1,0 +1,51 @@
+/**
+ * Whether the account is in a state where a chat can be started, and if not,
+ * why. One definition for every surface that offers a composer: the sidebar
+ * swaps the composer for the screen that resolves the state, and the quick
+ * prompt tells the user which screen that is and opens Beaver to it.
+ */
+import { atom } from 'jotai';
+import { isAuthenticatedAtom } from './auth';
+import {
+    hasAuthorizedFreeAccessAtom,
+    hasAuthorizedProAccessAtom,
+    hasCompletedOnboardingAtom,
+    isDatabaseSyncSupportedAtom,
+    isMigratingDataAtom,
+    isProfileLoadedAtom,
+    pendingDowngradeAckAtom,
+    pendingUpgradeConsentAtom,
+    syncedLibrariesAtom,
+    updateRequiredAtom,
+} from './profile';
+import { isLoadingThreadAtom } from './threads';
+
+/**
+ * What stands between the user and a chat, in the order the sidebar resolves
+ * them. `loading` covers a thread being opened and data being migrated;
+ * `connecting` an authenticated account whose profile has not arrived.
+ */
+export type ChatAccessGate =
+    | 'loading'
+    | 'signed-out'
+    | 'connecting'
+    | 'update-required'
+    | 'downgrade-ack'
+    | 'upgrade-consent'
+    | 'onboarding';
+
+export const chatAccessGateAtom = atom<ChatAccessGate | null>((get) => {
+    if (get(isLoadingThreadAtom) || get(isMigratingDataAtom)) return 'loading';
+    if (!get(isAuthenticatedAtom)) return 'signed-out';
+    if (!get(isProfileLoadedAtom)) return 'connecting';
+    if (get(updateRequiredAtom)) return 'update-required';
+    if (get(pendingDowngradeAckAtom)) return 'downgrade-ack';
+    if (get(pendingUpgradeConsentAtom)) return 'upgrade-consent';
+    // Free users need to have authorized free access only; Pro users need
+    // authorized access, completed onboarding, and at least one library.
+    const needsOnboarding = get(isDatabaseSyncSupportedAtom)
+        ? (!get(hasAuthorizedProAccessAtom) || !get(hasCompletedOnboardingAtom) || get(syncedLibrariesAtom).length === 0)
+        : !get(hasAuthorizedFreeAccessAtom);
+    if (needsOnboarding) return 'onboarding';
+    return null;
+});

--- a/react/atoms/quickPrompt.ts
+++ b/react/atoms/quickPrompt.ts
@@ -11,9 +11,8 @@ import { isRunActive } from '@beaver/agent-core/agents/types';
 import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { isWSChatPendingAtom } from './agentRunAtoms';
-import { isAuthenticatedAtom } from './auth';
+import { chatAccessGateAtom } from './chatAccess';
 import { addItemsToCurrentMessageItemsAtom, currentReaderAttachmentAtom } from './messageComposition';
-import { isProfileLoadedAtom } from './profile';
 import { newThreadAtom } from './threads';
 import {
     isQuickPromptOpenAtom,
@@ -60,15 +59,22 @@ async function selectedReaderAnnotations(attachment: Zotero.Item | null): Promis
 let openInFlight: Promise<void> | null = null;
 
 /**
- * Opens the quick prompt. With no run live, the open thread is left the way
- * "New chat" leaves it — cleared, with the current selection or open file
- * attached, plus the annotations selected in the reader — but the draft is
- * kept: Escape closes the popup without losing what was typed, and reopening
- * it goes through here again.
+ * Opens the quick prompt. When the account cannot start a chat, the popup says
+ * why and offers to open Beaver, which shows the screen that resolves it — the
+ * same gates the sidebar puts before its composer. With no run live, the open
+ * thread is left the way "New chat" leaves it — cleared, with the current
+ * selection or open file attached, plus the annotations selected in the
+ * reader — but the draft is kept: Escape closes the popup without losing what
+ * was typed, and reopening it goes through here again.
  */
 export const openQuickPromptAtom = atom(null, async (get, set) => {
     if (openInFlight) return openInFlight;
     openInFlight = (async () => {
+        const gate = get(chatAccessGateAtom);
+        if (gate) {
+            set(quickPromptStateAtom, { mode: 'blocked', reason: gate });
+            return;
+        }
         if (get(hasActiveWorkAtom)) {
             set(quickPromptStateAtom, { mode: 'busy' });
             return;
@@ -98,15 +104,13 @@ export const closeQuickPromptAtom = atom(null, (_get, set) => {
 export type QuickPromptToggleOutcome =
     /** The sidebar is open, so its composer is the place to type. */
     | 'focus-sidebar'
-    /** Beaver is not ready for a chat (signed out, profile not loaded); open it. */
-    | 'open-sidebar'
     | 'closed'
+    /** The popup is up: the composer, or a notice saying why not. */
     | 'opened';
 
 /**
  * The shortcut's action. The popup only stands in for a closed sidebar, so
- * with the sidebar open the shortcut focuses its composer instead, and when
- * Beaver cannot chat yet the sidebar is the surface that explains why.
+ * with the sidebar open the shortcut focuses its composer instead.
  */
 export const toggleQuickPromptAtom = atom(null, async (get, set): Promise<QuickPromptToggleOutcome> => {
     if (get(isSidebarVisibleAtom)) return 'focus-sidebar';
@@ -118,7 +122,6 @@ export const toggleQuickPromptAtom = atom(null, async (get, set): Promise<QuickP
         set(closeQuickPromptAtom);
         return 'closed';
     }
-    if (!get(isAuthenticatedAtom) || !get(isProfileLoadedAtom)) return 'open-sidebar';
     await set(openQuickPromptAtom);
     return 'opened';
 });

--- a/react/atoms/quickPrompt.ts
+++ b/react/atoms/quickPrompt.ts
@@ -1,0 +1,124 @@
+/**
+ * The quick prompt: a composer in the corner of the main window while the
+ * sidebar is closed, for starting a new chat without opening Beaver. The run
+ * it starts is reported by the run status popup in the same corner.
+ *
+ * The state atom itself lives in `./ui` with the other surface flags; this
+ * module holds the actions on it.
+ */
+import { atom } from 'jotai';
+import { isRunActive } from '@beaver/agent-core/agents/types';
+import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
+import { logger } from '@beaver/agent-core/platform/logger';
+import { isWSChatPendingAtom } from './agentRunAtoms';
+import { isAuthenticatedAtom } from './auth';
+import { addItemsToCurrentMessageItemsAtom, currentReaderAttachmentAtom } from './messageComposition';
+import { isProfileLoadedAtom } from './profile';
+import { newThreadAtom } from './threads';
+import {
+    isQuickPromptOpenAtom,
+    isSidebarVisibleAtom,
+    isThreadListViewAtom,
+    quickPromptStateAtom,
+    type QuickPromptMode,
+    type QuickPromptState,
+} from './ui';
+import { getCurrentReader } from '../utils/readerUtils';
+
+export { isQuickPromptOpenAtom, quickPromptStateAtom };
+export type { QuickPromptMode, QuickPromptState };
+
+/** Whether the open thread has a run that a send right now would join or stop. */
+export const hasActiveWorkAtom = atom(
+    (get) => get(isWSChatPendingAtom) || isRunActive(get(activeRunAtom)),
+);
+
+/**
+ * The annotations selected in the open reader, as message items. Only for a
+ * reader whose file is the staged attachment: that atom is set by the same
+ * new-thread step and only for a searchable library, so an excluded library's
+ * annotations never get this far.
+ */
+async function selectedReaderAnnotations(attachment: Zotero.Item | null): Promise<Zotero.Item[]> {
+    const reader = getCurrentReader();
+    if (!reader || !attachment || reader.itemID !== attachment.id) return [];
+    const keys: string[] = reader._internalReader?._state?.selectedAnnotationIDs ?? [];
+    if (keys.length === 0) return [];
+    const items: Zotero.Item[] = [];
+    for (const key of keys) {
+        const item = await Zotero.Items.getByLibraryAndKeyAsync(attachment.libraryID, key);
+        if (item && item.isAnnotation()) items.push(item);
+    }
+    return items;
+}
+
+/**
+ * An open in progress. A real keystroke can reach the shortcut twice in quick
+ * succession; the second must not read the first's finished state as a popup
+ * to close.
+ */
+let openInFlight: Promise<void> | null = null;
+
+/**
+ * Opens the quick prompt. With no run live, the open thread is left the way
+ * "New chat" leaves it — cleared, with the current selection or open file
+ * attached, plus the annotations selected in the reader — but the draft is
+ * kept: Escape closes the popup without losing what was typed, and reopening
+ * it goes through here again.
+ */
+export const openQuickPromptAtom = atom(null, async (get, set) => {
+    if (openInFlight) return openInFlight;
+    openInFlight = (async () => {
+        if (get(hasActiveWorkAtom)) {
+            set(quickPromptStateAtom, { mode: 'busy' });
+            return;
+        }
+        // The sidebar may have been left on the chat list; the send should land
+        // in the thread view when Beaver is next opened.
+        set(isThreadListViewAtom, false);
+        // No confirmation: there is no live work to interrupt (checked above), and
+        // a run that slips in meanwhile must not raise a modal from a hotkey.
+        await set(newThreadAtom, { skipActiveRunConfirm: true, preserveDraft: true });
+        try {
+            const annotations = await selectedReaderAnnotations(get(currentReaderAttachmentAtom));
+            if (annotations.length > 0) await set(addItemsToCurrentMessageItemsAtom, annotations);
+        } catch (error) {
+            logger(`openQuickPromptAtom: could not attach the selected annotations: ${error}`, 1);
+        }
+        set(quickPromptStateAtom, { mode: 'compose' });
+    })().finally(() => { openInFlight = null; });
+    return openInFlight;
+});
+
+export const closeQuickPromptAtom = atom(null, (_get, set) => {
+    set(quickPromptStateAtom, null);
+});
+
+/** What the quick prompt shortcut did; the caller dispatches the UI events. */
+export type QuickPromptToggleOutcome =
+    /** The sidebar is open, so its composer is the place to type. */
+    | 'focus-sidebar'
+    /** Beaver is not ready for a chat (signed out, profile not loaded); open it. */
+    | 'open-sidebar'
+    | 'closed'
+    | 'opened';
+
+/**
+ * The shortcut's action. The popup only stands in for a closed sidebar, so
+ * with the sidebar open the shortcut focuses its composer instead, and when
+ * Beaver cannot chat yet the sidebar is the surface that explains why.
+ */
+export const toggleQuickPromptAtom = atom(null, async (get, set): Promise<QuickPromptToggleOutcome> => {
+    if (get(isSidebarVisibleAtom)) return 'focus-sidebar';
+    if (openInFlight) {
+        await openInFlight;
+        return 'opened';
+    }
+    if (get(quickPromptStateAtom)) {
+        set(closeQuickPromptAtom);
+        return 'closed';
+    }
+    if (!get(isAuthenticatedAtom) || !get(isProfileLoadedAtom)) return 'open-sidebar';
+    await set(openQuickPromptAtom);
+    return 'opened';
+});

--- a/react/atoms/threads.ts
+++ b/react/atoms/threads.ts
@@ -299,7 +299,16 @@ export const threadNavigationSeqAtom = atom(0);
  */
 export const newThreadAtom = atom(
     null,
-    async (get, set, options?: { skipAutoPopulate?: boolean; skipActiveRunConfirm?: boolean }) => {
+    async (
+        get,
+        set,
+        options?: {
+            skipAutoPopulate?: boolean;
+            skipActiveRunConfirm?: boolean;
+            /** Keep the composer's text and pills; attachments are still reset. */
+            preserveDraft?: boolean;
+        },
+    ) => {
         // Show loading state immediately if there's an active run to cancel.
         // Gated on run status, not presence: a run that failed keeps sitting in
         // activeRunAtom, and prompting over it claims Beaver is still working.
@@ -348,7 +357,7 @@ export const newThreadAtom = atom(
             set(citationsAtom, []);
             set(resetCitationMarkersAtom);
             resetRunSelectorCaches();
-            set(clearComposerAtom);
+            if (!options?.preserveDraft) set(clearComposerAtom);
             set(resetMessageUIStateAtom);
             set(clearExternalReferenceCacheAtom);
             // Update message items from Zotero selection or reader

--- a/react/atoms/ui.ts
+++ b/react/atoms/ui.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai';
+import type { ChatAccessGate } from './chatAccess';
 import { PopupMessage, PopupMessageType } from '../types/popupMessage';
 import { ExternalReference } from '@beaver/agent-core/types/externalReferences';
 import { getPref } from '../../src/utils/prefs';
@@ -45,19 +46,23 @@ export const isBeaverUIVisibleAtom = atom(
 /**
  * The quick prompt: a composer in the corner of the main window while the
  * sidebar is closed (react/components/quickPrompt). `compose` shows the
- * composer on a fresh thread; `busy` shows a notice because the open thread's
- * run is still live. Fixed at open time so a send from the composer does not
- * flip it into the notice before the popup closes.
+ * composer on a fresh thread; the other modes show a notice instead. Fixed at
+ * open time so a send from the composer does not flip it into the busy notice
+ * before the popup closes.
  *
  * Defined here, beside the other surface flags, because it is one of the
  * surfaces `isBeaverUIVisibleAtom` counts: reader tracking (the open file,
  * its text selection) runs for it the way it runs for the sidebar.
  */
-export type QuickPromptMode = 'compose' | 'busy';
+export type QuickPromptMode = 'compose' | 'busy' | 'blocked';
 
-export interface QuickPromptState {
-    mode: QuickPromptMode;
-}
+export type QuickPromptState =
+    /** The composer, on a fresh thread. */
+    | { mode: 'compose' }
+    /** A notice: the open thread's run is still live. */
+    | { mode: 'busy' }
+    /** A notice: the account cannot start a chat until something is resolved in Beaver. */
+    | { mode: 'blocked'; reason: ChatAccessGate };
 
 export const quickPromptStateAtom = atom<QuickPromptState | null>(null);
 

--- a/react/atoms/ui.ts
+++ b/react/atoms/ui.ts
@@ -39,8 +39,29 @@ export const isBeaverWindowOpenAtom = atom(false);
  * alone leaves those atoms empty for window-only users.
  */
 export const isBeaverUIVisibleAtom = atom(
-    (get) => get(isSidebarVisibleAtom) || get(isBeaverWindowOpenAtom),
+    (get) => get(isSidebarVisibleAtom) || get(isBeaverWindowOpenAtom) || get(isQuickPromptOpenAtom),
 );
+
+/**
+ * The quick prompt: a composer in the corner of the main window while the
+ * sidebar is closed (react/components/quickPrompt). `compose` shows the
+ * composer on a fresh thread; `busy` shows a notice because the open thread's
+ * run is still live. Fixed at open time so a send from the composer does not
+ * flip it into the notice before the popup closes.
+ *
+ * Defined here, beside the other surface flags, because it is one of the
+ * surfaces `isBeaverUIVisibleAtom` counts: reader tracking (the open file,
+ * its text selection) runs for it the way it runs for the sidebar.
+ */
+export type QuickPromptMode = 'compose' | 'busy';
+
+export interface QuickPromptState {
+    mode: QuickPromptMode;
+}
+
+export const quickPromptStateAtom = atom<QuickPromptState | null>(null);
+
+export const isQuickPromptOpenAtom = atom((get) => get(quickPromptStateAtom) !== null);
 
 export const isLibraryTabAtom = atom(false);
 export const selectedZoteroTabIdAtom = atom<string | null>(null);

--- a/react/components/FloatingPopupRoot.tsx
+++ b/react/components/FloatingPopupRoot.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import FloatingPopupContainer from './ui/popup/FloatingPopupContainer';
+import QuickPromptPopup from './quickPrompt/QuickPromptPopup';
 import RunStatusPopup from './runStatusPopup/RunStatusPopup';
 
 const FloatingPopupRoot: React.FC = () => {
@@ -8,6 +9,7 @@ const FloatingPopupRoot: React.FC = () => {
     return (
         <div ref={containerRef} className="display-flex flex-col">
             <FloatingPopupContainer />
+            <QuickPromptPopup />
             <RunStatusPopup />
         </div>
     );

--- a/react/components/Sidebar.tsx
+++ b/react/components/Sidebar.tsx
@@ -21,7 +21,6 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import ProfileLoadingPage from './pages/ProfileLoadingPage';
 import OnboardingRouter from './pages/OnboardingRouter';
-import { isAuthenticatedAtom } from '../atoms/auth';
 import DragDropWrapper from './input/DragDropWrapper';
 import DialogContainer from './dialog/DialogContainer';
 import ThreadListView from './ThreadListView';
@@ -30,22 +29,13 @@ import EmbeddingIndexBar from './input/EmbeddingIndexBar';
 import UpgradeConsentPage from './pages/UpgradeConsentPage';
 import DowngradeAcknowledgmentPage from './pages/DowngradeAcknowledgmentPage';
 import { store } from '../store';
-import { isLoadingThreadAtom } from '../atoms/threads';
+import { chatAccessGateAtom } from '../atoms/chatAccess';
 import { Spinner } from './icons/icons';
 import { threadWarningsAtom } from '../atoms/warnings';
 import PopupOverlayContainer from './PopupOverlayContainer';
 import {
-    hasAuthorizedFreeAccessAtom,
-    hasAuthorizedProAccessAtom,
-    hasCompletedOnboardingAtom,
-    isProfileLoadedAtom,
     isMigratingDataAtom,
     profileWithPlanAtom,
-    syncedLibrariesAtom,
-    isDatabaseSyncSupportedAtom,
-    pendingUpgradeConsentAtom,
-    pendingDowngradeAckAtom,
-    updateRequiredAtom
 } from '../atoms/profile';
 import UpdateRequiredPage from './pages/UpdateRequiredPage';
 import FirstRunPage from './pages/FirstRunPage';
@@ -195,22 +185,12 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
         messagesContainerRef.current = node;
         setMessagesContainer(node);
     }, []);
-    const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+    const chatAccessGate = useAtomValue(chatAccessGateAtom);
     const setIsSkippedFilesDialogVisible = useSetAtom(isSkippedFilesDialogVisibleAtom);
-    const hasCompletedOnboarding = useAtomValue(hasCompletedOnboardingAtom);
-    const hasAuthorizedFreeAccess = useAtomValue(hasAuthorizedFreeAccessAtom);
-    const hasAuthorizedProAccess = useAtomValue(hasAuthorizedProAccessAtom);
-    const syncedLibraries = useAtomValue(syncedLibrariesAtom);
-    const isDatabaseSyncSupported = useAtomValue(isDatabaseSyncSupportedAtom);
-    const isProfileLoaded = useAtomValue(isProfileLoadedAtom);
-    const isLoadingThread = useAtomValue(isLoadingThreadAtom);
     const isMigratingData = useAtomValue(isMigratingDataAtom);
     const isThreadListView = useAtomValue(isThreadListViewAtom);
     const setIsThreadListView = useSetAtom(isThreadListViewAtom);
 
-    const pendingUpgradeConsent = useAtomValue(pendingUpgradeConsentAtom);
-    const pendingDowngradeAck = useAtomValue(pendingDowngradeAckAtom);
-    const updateRequired = useAtomValue(updateRequiredAtom);
     const allWarnings = useAtomValue(threadWarningsAtom);
     const creditInfoWarning = allWarnings.findLast((w) => w.type === 'credit_info');
     const isFirstRunVisible = useAtomValue(isFirstRunVisibleAtom);
@@ -277,7 +257,10 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
         }
     };
 
-    if (isLoadingThread || isMigratingData) {
+    // The screens that stand before a chat, in the order the shared gate
+    // resolves them. The quick prompt reads the same atom, so the two surfaces
+    // cannot disagree about whether a chat may start.
+    if (chatAccessGate === 'loading') {
         return (
             <SidebarShell
                 id="thread-loading"
@@ -298,7 +281,7 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
     }
 
     {/* Login page — only when there is no session at all. */}
-    if (!isAuthenticated) {
+    if (chatAccessGate === 'signed-out') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />
@@ -311,7 +294,7 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
     {/* Profile loading / connecting / offline / fatal-error page.
         Authenticated but profile not yet loaded — renders before LoginPage was the bug
         cause when a transient network failure cleared isProfileLoaded. */}
-    if (!isProfileLoaded) {
+    if (chatAccessGate === 'connecting') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />
@@ -322,7 +305,7 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
     }
 
     {/* Update required page - blocks access until user updates */}
-    if (updateRequired) {
+    if (chatAccessGate === 'update-required') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />
@@ -333,7 +316,7 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
     }
 
     {/* Plan transition: Downgrade acknowledgment page (Pro → Free) */}
-    if (pendingDowngradeAck) {
+    if (chatAccessGate === 'downgrade-ack') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />
@@ -344,7 +327,7 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
     }
 
     {/* Plan transition: Upgrade consent page (Free → Pro) */}
-    if (pendingUpgradeConsent) {
+    if (chatAccessGate === 'upgrade-consent') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />
@@ -354,15 +337,9 @@ const Sidebar = ({ location, isWindow = false }: SidebarProps) => {
         );
     }
 
-    {/* Onboarding page */}
-    {/* Free users: need has_authorized_free_access only (no full onboarding required) */}
-    {/* Pro users: need has_authorized_access AND has_completed_onboarding AND at least one library */}
-    const isFreeUser = !isDatabaseSyncSupported;
-    const needsOnboarding = isFreeUser 
-        ? !hasAuthorizedFreeAccess 
-        : (!hasAuthorizedProAccess || !hasCompletedOnboarding || syncedLibraries.length === 0);
-    
-    if (needsOnboarding) {
+    {/* Onboarding page: free users need to have authorized free access;
+        Pro users need authorized access, completed onboarding, and a library. */}
+    if (chatAccessGate === 'onboarding') {
         return (
             <SidebarShell isWindow={isWindow}>
                 <Header isWindow={isWindow} />

--- a/react/components/input/InputArea.tsx
+++ b/react/components/input/InputArea.tsx
@@ -587,7 +587,7 @@ const InputArea: React.FC<InputAreaProps> = ({
     const webSearchDescription = isWebSearchAllowed
         ? (isWebSearchEnabled ? 'Web search is enabled.' : 'Web search is disabled.')
         : 'Web search is unavailable. It requires Beaver credits. Use a Beaver model, or enable Plus Tools in Settings, API Keys.';
-    const menuPortalContainer = inputRef.current?.closest('[id^="beaver-react-root-"], #beaver-pane-window') as HTMLElement | null;
+    const menuPortalContainer = inputRef.current?.closest('[id^="beaver-react-root-"], #beaver-pane-window, #beaver-pane-floating-popup') as HTMLElement | null;
 
     return (
         <div

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -212,6 +212,7 @@ const PreferencePage: React.FC = () => {
     const rebuildIndexButtonProps = getRebuildIndexButtonProps();
     const sidebarShortcutLabel = `${Zotero.isMac ? '⌘' : 'Ctrl'}+${keyboardShortcut}`;
     const windowShortcutLabel = `${Zotero.isMac ? '⌘⇧' : 'Ctrl+Shift'}+${keyboardShortcut}`;
+    const quickPromptShortcutLabel = `${Zotero.isMac ? '⌘⌥' : 'Ctrl+Alt'}+${keyboardShortcut}`;
     type VisiblePreferencePageTab = Exclude<PreferencePageTab, 'account'>;
     interface PreferenceTabDefinition {
         id: VisiblePreferencePageTab;
@@ -381,7 +382,7 @@ const PreferencePage: React.FC = () => {
                         <SettingsGroup>
                             <SettingsRow
                                 title="Keyboard Shortcut"
-                                description={<>Sidebar: {sidebarShortcutLabel} &middot; Window: {windowShortcutLabel} &middot; Changes require restart</>}
+                                description={<>Sidebar: {sidebarShortcutLabel} &middot; Window: {windowShortcutLabel} &middot; Quick prompt: {quickPromptShortcutLabel} &middot; Changes require restart</>}
                                 control={
                                     <select
                                         id="keyboard-shortcut"

--- a/react/components/quickPrompt/QuickPromptPopup.tsx
+++ b/react/components/quickPrompt/QuickPromptPopup.tsx
@@ -5,11 +5,13 @@ import { isImeKeyEvent } from '@beaver/agent-ui/primitives/ime';
 import Button from '@beaver/agent-ui/primitives/Button';
 import IconButton from '@beaver/agent-ui/primitives/IconButton';
 import Tooltip from '@beaver/agent-ui/primitives/Tooltip';
-import { ArrowUpRightIcon, CancelIcon } from '../icons/icons';
+import { AlertIcon, ArrowUpRightIcon, CancelIcon, Icon, Spinner } from '../icons/icons';
 import { isWSChatPendingAtom } from '../../atoms/agentRunAtoms';
+import { chatAccessGateAtom, type ChatAccessGate } from '../../atoms/chatAccess';
 import {
     closeQuickPromptAtom,
     hasActiveWorkAtom,
+    openQuickPromptAtom,
     quickPromptStateAtom,
     toggleQuickPromptAtom,
 } from '../../atoms/quickPrompt';
@@ -42,6 +44,33 @@ const CloseButton: React.FC<{ onClose: () => void }> = ({ onClose }) => (
     </div>
 );
 
+/** A card that says why the composer is not here, with the way to Beaver. */
+const NoticeCard: React.FC<{
+    mark: React.ReactNode;
+    title: string;
+    detail: string;
+    onClose: () => void;
+}> = ({ mark, title, detail, onClose }) => (
+    <div className="beaver-quick-prompt__card beaver-quick-prompt__card--busy">
+        <CloseButton onClose={onClose} />
+        <div className="beaver-quick-prompt__notice">
+            <div className="beaver-quick-prompt__notice-mark">{mark}</div>
+            <div className="beaver-quick-prompt__notice-text">
+                <div className="font-color-primary beaver-quick-prompt__notice-title">{title}</div>
+                <div className="font-color-secondary beaver-quick-prompt__notice-detail" title={detail}>
+                    {detail}
+                </div>
+            </div>
+        </div>
+        <div className="beaver-quick-prompt__footer">
+            <div className="flex-1" />
+            <Button variant="outline" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={openBeaver}>
+                Open Beaver
+            </Button>
+        </div>
+    </div>
+);
+
 /**
  * Shown instead of the composer while the open thread's run is live: one chat
  * runs at a time, so a message typed now would either join that chat or have
@@ -52,24 +81,63 @@ const BusyNotice: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     const activeRun = useAtomValue(activeRunAtom);
     const name = threadDisplayName(threadName, activeRun);
     return (
-        <div className="beaver-quick-prompt__card beaver-quick-prompt__card--busy">
-            <CloseButton onClose={onClose} />
-            <div className="beaver-quick-prompt__notice">
-                <div className="beaver-quick-prompt__notice-mark"><RunPulse /></div>
-                <div className="beaver-quick-prompt__notice-text">
-                    <div className="font-color-primary beaver-quick-prompt__notice-title">Beaver is still working</div>
-                    <div className="font-color-secondary beaver-quick-prompt__notice-detail" title={name}>
-                        Wait for “{name}” to finish, or open Beaver to start another chat.
-                    </div>
-                </div>
-            </div>
-            <div className="beaver-quick-prompt__footer">
-                <div className="flex-1" />
-                <Button variant="outline" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={openBeaver}>
-                    Open Beaver
-                </Button>
-            </div>
-        </div>
+        <NoticeCard
+            mark={<RunPulse />}
+            title="Beaver is still working"
+            detail={`Wait for “${name}” to finish, or open Beaver to start another chat.`}
+            onClose={onClose}
+        />
+    );
+};
+
+/**
+ * What each account state says. Beaver itself shows the screen that resolves
+ * the state, so every notice points there; the loading ones need no action
+ * and the popup moves on to the composer by itself once Beaver is ready.
+ */
+const BLOCKED_COPY: Record<ChatAccessGate, { title: string; detail: string }> = {
+    loading: {
+        title: 'Beaver is still loading',
+        detail: 'The chat opens here on its own as soon as Beaver is ready.',
+    },
+    connecting: {
+        title: 'Beaver is still loading',
+        detail: 'The chat opens here on its own as soon as Beaver is ready.',
+    },
+    'signed-out': {
+        title: 'Sign in to use Beaver',
+        detail: 'Open Beaver to sign in, then press the shortcut again.',
+    },
+    'update-required': {
+        title: 'Update Beaver to continue',
+        detail: 'This version of Beaver is no longer supported. Open Beaver to see how to update.',
+    },
+    'downgrade-ack': {
+        title: 'Your plan has changed',
+        detail: 'Open Beaver to review what changed before starting a chat.',
+    },
+    'upgrade-consent': {
+        title: 'Review your new plan',
+        detail: 'Your account moved to a plan that syncs data with Beaver. Open Beaver to review and agree before starting a chat.',
+    },
+    onboarding: {
+        title: 'Finish setting up Beaver',
+        detail: 'Open Beaver to complete setup before starting a chat.',
+    },
+};
+
+const LOADING_GATES: ReadonlySet<ChatAccessGate> = new Set(['loading', 'connecting']);
+
+/** Shown instead of the composer while the account cannot start a chat. */
+const BlockedNotice: React.FC<{ reason: ChatAccessGate; onClose: () => void }> = ({ reason, onClose }) => {
+    const copy = BLOCKED_COPY[reason];
+    return (
+        <NoticeCard
+            mark={LOADING_GATES.has(reason) ? <Spinner size={16} /> : <Icon icon={AlertIcon} size={16} className="font-color-secondary" />}
+            title={copy.title}
+            detail={copy.detail}
+            onClose={onClose}
+        />
     );
 };
 
@@ -88,8 +156,10 @@ const QuickPromptPopup: React.FC = () => {
     const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
     const isPending = useAtomValue(isWSChatPendingAtom);
     const hasActiveWork = useAtomValue(hasActiveWorkAtom);
+    const chatAccessGate = useAtomValue(chatAccessGateAtom);
     const selectedTabId = useAtomValue(selectedZoteroTabIdAtom);
     const toggle = useSetAtom(toggleQuickPromptAtom);
+    const open = useSetAtom(openQuickPromptAtom);
     const close = useSetAtom(closeQuickPromptAtom);
     const rootRef = useRef<HTMLDivElement>(null);
     // The tab the popup was opened in. Its attachments — the open file, a
@@ -121,9 +191,6 @@ const QuickPromptPopup: React.FC = () => {
                 case 'focus-sidebar':
                     eventManager.dispatch('focusInput', {});
                     break;
-                case 'open-sidebar':
-                    openBeaver();
-                    break;
                 case 'closed':
                     dismiss();
                     break;
@@ -138,7 +205,9 @@ const QuickPromptPopup: React.FC = () => {
     // the same draft and thread), when the message it composed has been sent
     // (the run status popup takes over), and when the run it was waiting on
     // has finished (that popup reports the outcome; the shortcut reopens a
-    // composer).
+    // composer). A notice about the account moves on to what the user asked
+    // for, the composer, once the account can chat — Beaver finished loading,
+    // or the screen the notice pointed to has been completed.
     useEffect(() => {
         if (!state) return;
         if (isSidebarVisible) {
@@ -147,8 +216,10 @@ const QuickPromptPopup: React.FC = () => {
             dismiss();
         } else if (state.mode === 'busy' && !hasActiveWork) {
             dismiss();
+        } else if (state.mode === 'blocked' && chatAccessGate === null) {
+            void open();
         }
-    }, [state, isSidebarVisible, isPending, hasActiveWork, close, dismiss]);
+    }, [state, isSidebarVisible, isPending, hasActiveWork, chatAccessGate, close, dismiss, open]);
 
     // Switching tabs closes the popup without touching focus: Zotero has just
     // moved it into the new tab, and the draft is kept for the next open.
@@ -182,11 +253,13 @@ const QuickPromptPopup: React.FC = () => {
             ref={rootRef}
             className="beaver-quick-prompt"
             role="dialog"
-            aria-label={state.mode === 'busy' ? 'Beaver is still working' : 'New chat with Beaver'}
+            aria-label={state.mode === 'compose' ? 'New chat with Beaver' : state.mode === 'busy' ? 'Beaver is still working' : BLOCKED_COPY[state.reason].title}
             onKeyDown={handleKeyDown}
         >
             {state.mode === 'busy' ? (
                 <BusyNotice onClose={dismiss} />
+            ) : state.mode === 'blocked' ? (
+                <BlockedNotice reason={state.reason} onClose={dismiss} />
             ) : (
                 <div className="beaver-quick-prompt__card">
                     <CloseButton onClose={dismiss} />

--- a/react/components/quickPrompt/QuickPromptPopup.tsx
+++ b/react/components/quickPrompt/QuickPromptPopup.tsx
@@ -1,0 +1,203 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { activeRunAtom, currentThreadNameAtom } from '@beaver/agent-core/run-state/atoms';
+import { isImeKeyEvent } from '@beaver/agent-ui/primitives/ime';
+import Button from '@beaver/agent-ui/primitives/Button';
+import IconButton from '@beaver/agent-ui/primitives/IconButton';
+import Tooltip from '@beaver/agent-ui/primitives/Tooltip';
+import { ArrowUpRightIcon, CancelIcon } from '../icons/icons';
+import { isWSChatPendingAtom } from '../../atoms/agentRunAtoms';
+import {
+    closeQuickPromptAtom,
+    hasActiveWorkAtom,
+    quickPromptStateAtom,
+    toggleQuickPromptAtom,
+} from '../../atoms/quickPrompt';
+import { isSidebarVisibleAtom, selectedZoteroTabIdAtom } from '../../atoms/ui';
+import { eventManager } from '../../events/eventManager';
+import { useEventSubscription } from '../../hooks/useEventSubscription';
+import { uiManager } from '../../ui/UIManager';
+import InputArea from '../input/InputArea';
+import PopupOverlayContainer from '../PopupOverlayContainer';
+import RunPulse from '../runStatusPopup/RunPulse';
+import { threadDisplayName } from '../runStatusPopup/runStatusPopupModel';
+
+/** The compact control sizing shared with the run status popup's footer. */
+const FOOTER_BUTTON_STYLE: React.CSSProperties = { padding: '2px 10px', fontSize: '0.875rem', whiteSpace: 'nowrap' };
+
+function openBeaver(): void {
+    eventManager.dispatch('toggleChat', { forceOpen: true });
+}
+
+/**
+ * The close control, in the card's top-right corner. Shown only while the
+ * pointer is over the card (see the stylesheet), so the card stays quiet;
+ * Escape does the same and the tooltip says so.
+ */
+const CloseButton: React.FC<{ onClose: () => void }> = ({ onClose }) => (
+    <div className="beaver-quick-prompt__dismiss">
+        <Tooltip content="Close" secondaryContent="Esc" showArrow singleLine>
+            <IconButton icon={CancelIcon} variant="ghost-secondary" onClick={onClose} ariaLabel="Close" />
+        </Tooltip>
+    </div>
+);
+
+/**
+ * Shown instead of the composer while the open thread's run is live: one chat
+ * runs at a time, so a message typed now would either join that chat or have
+ * to stop it. The run status popup below reports the run itself.
+ */
+const BusyNotice: React.FC<{ onClose: () => void }> = ({ onClose }) => {
+    const threadName = useAtomValue(currentThreadNameAtom);
+    const activeRun = useAtomValue(activeRunAtom);
+    const name = threadDisplayName(threadName, activeRun);
+    return (
+        <div className="beaver-quick-prompt__card beaver-quick-prompt__card--busy">
+            <CloseButton onClose={onClose} />
+            <div className="beaver-quick-prompt__notice">
+                <div className="beaver-quick-prompt__notice-mark"><RunPulse /></div>
+                <div className="beaver-quick-prompt__notice-text">
+                    <div className="font-color-primary beaver-quick-prompt__notice-title">Beaver is still working</div>
+                    <div className="font-color-secondary beaver-quick-prompt__notice-detail" title={name}>
+                        Wait for “{name}” to finish, or open Beaver to start another chat.
+                    </div>
+                </div>
+            </div>
+            <div className="beaver-quick-prompt__footer">
+                <div className="flex-1" />
+                <Button variant="outline" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={openBeaver}>
+                    Open Beaver
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * A composer in the corner of the main window while the sidebar is closed,
+ * opened by its keyboard shortcut. It sends into a fresh thread the way the
+ * sidebar's composer would, so the run it starts is picked up by the run
+ * status popup in the same corner; the popup closes as soon as the run
+ * starts. Escape closes it and keeps the draft.
+ *
+ * Always mounted: the shortcut's event needs a subscriber whether or not the
+ * popup is showing.
+ */
+const QuickPromptPopup: React.FC = () => {
+    const state = useAtomValue(quickPromptStateAtom);
+    const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
+    const isPending = useAtomValue(isWSChatPendingAtom);
+    const hasActiveWork = useAtomValue(hasActiveWorkAtom);
+    const selectedTabId = useAtomValue(selectedZoteroTabIdAtom);
+    const toggle = useSetAtom(toggleQuickPromptAtom);
+    const close = useSetAtom(closeQuickPromptAtom);
+    const rootRef = useRef<HTMLDivElement>(null);
+    // The tab the popup was opened in. Its attachments — the open file, a
+    // selection, selected items — belong to that tab, so it does not outlive it.
+    const openedInTabRef = useRef<{ tabId: string | null } | null>(null);
+    const inputRef = useRef<HTMLElement | null>(null);
+    // Where focus was when the shortcut fired (the items tree, a reader), to
+    // return there when the popup goes away.
+    const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+    const dismiss = useCallback(() => {
+        close();
+        const target = restoreFocusRef.current;
+        restoreFocusRef.current = null;
+        if (target && target.isConnected) {
+            target.focus();
+        } else {
+            uiManager.focusToggleButton();
+        }
+    }, [close]);
+
+    useEventSubscription('toggleQuickPrompt', () => {
+        const doc = Zotero.getMainWindow()?.document;
+        const active = doc?.activeElement as HTMLElement | null;
+        // The document itself is not a place to send focus back to.
+        const focused = active && active !== doc?.body && active !== doc?.documentElement ? active : null;
+        void toggle().then((outcome) => {
+            switch (outcome) {
+                case 'focus-sidebar':
+                    eventManager.dispatch('focusInput', {});
+                    break;
+                case 'open-sidebar':
+                    openBeaver();
+                    break;
+                case 'closed':
+                    dismiss();
+                    break;
+                case 'opened':
+                    restoreFocusRef.current = focused;
+                    break;
+            }
+        });
+    }, [toggle, dismiss]);
+
+    // The popup steps aside on its own: when the sidebar opens (it now shows
+    // the same draft and thread), when the message it composed has been sent
+    // (the run status popup takes over), and when the run it was waiting on
+    // has finished (that popup reports the outcome; the shortcut reopens a
+    // composer).
+    useEffect(() => {
+        if (!state) return;
+        if (isSidebarVisible) {
+            close();
+        } else if (state.mode === 'compose' && isPending) {
+            dismiss();
+        } else if (state.mode === 'busy' && !hasActiveWork) {
+            dismiss();
+        }
+    }, [state, isSidebarVisible, isPending, hasActiveWork, close, dismiss]);
+
+    // Switching tabs closes the popup without touching focus: Zotero has just
+    // moved it into the new tab, and the draft is kept for the next open.
+    useEffect(() => {
+        if (!state) {
+            openedInTabRef.current = null;
+            return;
+        }
+        if (!openedInTabRef.current) {
+            openedInTabRef.current = { tabId: selectedTabId };
+            return;
+        }
+        if (openedInTabRef.current.tabId !== selectedTabId) close();
+    }, [state, selectedTabId, close]);
+
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key !== 'Escape' || event.defaultPrevented || isImeKeyEvent(event.nativeEvent)) return;
+        // A menu the composer opened (actions, sources, model) owns Escape
+        // while it is up; menus are portalled to the floating root, so they
+        // are looked for there.
+        const host = rootRef.current?.closest('#beaver-pane-floating-popup') ?? rootRef.current;
+        if (host?.querySelector('[role="menu"], [role="listbox"]')) return;
+        event.preventDefault();
+        dismiss();
+    }, [dismiss]);
+
+    if (!state || isSidebarVisible) return null;
+
+    return (
+        <div
+            ref={rootRef}
+            className="beaver-quick-prompt"
+            role="dialog"
+            aria-label={state.mode === 'busy' ? 'Beaver is still working' : 'New chat with Beaver'}
+            onKeyDown={handleKeyDown}
+        >
+            {state.mode === 'busy' ? (
+                <BusyNotice onClose={dismiss} />
+            ) : (
+                <div className="beaver-quick-prompt__card">
+                    <CloseButton onClose={dismiss} />
+                    <div className="beaver-quick-prompt__composer">
+                        <PopupOverlayContainer />
+                        <InputArea inputRef={inputRef} verticalPosition="above" placeholder="Ask Beaver — @ to add a source, / for actions" />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default QuickPromptPopup;

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -320,34 +320,47 @@ const CardView: React.FC<{ card: RunStatusPopupCard }> = ({ card }) => {
  * first paint is not animated: a card appearing should not unfold from zero.
  */
 const AnimatedCard: React.FC<{ card: RunStatusPopupCard; children: React.ReactNode }> = ({ card, children }) => {
-    const innerRef = useRef<HTMLDivElement>(null);
     const [height, setHeight] = useState<number | null>(null);
+    // The height as last measured, so a measurement that finds it unchanged
+    // does not reach the setter: a setter called with the current value still
+    // schedules a re-render while the component has a store update pending.
+    const heightRef = useRef<number | null>(null);
     const [settled, setSettled] = useState(false);
+    const observed = useRef<{ element: HTMLElement; disconnect: () => void } | null>(null);
 
-    const measure = useCallback(() => {
-        const inner = innerRef.current;
-        if (inner) setHeight(inner.getBoundingClientRect().height);
-    }, []);
-
-    // Measured in the same frame the new state is laid out, so the transition
-    // starts at once; the observer below covers the content changing on its
-    // own afterwards (a tool label's item name arriving).
-    useLayoutEffect(measure, [card, measure]);
-
-    useLayoutEffect(() => {
-        const inner = innerRef.current;
-        const win = inner?.ownerDocument.defaultView;
-        if (!inner || !win) return;
+    // Measurement is subscribed to the content element: its size changes with
+    // every state the card moves through and with content arriving on its own
+    // (a tool label's item name), and the observer reports both from the
+    // browser's layout pass rather than after each render. The first
+    // measurement is taken as the element attaches, so the card is drawn at
+    // its height from the start.
+    const innerRef = useCallback((inner: HTMLDivElement | null) => {
+        if (observed.current?.element === inner) return;
+        observed.current?.disconnect();
+        observed.current = null;
+        if (!inner) return;
+        const win = inner.ownerDocument.defaultView;
+        if (!win) return;
+        const measure = () => {
+            const next = inner.getBoundingClientRect().height;
+            if (next === heightRef.current) return;
+            heightRef.current = next;
+            setHeight(next);
+        };
+        measure();
         // Second frame: the first measurement is drawn without a transition,
         // and every change after it is animated.
         const frame = win.requestAnimationFrame(() => setSettled(true));
         const observer = new win.ResizeObserver(measure);
         observer.observe(inner);
-        return () => {
-            win.cancelAnimationFrame(frame);
-            observer.disconnect();
+        observed.current = {
+            element: inner,
+            disconnect: () => {
+                win.cancelAnimationFrame(frame);
+                observer.disconnect();
+            },
         };
-    }, [measure]);
+    }, []);
 
     const handleClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
         if (isCardBackgroundClick(event)) card.onOpen();

--- a/react/events/types.ts
+++ b/react/events/types.ts
@@ -48,6 +48,8 @@ export interface BeaverEvents {
             | 'copy-ocr-fixture-command';
     };
     focusInput: Record<string, never>;
+    /** The quick prompt shortcut: open or close the closed-sidebar composer. */
+    toggleQuickPrompt: Record<string, never>;
     'background-worker:status': {
         running: boolean;
     };

--- a/react/hooks/httpHandlers/testQuickPromptHandlers.ts
+++ b/react/hooks/httpHandlers/testQuickPromptHandlers.ts
@@ -1,0 +1,41 @@
+/**
+ * Dev-only HTTP handler for the quick prompt (`react/components/quickPrompt`).
+ *
+ * `/beaver/test/quick-prompt` drives the closed-sidebar composer without the
+ * keyboard: `{ toggle: true }` runs the shortcut's own action (and reports
+ * what it did), `{ open: true }` / `{ open: false }` set the popup directly.
+ * Every call returns the popup's state. Wired to its path in
+ * `useHttpEndpoints.ts`.
+ */
+
+import { store } from '../../store';
+import {
+    closeQuickPromptAtom,
+    openQuickPromptAtom,
+    quickPromptStateAtom,
+    toggleQuickPromptAtom,
+    type QuickPromptToggleOutcome,
+} from '../../atoms/quickPrompt';
+import { isSidebarVisibleAtom } from '../../atoms/ui';
+import { currentThreadIdAtom } from '../../atoms/threads';
+import { runsCountAtom } from '@beaver/agent-core/run-state/atoms';
+import { currentMessageContentAtom } from '../../atoms/messageComposition';
+
+export async function handleTestQuickPromptHttpRequest(request: any): Promise<any> {
+    let outcome: QuickPromptToggleOutcome | null = null;
+    if (request?.toggle === true) {
+        outcome = await store.set(toggleQuickPromptAtom);
+    } else if (request?.open === true) {
+        await store.set(openQuickPromptAtom);
+    } else if (request?.open === false) {
+        store.set(closeQuickPromptAtom);
+    }
+    return {
+        outcome,
+        state: store.get(quickPromptStateAtom),
+        sidebarVisible: store.get(isSidebarVisibleAtom),
+        threadId: store.get(currentThreadIdAtom),
+        runCount: store.get(runsCountAtom),
+        draft: store.get(currentMessageContentAtom),
+    };
+}

--- a/react/hooks/httpHandlers/testQuickPromptHandlers.ts
+++ b/react/hooks/httpHandlers/testQuickPromptHandlers.ts
@@ -3,9 +3,10 @@
  *
  * `/beaver/test/quick-prompt` drives the closed-sidebar composer without the
  * keyboard: `{ toggle: true }` runs the shortcut's own action (and reports
- * what it did), `{ open: true }` / `{ open: false }` set the popup directly.
- * Every call returns the popup's state. Wired to its path in
- * `useHttpEndpoints.ts`.
+ * what it did), `{ open: true }` / `{ open: false }` set the popup directly,
+ * and `{ state: { mode: 'blocked', reason } }` draws a notice without the
+ * account being in that state. Every call returns the popup's state. Wired to
+ * its path in `useHttpEndpoints.ts`.
  */
 
 import { store } from '../../store';
@@ -29,6 +30,8 @@ export async function handleTestQuickPromptHttpRequest(request: any): Promise<an
         await store.set(openQuickPromptAtom);
     } else if (request?.open === false) {
         store.set(closeQuickPromptAtom);
+    } else if (request?.state && typeof request.state.mode === 'string') {
+        store.set(quickPromptStateAtom, request.state);
     }
     return {
         outcome,

--- a/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
+++ b/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
@@ -6,7 +6,9 @@
  * without a run in that state: `{ preview: { kind: 'approval', ... } }` sets
  * the preview card, `{ clear: true }` removes it, and `{ forceVisible: true }`
  * keeps the popup on screen while the sidebar is open. The preview's own
- * controls only clear the preview. Every field but `kind` is optional and
+ * controls only clear the preview. `{ completion: { runId } }` shows the real
+ * completed card for a run of the open thread, so its rows can be exercised
+ * without waiting for a run to finish with the sidebar closed. Every field but `kind` is optional and
  * falls back to sample copy — see `RunStatusPopupPreview`. `{ tip: true }`
  * shows the one-time onboarding tip about the popup (`tipInPanel` overrides
  * where it goes); `{ tip: false }` removes it.
@@ -45,6 +47,11 @@ export async function handleTestRunStatusPopupHttpRequest(request: any): Promise
     }
     if (request?.clearCompletion) {
         store.set(runStatusPopupCompletionAtom, null);
+    }
+    // Draw the completed card for a run of the open thread, as if it had just
+    // finished while the sidebar was closed; its rows act on the real run.
+    if (typeof request?.completion?.runId === 'string') {
+        store.set(runStatusPopupCompletionAtom, { runId: request.completion.runId, completedAt: Date.now() });
     }
     if (request?.preview) {
         const preview = request.preview as RunStatusPopupPreview;

--- a/react/hooks/httpHandlers/testSavedActionsHandlers.ts
+++ b/react/hooks/httpHandlers/testSavedActionsHandlers.ts
@@ -1,0 +1,21 @@
+/**
+ * Dev-only HTTP handler listing the saved actions with their slash commands,
+ * so a headless driver can send a /command pill through `/beaver/test/chat-send`.
+ */
+
+import { store } from '../../store';
+import { actionsAtom } from '../../atoms/actions';
+import { getActionCommand } from '@beaver/agent-ui/composer/slashCommands';
+import type { Action } from '@beaver/agent-core/types/actions';
+
+export async function handleTestListSavedActionsHttpRequest(_request: any): Promise<any> {
+    const actions: Action[] = store.get(actionsAtom);
+    return {
+        ok: true,
+        actions: actions.map((action) => ({
+            id: action.id,
+            title: action.title,
+            command: getActionCommand(action),
+        })),
+    };
+}

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -202,6 +202,7 @@ import {
 } from './httpHandlers/testTableHandlers';
 import { handleTestRunStatusPopupHttpRequest } from './httpHandlers/testRunStatusPopupHandlers';
 import { handleTestQuickPromptHttpRequest } from './httpHandlers/testQuickPromptHandlers';
+import { handleTestListSavedActionsHttpRequest } from './httpHandlers/testSavedActionsHandlers';
 import type {
     WSZoteroDataRequest,
     WSExternalReferenceCheckRequest,
@@ -417,6 +418,7 @@ const ENDPOINT_PATHS = [
     '/beaver/test/table-item-pane',
     '/beaver/test/run-status-popup',
     '/beaver/test/quick-prompt',
+    '/beaver/test/saved-actions',
 ] as const;
 
 /**
@@ -1471,6 +1473,9 @@ function registerEndpoints(): boolean {
 
         Zotero.Server.Endpoints['/beaver/test/quick-prompt'] =
             createEndpoint(handleTestQuickPromptHttpRequest);
+
+        Zotero.Server.Endpoints['/beaver/test/saved-actions'] =
+            createEndpoint(handleTestListSavedActionsHttpRequest);
     }
 
     logger(`useHttpEndpoints: Registered ${ENDPOINT_PATHS.length} HTTP endpoints`, 3);

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -201,6 +201,7 @@ import {
     handleTestTableViewStateHttpRequest,
 } from './httpHandlers/testTableHandlers';
 import { handleTestRunStatusPopupHttpRequest } from './httpHandlers/testRunStatusPopupHandlers';
+import { handleTestQuickPromptHttpRequest } from './httpHandlers/testQuickPromptHandlers';
 import type {
     WSZoteroDataRequest,
     WSExternalReferenceCheckRequest,
@@ -415,6 +416,7 @@ const ENDPOINT_PATHS = [
     // The item-pane section for a stored table (dev-only)
     '/beaver/test/table-item-pane',
     '/beaver/test/run-status-popup',
+    '/beaver/test/quick-prompt',
 ] as const;
 
 /**
@@ -1466,6 +1468,9 @@ function registerEndpoints(): boolean {
 
         Zotero.Server.Endpoints['/beaver/test/run-status-popup'] =
             createEndpoint(handleTestRunStatusPopupHttpRequest);
+
+        Zotero.Server.Endpoints['/beaver/test/quick-prompt'] =
+            createEndpoint(handleTestQuickPromptHttpRequest);
     }
 
     logger(`useHttpEndpoints: Registered ${ENDPOINT_PATHS.length} HTTP endpoints`, 3);

--- a/react/host/zotero/components/AgentActionView.tsx
+++ b/react/host/zotero/components/AgentActionView.tsx
@@ -135,8 +135,8 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
 
     // The footer's buttons never wrap; when the row is too narrow for them,
     // the permission trigger drops to its icon.
-    const footerRef = useRef<HTMLDivElement>(null);
-    const permissionIconOnly = useOverflowCollapse(footerRef, 1) >= 1;
+    const footer = useOverflowCollapse(1);
+    const permissionIconOnly = footer.level >= 1;
 
     const prevAwaitingRef = useRef(isAwaitingApproval);
     const hasInitializedRef = useRef(false);
@@ -704,7 +704,7 @@ export const AgentActionView: React.FC<AgentActionViewProps> = ({
                         </div>
                     )}
 
-                    <div ref={footerRef} className="display-flex flex-row items-center gap-2 px-2 py-2">
+                    <div ref={footer.ref} className="display-flex flex-row items-center gap-2 px-2 py-2">
                         {/* A cost confirmation has no permission control to offer:
                             what a request may spend is set once by the credit
                             limit. While the run is waiting on this card the

--- a/react/host/zotero/components/EditNoteGroupView.tsx
+++ b/react/host/zotero/components/EditNoteGroupView.tsx
@@ -743,10 +743,9 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
     // The footer's buttons never wrap (a two-line "Apply All" is unreadable).
     // When the row is too narrow for them, the permission trigger drops to
     // its icon first and the preview button second.
-    const footerRef = useRef<HTMLDivElement>(null);
-    const footerCollapseLevel = useOverflowCollapse(footerRef, 2);
-    const permissionIconOnly = footerCollapseLevel >= 1;
-    const previewIconOnly = footerCollapseLevel >= 2;
+    const footer = useOverflowCollapse(2);
+    const permissionIconOnly = footer.level >= 1;
+    const previewIconOnly = footer.level >= 2;
 
     const canShowPreview =
         !isProcessing
@@ -901,7 +900,7 @@ export const EditNoteGroupView: React.FC<EditNoteGroupViewProps> = ({
                     </div>
 
                     {(showFooterApply || showFooterReject || showFooterUndo || showFooterRetry || canShowPreview || hasPendingApprovals) && (
-                        <div ref={footerRef} className="display-flex flex-row items-center gap-2 px-2 py-2">
+                        <div ref={footer.ref} className="display-flex flex-row items-center gap-2 px-2 py-2">
                             {/* Only while the run is waiting on this card: once
                                 it is not, there is no run left to grant. */}
                             {hasPendingApprovals && (

--- a/src/ui/toggleChat.ts
+++ b/src/ui/toggleChat.ts
@@ -14,3 +14,12 @@ export function triggerToggleChat(win: Window) {
         location: location
     });
 }
+
+/**
+ * Toggle the quick prompt — the composer shown in the corner of the main
+ * window while the sidebar is closed. The React side decides what the
+ * shortcut does when the sidebar is open or Beaver is not signed in.
+ */
+export function triggerToggleQuickPrompt() {
+    eventManager.dispatch('toggleQuickPrompt', {});
+}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,5 +1,5 @@
 import { getLocaleID, getString } from "../utils/locale";
-import { triggerToggleChat } from "./toggleChat";
+import { triggerToggleChat, triggerToggleQuickPrompt } from "./toggleChat";
 import { initializeReactUI } from "../../react/ui/initialization";
 import { KeyboardManager } from "../utils/keyboardManager";
 import { getPref } from "../utils/prefs";
@@ -531,6 +531,25 @@ export class BeaverUIFactory {
                 if (isMacShortcut || isWindowsShortcut) {
                     ev.preventDefault();
                     this.openBeaverWindow();
+                }
+            }
+        );
+
+        // Register keyboard shortcut for the quick prompt (composer in the
+        // corner while the sidebar is closed).
+        // Mac: Cmd+Option+J, Windows/Linux: Ctrl+Alt+J
+        manager.register(
+            (ev) => {
+                // With Option held, macOS reports the key as the character it
+                // types (Option+J is "∆"), so the physical key is checked too.
+                const isShortcutKey = ev.key.toLowerCase() === keyboardShortcut
+                    || ev.code.toLowerCase() === `key${keyboardShortcut}`;
+                const isMacShortcut = Zotero.isMac && isShortcutKey && ev.metaKey && ev.altKey && !ev.ctrlKey && !ev.shiftKey;
+                const isWindowsShortcut = !Zotero.isMac && isShortcutKey && ev.ctrlKey && ev.altKey && !ev.shiftKey && !ev.metaKey;
+
+                if (isMacShortcut || isWindowsShortcut) {
+                    ev.preventDefault();
+                    triggerToggleQuickPrompt();
                 }
             }
         );

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -2,6 +2,7 @@ import { getLocaleID, getString } from "../utils/locale";
 import { triggerToggleChat, triggerToggleQuickPrompt } from "./toggleChat";
 import { initializeReactUI } from "../../react/ui/initialization";
 import { KeyboardManager } from "../utils/keyboardManager";
+import { isQuickPromptShortcut } from "../utils/shortcuts";
 import { getPref } from "../utils/prefs";
 import { PreferencePageTab } from "../../react/atoms/ui";
 import { ActionCategoryFilter } from "@beaver/agent-core/types/actions";
@@ -540,14 +541,7 @@ export class BeaverUIFactory {
         // Mac: Cmd+Option+J, Windows/Linux: Ctrl+Alt+J
         manager.register(
             (ev) => {
-                // With Option held, macOS reports the key as the character it
-                // types (Option+J is "∆"), so the physical key is checked too.
-                const isShortcutKey = ev.key.toLowerCase() === keyboardShortcut
-                    || ev.code.toLowerCase() === `key${keyboardShortcut}`;
-                const isMacShortcut = Zotero.isMac && isShortcutKey && ev.metaKey && ev.altKey && !ev.ctrlKey && !ev.shiftKey;
-                const isWindowsShortcut = !Zotero.isMac && isShortcutKey && ev.ctrlKey && ev.altKey && !ev.shiftKey && !ev.metaKey;
-
-                if (isMacShortcut || isWindowsShortcut) {
+                if (isQuickPromptShortcut(ev, keyboardShortcut, Zotero.isMac)) {
                     ev.preventDefault();
                     triggerToggleQuickPrompt();
                 }

--- a/src/utils/keyboardManager.ts
+++ b/src/utils/keyboardManager.ts
@@ -284,7 +284,23 @@ export class KeyboardManager {
         }
     };
 
+    /**
+     * The last key event handed to the callbacks. A keystroke inside a reader
+     * tab propagates through the reader's window and then the main window,
+     * and listeners are installed on both, so the same event arrives here
+     * twice — and, with microtasks running between the two deliveries, the
+     * second one can observe state the first has already changed. One
+     * physical keystroke is dispatched once.
+     */
+    private _lastDispatched: { type: string; timeStamp: number; key: string; code: string } | null = null;
+
     private dispatchCallback(...args: [KeyboardEvent, { keyboard?: KeyModifier; type: "keydown" | "keyup" }]) {
+        const e = args[0];
+        const last = this._lastDispatched;
+        if (last && last.type === e.type && last.timeStamp === e.timeStamp && last.key === e.key && last.code === e.code) {
+            return;
+        }
+        this._lastDispatched = { type: e.type, timeStamp: e.timeStamp, key: e.key, code: e.code };
         for (const callback of this._keyboardCallbacks) {
             try {
                 callback(...args);

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -1,0 +1,41 @@
+/**
+ * Keyboard chord matching for Beaver's shortcuts. Pure, so the platform and
+ * the configured key are parameters rather than globals.
+ */
+
+/** The parts of a keyboard event a chord is decided from. */
+export interface ChordEvent {
+    key: string;
+    code: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    shiftKey: boolean;
+    getModifierState?: (key: string) => boolean;
+}
+
+/**
+ * Whether the event is the quick prompt chord: Cmd+Option+<key> on macOS,
+ * Ctrl+Alt+<key> elsewhere.
+ *
+ * The configured key is matched by the character typed or by the physical
+ * key. On macOS, Option changes the character (Option+J is "∆") and Gecko also
+ * reports the AltGraph state for it, so there the physical key decides and the
+ * state is ignored. On Windows and Linux, AltGr arrives as Ctrl+Alt with the
+ * AltGraph state, and on layouts that use it the same physical key types a
+ * character (AltGr+Q is "@" on a German keyboard). Under that state only the
+ * typed character may match: a key that produced another character is text
+ * entry, and taking it would swallow the character.
+ */
+export function isQuickPromptShortcut(event: ChordEvent, shortcutKey: string, isMac: boolean): boolean {
+    const key = shortcutKey.toLowerCase();
+    const typedKeyMatches = event.key.toLowerCase() === key;
+    const physicalKeyMatches = event.code.toLowerCase() === `key${key}`;
+    if (isMac) {
+        return (typedKeyMatches || physicalKeyMatches)
+            && event.metaKey && event.altKey && !event.ctrlKey && !event.shiftKey;
+    }
+    const altGraph = event.getModifierState?.('AltGraph') ?? false;
+    const keyMatches = typedKeyMatches || (!altGraph && physicalKeyMatches);
+    return keyMatches && event.ctrlKey && event.altKey && !event.shiftKey && !event.metaKey;
+}

--- a/tests/unit/atoms/quickPrompt.test.ts
+++ b/tests/unit/atoms/quickPrompt.test.ts
@@ -1,0 +1,222 @@
+/**
+ * What the quick prompt shortcut does, and how opening the popup prepares the
+ * thread it composes into.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'jotai';
+
+const mocks = vi.hoisted(() => ({
+    newThread: vi.fn(async (_options?: unknown) => {}),
+    addItems: vi.fn(async (_items: unknown) => {}),
+    reader: null as any,
+    annotationItems: new Map<string, any>(),
+}));
+
+vi.mock('../../../react/atoms/threads', async () => {
+    const { atom } = await import('jotai');
+    return {
+        newThreadAtom: atom(null, async (_get, _set, options?: unknown) => mocks.newThread(options)),
+    };
+});
+vi.mock('../../../react/atoms/agentRunAtoms', async () => {
+    const { atom } = await import('jotai');
+    return { isWSChatPendingAtom: atom(false) };
+});
+vi.mock('../../../react/atoms/auth', async () => {
+    const { atom } = await import('jotai');
+    return { isAuthenticatedAtom: atom(true) };
+});
+vi.mock('../../../react/atoms/profile', async () => {
+    const { atom } = await import('jotai');
+    return { isProfileLoadedAtom: atom(true) };
+});
+vi.mock('../../../react/atoms/ui', async () => {
+    const { atom } = await import('jotai');
+    const quickPromptStateAtom = atom<{ mode: string } | null>(null);
+    return {
+        isSidebarVisibleAtom: atom(false),
+        isThreadListViewAtom: atom(false),
+        quickPromptStateAtom,
+        isQuickPromptOpenAtom: atom((get) => get(quickPromptStateAtom) !== null),
+    };
+});
+vi.mock('../../../react/atoms/messageComposition', async () => {
+    const { atom } = await import('jotai');
+    return {
+        currentReaderAttachmentAtom: atom<unknown>(null),
+        addItemsToCurrentMessageItemsAtom: atom(null, async (_get, _set, items: unknown) => mocks.addItems(items)),
+    };
+});
+vi.mock('../../../react/utils/readerUtils', () => ({ getCurrentReader: () => mocks.reader }));
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+
+import type { AgentRun } from '@beaver/agent-core/agents/types';
+import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
+import { isWSChatPendingAtom } from '../../../react/atoms/agentRunAtoms';
+import { isAuthenticatedAtom } from '../../../react/atoms/auth';
+import { isProfileLoadedAtom } from '../../../react/atoms/profile';
+import { isSidebarVisibleAtom, isThreadListViewAtom } from '../../../react/atoms/ui';
+import { currentReaderAttachmentAtom } from '../../../react/atoms/messageComposition';
+import {
+    closeQuickPromptAtom,
+    hasActiveWorkAtom,
+    isQuickPromptOpenAtom,
+    openQuickPromptAtom,
+    quickPromptStateAtom,
+    toggleQuickPromptAtom,
+} from '../../../react/atoms/quickPrompt';
+
+function run(status: AgentRun['status']): AgentRun {
+    return {
+        id: 'run-1',
+        user_id: 'user-1',
+        thread_id: 'thread-1',
+        agent_name: 'beaver',
+        user_prompt: { content: 'Summarize', attachments: [] } as any,
+        status,
+        model_messages: [],
+        model_name: 'test',
+        created_at: '2026-09-08T10:00:00.000Z',
+        consent_to_share: false,
+    };
+}
+
+let store = createStore();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    store = createStore();
+    mocks.reader = null;
+    mocks.annotationItems.clear();
+    (globalThis as any).Zotero = {
+        Items: {
+            getByLibraryAndKeyAsync: async (_libraryID: number, key: string) => mocks.annotationItems.get(key) ?? null,
+        },
+    };
+});
+
+function attachment(id: number, libraryID = 1) {
+    return { id, libraryID, key: `ATT${id}`, isAnnotation: () => false } as any;
+}
+
+function annotation(key: string) {
+    const item = { key, libraryID: 1, isAnnotation: () => true } as any;
+    mocks.annotationItems.set(key, item);
+    return item;
+}
+
+describe('openQuickPromptAtom', () => {
+    it('starts a fresh thread but keeps the draft, and leaves the chat list view', async () => {
+        store.set(isThreadListViewAtom, true);
+        await store.set(openQuickPromptAtom);
+        expect(mocks.newThread).toHaveBeenCalledWith({ skipActiveRunConfirm: true, preserveDraft: true });
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        expect(store.get(isThreadListViewAtom)).toBe(false);
+        expect(store.get(isQuickPromptOpenAtom)).toBe(true);
+    });
+
+    it('shows the busy notice instead of touching a thread whose run is live', async () => {
+        store.set(activeRunAtom, run('in_progress'));
+        await store.set(openQuickPromptAtom);
+        expect(mocks.newThread).not.toHaveBeenCalled();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'busy' });
+    });
+
+    it('treats a pending send as live work even before the run arrives', async () => {
+        store.set(isWSChatPendingAtom, true);
+        expect(store.get(hasActiveWorkAtom)).toBe(true);
+        await store.set(openQuickPromptAtom);
+        expect(mocks.newThread).not.toHaveBeenCalled();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'busy' });
+    });
+
+    it('attaches the annotations selected in the open reader', async () => {
+        const file = attachment(82);
+        const selected = annotation('ANN1');
+        annotation('ANN2');
+        mocks.reader = { itemID: 82, _internalReader: { _state: { selectedAnnotationIDs: ['ANN1', 'MISSING'] } } };
+        store.set(currentReaderAttachmentAtom, file);
+        await store.set(openQuickPromptAtom);
+        expect(mocks.addItems).toHaveBeenCalledTimes(1);
+        expect(mocks.addItems).toHaveBeenCalledWith([selected]);
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+
+    it('does not attach annotations from a reader whose file is not the staged attachment', async () => {
+        annotation('ANN1');
+        mocks.reader = { itemID: 82, _internalReader: { _state: { selectedAnnotationIDs: ['ANN1'] } } };
+        // An excluded library leaves no attachment; a different file is not the one in front of the user.
+        store.set(currentReaderAttachmentAtom, null);
+        await store.set(openQuickPromptAtom);
+        store.set(currentReaderAttachmentAtom, attachment(99));
+        await store.set(openQuickPromptAtom);
+        expect(mocks.addItems).not.toHaveBeenCalled();
+    });
+
+    it('still opens when attaching the annotations fails', async () => {
+        annotation('ANN1');
+        mocks.reader = { itemID: 82, _internalReader: { _state: { selectedAnnotationIDs: ['ANN1'] } } };
+        store.set(currentReaderAttachmentAtom, attachment(82));
+        mocks.addItems.mockRejectedValueOnce(new Error('boom'));
+        await store.set(openQuickPromptAtom);
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+
+    it('does not count a finished run as live work', async () => {
+        store.set(activeRunAtom, run('completed'));
+        expect(store.get(hasActiveWorkAtom)).toBe(false);
+        await store.set(openQuickPromptAtom);
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+});
+
+describe('toggleQuickPromptAtom', () => {
+    it('opens the popup while the sidebar is closed', async () => {
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('opened');
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+
+    it('treats a second press while the first is still opening as the same press', async () => {
+        let finish: () => void = () => {};
+        mocks.newThread.mockImplementationOnce(() => new Promise<void>((resolve) => { finish = resolve; }));
+        const first = store.set(toggleQuickPromptAtom);
+        const second = store.set(toggleQuickPromptAtom);
+        finish();
+        await expect(first).resolves.toBe('opened');
+        await expect(second).resolves.toBe('opened');
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        expect(mocks.newThread).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes an open popup', async () => {
+        await store.set(openQuickPromptAtom);
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('closed');
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('hands the shortcut to the sidebar composer while the sidebar is open', async () => {
+        store.set(isSidebarVisibleAtom, true);
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('focus-sidebar');
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+        expect(mocks.newThread).not.toHaveBeenCalled();
+    });
+
+    it('opens the sidebar instead when Beaver is signed out', async () => {
+        store.set(isAuthenticatedAtom, false);
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('open-sidebar');
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('opens the sidebar instead while the profile is still loading', async () => {
+        store.set(isProfileLoadedAtom, false);
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('open-sidebar');
+    });
+});
+
+describe('closeQuickPromptAtom', () => {
+    it('clears the popup state', async () => {
+        await store.set(openQuickPromptAtom);
+        store.set(closeQuickPromptAtom);
+        expect(store.get(isQuickPromptOpenAtom)).toBe(false);
+    });
+});

--- a/tests/unit/atoms/quickPrompt.test.ts
+++ b/tests/unit/atoms/quickPrompt.test.ts
@@ -22,13 +22,9 @@ vi.mock('../../../react/atoms/agentRunAtoms', async () => {
     const { atom } = await import('jotai');
     return { isWSChatPendingAtom: atom(false) };
 });
-vi.mock('../../../react/atoms/auth', async () => {
+vi.mock('../../../react/atoms/chatAccess', async () => {
     const { atom } = await import('jotai');
-    return { isAuthenticatedAtom: atom(true) };
-});
-vi.mock('../../../react/atoms/profile', async () => {
-    const { atom } = await import('jotai');
-    return { isProfileLoadedAtom: atom(true) };
+    return { chatAccessGateAtom: atom<string | null>(null) };
 });
 vi.mock('../../../react/atoms/ui', async () => {
     const { atom } = await import('jotai');
@@ -53,8 +49,7 @@ vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
 import type { AgentRun } from '@beaver/agent-core/agents/types';
 import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { isWSChatPendingAtom } from '../../../react/atoms/agentRunAtoms';
-import { isAuthenticatedAtom } from '../../../react/atoms/auth';
-import { isProfileLoadedAtom } from '../../../react/atoms/profile';
+import { chatAccessGateAtom } from '../../../react/atoms/chatAccess';
 import { isSidebarVisibleAtom, isThreadListViewAtom } from '../../../react/atoms/ui';
 import { currentReaderAttachmentAtom } from '../../../react/atoms/messageComposition';
 import {
@@ -201,15 +196,18 @@ describe('toggleQuickPromptAtom', () => {
         expect(mocks.newThread).not.toHaveBeenCalled();
     });
 
-    it('opens the sidebar instead when Beaver is signed out', async () => {
-        store.set(isAuthenticatedAtom, false);
-        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('open-sidebar');
-        expect(store.get(quickPromptStateAtom)).toBeNull();
+    it('shows why a chat cannot start instead of the composer when the account is gated', async () => {
+        store.set(chatAccessGateAtom as any, 'update-required');
+        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('opened');
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'blocked', reason: 'update-required' });
+        expect(mocks.newThread).not.toHaveBeenCalled();
     });
 
-    it('opens the sidebar instead while the profile is still loading', async () => {
-        store.set(isProfileLoadedAtom, false);
-        await expect(store.set(toggleQuickPromptAtom)).resolves.toBe('open-sidebar');
+    it('puts the account gate before the busy notice', async () => {
+        store.set(chatAccessGateAtom as any, 'signed-out');
+        store.set(activeRunAtom, run('in_progress'));
+        await store.set(openQuickPromptAtom);
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'blocked', reason: 'signed-out' });
     });
 });
 

--- a/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
+++ b/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
@@ -37,13 +37,9 @@ vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
     const { atom } = await import('jotai');
     return { isWSChatPendingAtom: atom(false) };
 });
-vi.mock('../../../../react/atoms/auth', async () => {
+vi.mock('../../../../react/atoms/chatAccess', async () => {
     const { atom } = await import('jotai');
-    return { isAuthenticatedAtom: atom(true) };
-});
-vi.mock('../../../../react/atoms/profile', async () => {
-    const { atom } = await import('jotai');
-    return { isProfileLoadedAtom: atom(true) };
+    return { chatAccessGateAtom: atom<string | null>(null) };
 });
 vi.mock('../../../../react/atoms/ui', async () => {
     const { atom } = await import('jotai');
@@ -78,6 +74,7 @@ import type { AgentRun } from '@beaver/agent-core/agents/types';
 import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { isWSChatPendingAtom } from '../../../../react/atoms/agentRunAtoms';
 import { isSidebarVisibleAtom, selectedZoteroTabIdAtom } from '../../../../react/atoms/ui';
+import { chatAccessGateAtom } from '../../../../react/atoms/chatAccess';
 import { quickPromptStateAtom } from '../../../../react/atoms/quickPrompt';
 import QuickPromptPopup from '../../../../react/components/quickPrompt/QuickPromptPopup';
 
@@ -276,6 +273,31 @@ describe('QuickPromptPopup', () => {
         const open = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('Open Beaver'))!;
         act(() => { open.click(); });
         expect(mocks.dispatch).toHaveBeenCalledWith('toggleChat', { forceOpen: true });
+    });
+
+    it('explains a gated account and offers Beaver instead of a composer', async () => {
+        store.set(chatAccessGateAtom as any, 'signed-out');
+        mount();
+        await fireShortcut();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'blocked', reason: 'signed-out' });
+        expect(container.querySelector('.stub-composer')).toBeNull();
+        expect(container.textContent).toContain('Sign in to use Beaver');
+        const open = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('Open Beaver'))!;
+        act(() => { open.click(); });
+        expect(mocks.dispatch).toHaveBeenCalledWith('toggleChat', { forceOpen: true });
+    });
+
+    it('moves from a loading notice to the composer once Beaver is ready', async () => {
+        store.set(chatAccessGateAtom as any, 'connecting');
+        mount();
+        await fireShortcut();
+        expect(container.textContent).toContain('Beaver is still loading');
+        await act(async () => {
+            store.set(chatAccessGateAtom as any, null);
+            await Promise.resolve();
+        });
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        expect(container.querySelector('.stub-composer')).not.toBeNull();
     });
 
     it('toggles closed on a second shortcut press', async () => {

--- a/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
+++ b/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+
+/**
+ * When the quick prompt popup shows, and what makes it go away.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    dispatch: vi.fn(),
+    subscribers: new Map<string, (detail: unknown) => void>(),
+    focusToggleButton: vi.fn(),
+    newThread: vi.fn(async (_options?: unknown) => {}),
+}));
+
+vi.mock('../../../../react/events/eventManager', () => ({
+    eventManager: {
+        dispatch: mocks.dispatch,
+        subscribe: (name: string, callback: (detail: unknown) => void) => {
+            mocks.subscribers.set(name, callback);
+            return () => { mocks.subscribers.delete(name); };
+        },
+    },
+}));
+vi.mock('../../../../react/ui/UIManager', () => ({
+    uiManager: { focusToggleButton: mocks.focusToggleButton },
+}));
+vi.mock('../../../../react/atoms/threads', async () => {
+    const { atom } = await import('jotai');
+    return {
+        newThreadAtom: atom(null, async (_get, _set, options?: unknown) => mocks.newThread(options)),
+    };
+});
+vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
+    const { atom } = await import('jotai');
+    return { isWSChatPendingAtom: atom(false) };
+});
+vi.mock('../../../../react/atoms/auth', async () => {
+    const { atom } = await import('jotai');
+    return { isAuthenticatedAtom: atom(true) };
+});
+vi.mock('../../../../react/atoms/profile', async () => {
+    const { atom } = await import('jotai');
+    return { isProfileLoadedAtom: atom(true) };
+});
+vi.mock('../../../../react/atoms/ui', async () => {
+    const { atom } = await import('jotai');
+    const quickPromptStateAtom = atom<{ mode: string } | null>(null);
+    return {
+        isSidebarVisibleAtom: atom(false),
+        isThreadListViewAtom: atom(false),
+        selectedZoteroTabIdAtom: atom<string | null>('tab-library'),
+        quickPromptStateAtom,
+        isQuickPromptOpenAtom: atom((get) => get(quickPromptStateAtom) !== null),
+    };
+});
+vi.mock('../../../../react/atoms/messageComposition', async () => {
+    const { atom } = await import('jotai');
+    return {
+        currentReaderAttachmentAtom: atom<unknown>(null),
+        addItemsToCurrentMessageItemsAtom: atom(null, async () => {}),
+    };
+});
+vi.mock('../../../../react/utils/readerUtils', () => ({ getCurrentReader: () => null }));
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+// The composer drags in the whole Zotero-side composition stack; a stub that
+// exposes an editor to press keys in is all these tests need.
+vi.mock('../../../../react/components/input/InputArea', () => ({
+    default: () => React.createElement('div', { className: 'stub-composer' },
+        React.createElement('div', { className: 'beaver-lexical-content', contentEditable: true, 'data-testid': 'editor' })),
+}));
+vi.mock('../../../../react/components/PopupOverlayContainer', () => ({ default: () => null }));
+vi.mock('../../../../react/components/runStatusPopup/RunPulse', () => ({ default: () => null }));
+
+import type { AgentRun } from '@beaver/agent-core/agents/types';
+import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
+import { isWSChatPendingAtom } from '../../../../react/atoms/agentRunAtoms';
+import { isSidebarVisibleAtom, selectedZoteroTabIdAtom } from '../../../../react/atoms/ui';
+import { quickPromptStateAtom } from '../../../../react/atoms/quickPrompt';
+import QuickPromptPopup from '../../../../react/components/quickPrompt/QuickPromptPopup';
+
+function run(status: AgentRun['status']): AgentRun {
+    return {
+        id: 'run-1',
+        user_id: 'user-1',
+        thread_id: 'thread-1',
+        agent_name: 'beaver',
+        user_prompt: { content: 'Summarize the neighborhood effects literature', attachments: [] } as any,
+        status,
+        model_messages: [],
+        model_name: 'test',
+        created_at: '2026-09-08T10:00:00.000Z',
+        consent_to_share: false,
+    };
+}
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let store = createStore();
+let root: Root | null = null;
+let container: HTMLDivElement;
+let floatingRoot: HTMLDivElement;
+
+function mount() {
+    floatingRoot = document.createElement('div');
+    floatingRoot.id = 'beaver-pane-floating-popup';
+    container = document.createElement('div');
+    floatingRoot.appendChild(container);
+    document.body.appendChild(floatingRoot);
+    root = createRoot(container);
+    act(() => {
+        root!.render(React.createElement(Provider, { store }, React.createElement(QuickPromptPopup)));
+    });
+}
+
+async function fireShortcut() {
+    await act(async () => {
+        mocks.subscribers.get('toggleQuickPrompt')?.({});
+        await Promise.resolve();
+    });
+}
+
+function pressEscape(target: Element) {
+    act(() => {
+        target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.subscribers.clear();
+    (globalThis as any).Zotero = { getMainWindow: () => window };
+    store = createStore();
+});
+
+afterEach(() => {
+    act(() => { root?.unmount(); });
+    root = null;
+    floatingRoot.remove();
+});
+
+describe('QuickPromptPopup', () => {
+    it('draws nothing until the shortcut opens it', () => {
+        mount();
+        expect(container.querySelector('.beaver-quick-prompt')).toBeNull();
+    });
+
+    it('opens on the shortcut with the composer on a fresh thread', async () => {
+        mount();
+        await fireShortcut();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        expect(container.querySelector('.stub-composer')).not.toBeNull();
+        expect(mocks.newThread).toHaveBeenCalledWith({ skipActiveRunConfirm: true, preserveDraft: true });
+    });
+
+    it('offers a close button that names the Escape shortcut', async () => {
+        mount();
+        await fireShortcut();
+        expect(container.querySelector('.beaver-quick-prompt__header')).toBeNull();
+        const close = container.querySelector<HTMLButtonElement>('.beaver-quick-prompt__dismiss button[aria-label="Close"]')!;
+        expect(close).not.toBeNull();
+        act(() => { close.click(); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('focuses the sidebar composer instead while the sidebar is open', async () => {
+        store.set(isSidebarVisibleAtom, true);
+        mount();
+        await fireShortcut();
+        expect(mocks.dispatch).toHaveBeenCalledWith('focusInput', {});
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('closes on Escape from the editor and returns focus where it was', async () => {
+        const tree = document.createElement('button');
+        document.body.appendChild(tree);
+        tree.focus();
+        mount();
+        await fireShortcut();
+        const editor = container.querySelector('[data-testid="editor"]')!;
+        pressEscape(editor);
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+        expect(container.querySelector('.beaver-quick-prompt')).toBeNull();
+        expect(document.activeElement).toBe(tree);
+        tree.remove();
+    });
+
+    it('leaves Escape to a menu the composer has open', async () => {
+        mount();
+        await fireShortcut();
+        const menu = document.createElement('div');
+        menu.setAttribute('role', 'menu');
+        floatingRoot.appendChild(menu);
+        pressEscape(container.querySelector('[data-testid="editor"]')!);
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        menu.remove();
+        pressEscape(container.querySelector('[data-testid="editor"]')!);
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('ignores an Escape another handler has already claimed', async () => {
+        mount();
+        await fireShortcut();
+        const editor = container.querySelector('[data-testid="editor"]')!;
+        act(() => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+            event.preventDefault();
+            editor.dispatchEvent(event);
+        });
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+
+    it('closes once the message it composed is being sent', async () => {
+        mount();
+        await fireShortcut();
+        act(() => { store.set(isWSChatPendingAtom, true); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+        expect(mocks.focusToggleButton).toHaveBeenCalled();
+    });
+
+    it('closes when the sidebar opens over it', async () => {
+        mount();
+        await fireShortcut();
+        act(() => { store.set(isSidebarVisibleAtom, true); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('closes when the user switches tabs, leaving focus where Zotero put it', async () => {
+        mount();
+        await fireShortcut();
+        const elsewhere = document.createElement('button');
+        document.body.appendChild(elsewhere);
+        elsewhere.focus();
+        act(() => { store.set(selectedZoteroTabIdAtom, 'tab-reader-1'); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+        expect(document.activeElement).toBe(elsewhere);
+        expect(mocks.focusToggleButton).not.toHaveBeenCalled();
+        elsewhere.remove();
+    });
+
+    it('stays open while the tab does not change', async () => {
+        mount();
+        await fireShortcut();
+        act(() => { store.set(selectedZoteroTabIdAtom, 'tab-library'); });
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+    });
+
+    it('is tied to the tab it was reopened in, not the one from an earlier open', async () => {
+        mount();
+        await fireShortcut();
+        act(() => { store.set(selectedZoteroTabIdAtom, 'tab-reader-1'); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+        await fireShortcut();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
+        act(() => { store.set(selectedZoteroTabIdAtom, 'tab-reader-2'); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('shows the busy notice while a run is live, and closes when it ends', async () => {
+        store.set(activeRunAtom, run('in_progress'));
+        mount();
+        await fireShortcut();
+        expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'busy' });
+        expect(container.querySelector('.beaver-quick-prompt__card--busy')?.textContent).toContain('Beaver is still working');
+        expect(container.querySelector('.stub-composer')).toBeNull();
+        act(() => { store.set(activeRunAtom, run('completed')); });
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+
+    it('opens Beaver from the busy notice', async () => {
+        store.set(activeRunAtom, run('in_progress'));
+        mount();
+        await fireShortcut();
+        const open = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('Open Beaver'))!;
+        act(() => { open.click(); });
+        expect(mocks.dispatch).toHaveBeenCalledWith('toggleChat', { forceOpen: true });
+    });
+
+    it('toggles closed on a second shortcut press', async () => {
+        mount();
+        await fireShortcut();
+        await fireShortcut();
+        expect(store.get(quickPromptStateAtom)).toBeNull();
+    });
+});

--- a/tests/unit/ui/useOverflowCollapse.test.ts
+++ b/tests/unit/ui/useOverflowCollapse.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+/**
+ * How a row of controls collapses to fit, and what may expand it again.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useOverflowCollapse } from '@beaver/agent-ui/utils/useOverflowCollapse';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * The box the hook reads; jsdom has no layout, so the widths are scripted.
+ * Collapsing shrinks the row, so the content width is given per level.
+ */
+const box = { clientWidth: 300, neededAt: [300, 300, 300] };
+let resizeCallbacks: Array<() => void> = [];
+let latestLevel = -1;
+let renders = 0;
+let root: Root | null = null;
+let container: HTMLDivElement;
+
+class FakeResizeObserver {
+    constructor(private readonly callback: () => void) {}
+    observe() { resizeCallbacks.push(this.callback); }
+    disconnect() { resizeCallbacks = resizeCallbacks.filter((cb) => cb !== this.callback); }
+}
+
+const Harness: React.FC<{ tick: number }> = () => {
+    const { level, ref } = useOverflowCollapse(2);
+    latestLevel = level;
+    renders += 1;
+    return React.createElement('div', { ref, 'data-testid': 'row' }, React.createElement('span', null, 'controls'));
+};
+
+function row(): HTMLDivElement {
+    return container.querySelector('[data-testid="row"]') as HTMLDivElement;
+}
+
+/** Mount with the scripted box in place before the element attaches. */
+function mount() {
+    act(() => { root!.render(React.createElement(Harness, { tick: 0 })); });
+}
+
+/** A re-render with unchanged props: nothing about the row's box has changed. */
+function rerender(tick: number) {
+    act(() => { root!.render(React.createElement(Harness, { tick })); });
+}
+
+/** The container changed size: the resize observer reports it. */
+function resize() {
+    act(() => { resizeCallbacks.forEach((cb) => cb()); });
+}
+
+/** The row's content changed: the mutation observer reports it. */
+async function mutateContent() {
+    await act(async () => {
+        row().querySelector('span')!.textContent = `controls ${Math.random()}`;
+        await Promise.resolve();
+    });
+}
+
+beforeEach(() => {
+    (window as any).ResizeObserver = FakeResizeObserver;
+    // jsdom lays nothing out; the row reads its scripted widths instead.
+    Object.defineProperty(HTMLDivElement.prototype, 'clientWidth', { configurable: true, get: () => box.clientWidth });
+    Object.defineProperty(HTMLDivElement.prototype, 'scrollWidth', {
+        configurable: true,
+        get: () => Math.max(box.clientWidth, box.neededAt[latestLevel < 0 ? 0 : latestLevel] ?? box.neededAt[box.neededAt.length - 1]),
+    });
+    resizeCallbacks = [];
+    renders = 0;
+    latestLevel = -1;
+    box.clientWidth = 300;
+    box.neededAt = [300, 300, 300];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root?.unmount(); });
+    container.remove();
+    delete (HTMLDivElement.prototype as any).clientWidth;
+    delete (HTMLDivElement.prototype as any).scrollWidth;
+});
+
+describe('useOverflowCollapse', () => {
+    it('stays at level 0 while the content fits', () => {
+        mount();
+        resize();
+        rerender(1);
+        expect(latestLevel).toBe(0);
+    });
+
+    it('is collapsed from its first paint when the row attaches too narrow', () => {
+        box.neededAt = [340, 290, 280];
+        mount();
+        expect(latestLevel).toBe(1);
+    });
+
+    it('collapses further when content arriving in a fixed box overflows it', async () => {
+        mount();
+        expect(latestLevel).toBe(0);
+        box.neededAt = [340, 320, 310];
+        await mutateContent();
+        // The level-1 content still overflows; its own re-layout is a mutation too.
+        await mutateContent();
+        expect(latestLevel).toBe(2);
+        await mutateContent();
+        expect(latestLevel).toBe(2);
+    });
+
+    it('does not expand on a content change alone, even when the box reads wide enough', async () => {
+        box.neededAt = [340, 290, 280];
+        mount();
+        expect(latestLevel).toBe(1);
+        // A container whose width follows its content reads "fits" once the
+        // row has collapsed; taking that as a cue to expand would overflow it
+        // again and loop.
+        box.clientWidth = 350;
+        await mutateContent();
+        rerender(1);
+        expect(latestLevel).toBe(1);
+    });
+
+    it('expands when the container has resized to the width the content needed', () => {
+        box.neededAt = [340, 290, 280];
+        mount();
+        expect(latestLevel).toBe(1);
+        box.clientWidth = 340;
+        resize();
+        expect(latestLevel).toBe(0);
+    });
+
+    it('keeps the level when the container resizes but is still narrower than the content needed', () => {
+        box.neededAt = [340, 290, 280];
+        mount();
+        box.clientWidth = 330;
+        resize();
+        expect(latestLevel).toBe(1);
+    });
+
+    it('never renders for a measurement that changes nothing', () => {
+        box.neededAt = [340, 290, 280];
+        mount();
+        const after = renders;
+        for (let i = 0; i < 20; i++) resize();
+        expect(renders).toBe(after);
+        for (let i = 1; i <= 5; i++) rerender(i);
+        expect(renders).toBe(after + 5);
+        expect(latestLevel).toBe(1);
+    });
+
+    it('stops observing an element it has let go of', () => {
+        mount();
+        expect(resizeCallbacks.length).toBe(1);
+        act(() => { root!.unmount(); });
+        root = createRoot(container);
+        expect(resizeCallbacks.length).toBe(0);
+    });
+});

--- a/tests/unit/utils/keyboardManager.test.ts
+++ b/tests/unit/utils/keyboardManager.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+/**
+ * One keystroke reaches the manager's listeners once, however many windows
+ * it propagates through.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('zotero-plugin-toolkit', () => ({
+    KeyModifier: class { constructor(_event: unknown) {} },
+}));
+
+import { KeyboardManager } from '../../../src/utils/keyboardManager';
+
+let manager: KeyboardManager | null = null;
+
+beforeEach(() => {
+    (globalThis as any).ztoolkit = { log: vi.fn() };
+    (globalThis as any).Zotero = {
+        getMainWindow: () => window,
+        getMainWindows: () => [window],
+        Reader: undefined,
+    };
+});
+
+afterEach(() => {
+    manager?.unregisterAll();
+    manager = null;
+});
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+    return new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+}
+
+describe('KeyboardManager', () => {
+    it('dispatches a key event to its callbacks', () => {
+        manager = new KeyboardManager();
+        const callback = vi.fn();
+        manager.register(callback);
+        window.dispatchEvent(keydown({ key: 'j', code: 'KeyJ', metaKey: true }));
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches the same event only once when it arrives through two windows', () => {
+        manager = new KeyboardManager();
+        const callback = vi.fn();
+        manager.register(callback);
+        // A keystroke in a reader tab is seen by the listener on the reader's
+        // window and again by the one on the main window: the same event,
+        // delivered twice.
+        const event = keydown({ key: 'j', code: 'KeyJ', metaKey: true, altKey: true });
+        window.dispatchEvent(event);
+        window.dispatchEvent(event);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('still dispatches a repeated press of the same key', () => {
+        manager = new KeyboardManager();
+        const callback = vi.fn();
+        manager.register(callback);
+        const first = keydown({ key: 'j', code: 'KeyJ', metaKey: true });
+        const second = keydown({ key: 'j', code: 'KeyJ', metaKey: true });
+        // Distinct keystrokes carry distinct timestamps.
+        Object.defineProperty(second, 'timeStamp', { value: first.timeStamp + 40 });
+        window.dispatchEvent(first);
+        window.dispatchEvent(second);
+        expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores modifier-only presses', () => {
+        manager = new KeyboardManager();
+        const callback = vi.fn();
+        manager.register(callback);
+        window.dispatchEvent(keydown({ key: 'Meta' }));
+        window.dispatchEvent(keydown({ key: 'Alt' }));
+        expect(callback).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/utils/shortcuts.test.ts
+++ b/tests/unit/utils/shortcuts.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Which keyboard events are the quick prompt chord.
+ */
+import { describe, expect, it } from 'vitest';
+import { isQuickPromptShortcut, type ChordEvent } from '../../../src/utils/shortcuts';
+
+function event(overrides: Partial<ChordEvent>): ChordEvent {
+    return {
+        key: 'j',
+        code: 'KeyJ',
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        getModifierState: () => false,
+        ...overrides,
+    };
+}
+
+describe('isQuickPromptShortcut', () => {
+    it('matches Cmd+Option+key on macOS, including the character Option types', () => {
+        expect(isQuickPromptShortcut(event({ key: 'j', metaKey: true, altKey: true }), 'j', true)).toBe(true);
+        expect(isQuickPromptShortcut(event({ key: '∆', metaKey: true, altKey: true }), 'j', true)).toBe(true);
+    });
+
+    it('ignores the AltGraph state on macOS, where Option always carries it', () => {
+        const option = event({ key: '∆', metaKey: true, altKey: true, getModifierState: (name) => name === 'AltGraph' });
+        expect(isQuickPromptShortcut(option, 'j', true)).toBe(true);
+    });
+
+    it('matches Ctrl+Alt+key on Windows and Linux', () => {
+        expect(isQuickPromptShortcut(event({ ctrlKey: true, altKey: true }), 'j', false)).toBe(true);
+    });
+
+    it('rejects AltGr character entry, which arrives as Ctrl+Alt with the AltGraph state', () => {
+        const altGr = event({ key: '@', code: 'KeyQ', ctrlKey: true, altKey: true, getModifierState: (name) => name === 'AltGraph' });
+        expect(isQuickPromptShortcut(altGr, 'q', false)).toBe(false);
+    });
+
+    it('still matches under AltGr when the key types nothing but its own letter', () => {
+        const altGr = event({ key: 'j', code: 'KeyJ', ctrlKey: true, altKey: true, getModifierState: (name) => name === 'AltGraph' });
+        expect(isQuickPromptShortcut(altGr, 'j', false)).toBe(true);
+    });
+
+    it('rejects the other Beaver chords and plain keys', () => {
+        expect(isQuickPromptShortcut(event({ metaKey: true }), 'j', true)).toBe(false);
+        expect(isQuickPromptShortcut(event({ metaKey: true, shiftKey: true }), 'j', true)).toBe(false);
+        expect(isQuickPromptShortcut(event({ metaKey: true, altKey: true, shiftKey: true }), 'j', true)).toBe(false);
+        expect(isQuickPromptShortcut(event({ ctrlKey: true, altKey: true }), 'j', true)).toBe(false);
+        expect(isQuickPromptShortcut(event({ altKey: true }), 'j', false)).toBe(false);
+    });
+
+    it('follows the configured key, case-insensitively', () => {
+        expect(isQuickPromptShortcut(event({ key: 'K', code: 'KeyK', metaKey: true, altKey: true }), 'K', true)).toBe(true);
+        expect(isQuickPromptShortcut(event({ key: 'j', code: 'KeyJ', metaKey: true, altKey: true }), 'k', true)).toBe(false);
+    });
+
+    it('works without getModifierState on the event', () => {
+        const bare = event({ ctrlKey: true, altKey: true });
+        delete bare.getModifierState;
+        expect(isQuickPromptShortcut(bare, 'j', false)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a keyboard-triggered quick prompt composer when the sidebar is closed.
- Preserve drafts, attach reader selections, and handle active runs with a busy notice.
- Add popup lifecycle, focus handling, shortcut documentation, and dev HTTP controls.
- Add unit coverage for quick prompt state, keyboard deduplication, and popup behavior.

## Testing
- Not run.