### PR TITLE
feat(citations): support external file citation tags in notes

### DIFF
--- a/packages/agent-ui/src/chat/Citation.tsx
+++ b/packages/agent-ui/src/chat/Citation.tsx
@@ -159,17 +159,21 @@ const Citation: React.FC<CitationProps> = (props) => {
         // clickable link to the locally stored file; the plain-text form is the
         // client-agnostic fallback when the host can't (e.g. no local copy).
         if (isExternalFile) {
+            // A file this device has never seen carries neither metadata nor a
+            // local copy. Name it by its id rather than export an empty pair of
+            // parentheses.
+            const fileLabel = citation || (externalFileKey ? `Attached file ext-${externalFileKey}` : '');
             const locatorSuffix = hasLocatorDisplay ? `, p.${pagesDisplay}` : '';
             const exportedFile = getHost().documentExport?.renderExternalFileCitation?.({
                 externalFileKey,
-                displayName: citation,
+                displayName: fileLabel,
                 locatorSuffix,
                 localPathsByExtKey: externalFileLocalPaths,
             });
             if (exportedFile && exportedFile.kind === 'html') {
                 return <span dangerouslySetInnerHTML={{ __html: exportedFile.html }} />;
             }
-            return (<span>{`(${citation}${locatorSuffix})`}</span>);
+            return (<span>{`(${fileLabel}${locatorSuffix})`}</span>);
         }
 
         // For library citations, delegate host-native formatting (CSL for

--- a/react/hooks/httpHandlers/testNoteHandlers.ts
+++ b/react/hooks/httpHandlers/testNoteHandlers.ts
@@ -7,7 +7,8 @@
  */
 
 import { wrapWithSchemaVersion } from '../../utils/noteActions';
-import { undoEditNoteOrBatchAction } from '../../utils/editNoteActions';
+import { executeEditNoteOrBatchAction, undoEditNoteOrBatchAction } from '../../utils/editNoteActions';
+import { containsPreviewMarkers } from '../../../src/utils/notePreviewGuard';
 import { getLatestNoteHtml } from '../../../src/utils/noteEditorIO';
 import type { AgentAction } from '../../agents/agentActions';
 import { UNRESOLVED_LIBRARY_ID } from '../../../src/utils/libraryIdentity';
@@ -184,4 +185,44 @@ export async function handleTestNoteUndoHttpRequest(request: any) {
     } catch (e: any) {
         return { ok: false, error: e?.message || String(e) };
     }
+}
+
+
+/** Exercise the same local executor used when approving a stored note action. */
+export async function handleTestNoteApplyHttpRequest(request: any) {
+    const action = request.action as AgentAction;
+    if (!action?.proposed_data || !['edit_note', 'edit_note_batch'].includes(action.action_type)) {
+        return { ok: false, error: 'An edit_note or edit_note_batch action is required' };
+    }
+    try {
+        return { ok: true, result_data: await executeEditNoteOrBatchAction(action) };
+    } catch (e: any) {
+        return { ok: false, error: e?.message || String(e) };
+    }
+}
+
+/** Render a real note-editor preview and return its displayed HTML for live checks. */
+export async function handleTestNotePreviewHttpRequest(request: any) {
+    const { showDiffPreview, dismissDiffPreview } = await import('../../utils/noteEditorDiffPreview');
+    if (request.dismiss) {
+        await dismissDiffPreview();
+        return { ok: true };
+    }
+    const { library_id, zotero_key, edits } = request;
+    if (typeof library_id !== 'number' || typeof zotero_key !== 'string' || !Array.isArray(edits)) {
+        return { ok: false, error: 'Provide library_id, zotero_key and edits' };
+    }
+    const shown = await showDiffPreview(library_id, zotero_key, edits);
+    const itemID = Zotero.Items.getIDFromLibraryAndKey(library_id, zotero_key);
+    const instance = (Zotero as any).Notes._editorInstances.find((inst: any) => (
+        inst.itemID === itemID && inst._disableSaving
+    ));
+    const readHtml = () => instance?._iframeWindow?.wrappedJSObject?._currentEditorInstance?._editorCore?.view?.dom?.innerHTML;
+    let html = readHtml();
+    // The editor receives its update asynchronously through postMessage.
+    for (let attempt = 0; shown && !containsPreviewMarkers(html ?? '') && attempt < 60; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 25));
+        html = readHtml();
+    }
+    return { ok: shown, html };
 }

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -88,6 +88,8 @@ import {
     handleTestNoteOpenEditorHttpRequest,
     handleTestNoteCloseEditorHttpRequest,
     handleTestNoteUndoHttpRequest,
+    handleTestNoteApplyHttpRequest,
+    handleTestNotePreviewHttpRequest,
 } from './httpHandlers/testNoteHandlers';
 import {
     handleTestCollectionCreateHttpRequest,
@@ -301,6 +303,8 @@ const ENDPOINT_PATHS = [
     '/beaver/test/note-open-editor',
     '/beaver/test/note-close-editor',
     '/beaver/test/note-undo',
+    '/beaver/test/note-apply',
+    '/beaver/test/note-preview',
     // Test-only endpoints (collection seeding/teardown)
     '/beaver/test/collection-create',
     '/beaver/test/collection-delete',
@@ -1194,6 +1198,12 @@ function registerEndpoints(): boolean {
 
         Zotero.Server.Endpoints['/beaver/test/note-undo'] =
             createEndpoint(handleTestNoteUndoHttpRequest);
+
+        Zotero.Server.Endpoints['/beaver/test/note-apply'] =
+            createEndpoint(handleTestNoteApplyHttpRequest);
+
+        Zotero.Server.Endpoints['/beaver/test/note-preview'] =
+            createEndpoint(handleTestNotePreviewHttpRequest);
 
         // Collection seeding/teardown (dev-only)
         Zotero.Server.Endpoints['/beaver/test/collection-create'] =

--- a/react/host/zotero/citationExport.ts
+++ b/react/host/zotero/citationExport.ts
@@ -1,3 +1,4 @@
+import { formatExternalFileCitationHTML } from '../../../src/utils/externalFileCitation';
 import { getPageLabelsForItem } from './itemData';
 import { getPageLocator } from '@beaver/agent-core/citations/citationGrammar';
 import { translatePageNumberToLabelFromLabels } from '../../utils/pageLabels';
@@ -11,15 +12,6 @@ import type {
     DocumentExportHost,
     ExternalFileCitationExportRequest,
 } from '@beaver/agent-ui/host/types';
-
-/** Escape text for safe interpolation into an HTML attribute or text node. */
-function escapeHtml(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
-}
 
 /**
  * Render a Zotero/library citation as CSL-formatted HTML for note export.
@@ -94,10 +86,8 @@ function renderExternalFileCitation(request: ExternalFileCitationExportRequest):
     const path = localPathsByExtKey[externalFileKey];
     if (!path) return null;
     try {
-        const href = escapeHtml(Zotero.File.pathToFileURI(path));
-        const label = escapeHtml(displayName);
-        const suffix = escapeHtml(locatorSuffix);
-        return { kind: 'html', html: `(<a href="${href}">${label}</a>${suffix})` };
+        const href = Zotero.File.pathToFileURI(path);
+        return { kind: 'html', html: formatExternalFileCitationHTML(displayName, locatorSuffix, href) };
     } catch (e) {
         logger(`zoteroDocumentExport: failed to build file link for ext-${externalFileKey}: ${e}`);
         return null;

--- a/react/utils/citationRenderContext.ts
+++ b/react/utils/citationRenderContext.ts
@@ -6,14 +6,17 @@ import { externalReferenceItemMappingAtom, externalReferenceMappingAtom } from '
 import { CITATION_TAG_PATTERN } from './citationPreprocessing';
 import {
     citationIndexCandidateIdsForLocator,
+    getPageLocator,
     normalizeCitationTag,
     parseRawCitationAttributes,
     requestedCitationKey,
+    type ExternalFileCitationRef,
     type Locator,
 } from '@beaver/agent-core/citations/citationGrammar';
 import { getCitationPreloadFilePath, preloadPageLabelsForContent } from './pageLabels';
 import type { CitationIndexEntry, StructuredExtractResult } from '@beaver/agent-core/extract/schema';
 import { UNRESOLVED_LIBRARY_ID } from '../../src/utils/libraryIdentity';
+import type { ExternalFileRecord } from '../../src/services/database';
 
 function citationLocationsFromEntries(entries: CitationIndexEntry[]): PartLocation[] {
     const byPage = new Map<number, PartLocation>();
@@ -145,19 +148,32 @@ export async function buildLocalCitationDataMapForContent(
 }
 
 /**
- * Resolve absolute local paths for external-file citations in the content,
- * limited to files that exist on this computer. Used by note export to offer a
- * clickable file link; files attached on another machine resolve to no entry and
- * fall back to plain text.
+ * Resolve the external-file citations in the content against the local
+ * `external_files` registry.
+ *
+ * Returns the absolute path of each cited file that exists on this computer
+ * (so the export can offer a clickable file link) and a synthetic citation per
+ * cited identity carrying the file's name, content kind and cited pages.
+ *
+ * That synthetic metadata is what makes the exported reference readable.
+ * Backend citation metadata is resolved from a run's message text only, so a
+ * file cited inside note content has none — and unlike a library citation
+ * there is no Zotero item the export could format from instead, so the
+ * reference would render with an empty label. Real backend metadata, when it
+ * exists, still wins: `prepareCitationRenderContext` merges it over this map.
  */
-export async function resolveExternalFileLocalPaths(
-    content: string,
-): Promise<Record<string, string>> {
-    const db = Zotero.Beaver?.db;
-    if (!db) return {};
+export async function resolveExternalFileCitations(content: string): Promise<{
+    localPaths: Record<string, string>;
+    citationDataMap: Record<string, Citation>;
+}> {
+    const localPaths: Record<string, string> = {};
+    const citationDataMap: Record<string, Citation> = {};
 
-    const result: Record<string, string> = {};
-    const seen = new Set<string>();
+    const db = Zotero.Beaver?.db;
+    if (!db) return { localPaths, citationDataMap };
+
+    // One entry per cited identity (ext key + locator), in citation order.
+    const citedRefs = new Map<string, { ref: ExternalFileCitationRef; rawTag: string }>();
     const regex = new RegExp(CITATION_TAG_PATTERN.source, CITATION_TAG_PATTERN.flags);
     let match: RegExpExecArray | null;
 
@@ -165,23 +181,54 @@ export async function resolveExternalFileLocalPaths(
         const normalized = normalizeCitationTag(parseRawCitationAttributes(match[1] || ''));
         if (!normalized.ok || normalized.ref.kind !== 'external_file') continue;
 
-        const extKey = normalized.ref.ext_key;
-        if (seen.has(extKey)) continue;
-        seen.add(extKey);
-
-        try {
-            const record = await db.getExternalFileByKey(extKey);
-            const path = record?.storedPath ?? null;
-            if (path && (await IOUtils.exists(path).catch(() => false))) {
-                result[extKey] = path;
-            }
-        } catch {
-            // The file link is an export enhancement; unresolved external files
-            // fall back to plain-text citation rendering.
-        }
+        const citationKey = requestedCitationKey(normalized.ref);
+        if (citedRefs.has(citationKey)) continue;
+        citedRefs.set(citationKey, { ref: normalized.ref, rawTag: match[0] });
     }
 
-    return result;
+    if (citedRefs.size === 0) return { localPaths, citationDataMap };
+
+    // Each distinct file is read once, however often it is cited.
+    const extKeys = new Set([...citedRefs.values()].map(({ ref }) => ref.ext_key));
+    const recordsByExtKey = new Map<string, ExternalFileRecord>();
+    await Promise.all([...extKeys].map(async (extKey) => {
+        try {
+            const record = await db.getExternalFileByKey(extKey);
+            if (!record) return;
+            recordsByExtKey.set(extKey, record);
+            if (await IOUtils.exists(record.storedPath).catch(() => false)) {
+                localPaths[extKey] = record.storedPath;
+            }
+        } catch {
+            // Both the link and the filename are export enhancements; a file
+            // this device knows nothing about falls back to the plain-text
+            // citation rendering.
+        }
+    }));
+
+    for (const [citationKey, { ref, rawTag }] of citedRefs) {
+        const record = recordsByExtKey.get(ref.ext_key);
+        if (!record) continue;
+
+        const citedPage = Number.parseInt(getPageLocator(ref) ?? '', 10);
+        citationDataMap[`local:${citationKey}`] = {
+            citation_id: `local:${citationKey}`,
+            run_id: 'local',
+            citation_type: 'external_file',
+            // External files are attachments living outside Zotero; the client
+            // branches on content_kind for the per-type icon and for how a
+            // cited page reads (an EPUB "page" is a section ordinal).
+            item_type: 'attachment',
+            content_kind: record.contentKind,
+            display_name: record.filename,
+            requested_ref: ref,
+            resolved_ref: ref,
+            raw_tag: rawTag,
+            ...(Number.isFinite(citedPage) && citedPage > 0 ? { pages: [citedPage] } : {}),
+        };
+    }
+
+    return { localPaths, citationDataMap };
 }
 
 /**
@@ -191,11 +238,17 @@ export async function prepareCitationRenderContext(
     content: string,
     contextData?: RenderContextData,
 ): Promise<RenderContextData | undefined> {
-    const [pageLabelsByAttachmentId, localCitationDataMap, externalFileLocalPaths] = await Promise.all([
+    const [pageLabelsByAttachmentId, structuredCitationDataMap, externalFiles] = await Promise.all([
         preloadPageLabelsForContent(content),
         buildLocalCitationDataMapForContent(content),
-        resolveExternalFileLocalPaths(content),
+        resolveExternalFileCitations(content),
     ]);
+
+    const localCitationDataMap = {
+        ...structuredCitationDataMap,
+        ...externalFiles.citationDataMap,
+    };
+    const externalFileLocalPaths = externalFiles.localPaths;
 
     const hasPageLabels = Object.keys(pageLabelsByAttachmentId).length > 0;
     const hasLocalCitations = Object.keys(localCitationDataMap).length > 0;

--- a/react/utils/citationRenderContext.ts
+++ b/react/utils/citationRenderContext.ts
@@ -148,6 +148,49 @@ export async function buildLocalCitationDataMapForContent(
 }
 
 /**
+ * The most pages one locator is expanded to. A citation naming a longer span is
+ * malformed rather than ambitious, so it keeps only its endpoints: the
+ * reference still reports what it covers without allocating the span.
+ */
+const MAX_CITED_PAGES = 100;
+
+/**
+ * Expand a page locator's value into the 1-based pages it cites.
+ *
+ * A locator carries the range or list the model wrote (`page6-8`, `page6,8`),
+ * while `Citation.pages` is the flat list the renderer collapses back into a
+ * display range. Reading only the locator's first number would silently narrow
+ * the citation to its opening page.
+ */
+function citedPagesFromLocator(value: string | undefined): number[] {
+    if (!value) return [];
+
+    const pages = new Set<number>();
+    // En/em dashes reach here from a model that wrote the range typographically.
+    for (const part of value.replace(/[\u2013\u2014]/g, '-').split(',')) {
+        const [startText, endText] = part.split('-');
+        const start = Number.parseInt(startText ?? '', 10);
+        if (!Number.isSafeInteger(start) || start <= 0) continue;
+
+        const end = endText === undefined ? start : Number.parseInt(endText, 10);
+        if (!Number.isSafeInteger(end) || end <= 0) {
+            pages.add(start);
+            continue;
+        }
+
+        const [low, high] = start <= end ? [start, end] : [end, start];
+        if (high - low >= MAX_CITED_PAGES) {
+            pages.add(low);
+            pages.add(high);
+            continue;
+        }
+        for (let page = low; page <= high; page++) pages.add(page);
+    }
+
+    return [...pages].sort((a, b) => a - b);
+}
+
+/**
  * Resolve the external-file citations in the content against the local
  * `external_files` registry.
  *
@@ -210,7 +253,7 @@ export async function resolveExternalFileCitations(content: string): Promise<{
         const record = recordsByExtKey.get(ref.ext_key);
         if (!record) continue;
 
-        const citedPage = Number.parseInt(getPageLocator(ref) ?? '', 10);
+        const citedPages = citedPagesFromLocator(getPageLocator(ref));
         citationDataMap[`local:${citationKey}`] = {
             citation_id: `local:${citationKey}`,
             run_id: 'local',
@@ -224,7 +267,7 @@ export async function resolveExternalFileCitations(content: string): Promise<{
             requested_ref: ref,
             resolved_ref: ref,
             raw_tag: rawTag,
-            ...(Number.isFinite(citedPage) && citedPage > 0 ? { pages: [citedPage] } : {}),
+            ...(citedPages.length > 0 ? { pages: citedPages } : {}),
         };
     }
 

--- a/react/utils/editNoteActions.ts
+++ b/react/utils/editNoteActions.ts
@@ -3,6 +3,7 @@
  * These functions are used by AgentActionView for post-run action handling.
  */
 
+import { preloadExternalFileCitations } from '../../src/utils/externalFileCitation';
 import { AgentAction } from '../agents/agentActions';
 import type { EditNoteResultData, EditNoteOperation } from '@beaver/agent-core/types/agentActions/editNote';
 import type {
@@ -90,13 +91,12 @@ import {
 } from '../../src/services/agentDataProvider/actions/editNoteBatch';
 import { checkLibraryExcluded, excludedLibraryUserMessage } from '../../src/services/agentDataProvider/utils';
 
-/**
- * Snapshot the thread's external-reference state from the Jotai store so
- * `expandToRawHtml('new', ...)` can resolve `<citation external_id="..."/>`
- * to either an in-library Zotero item or an inline `<a>` link.
- */
-function getExternalRefContext(): ExternalRefContext {
+/** Preload external files and snapshot external-work mappings for note expansion. */
+async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
+    const { files, warnings } = await preloadExternalFileCitations(content);
     return {
+        externalFiles: files,
+        externalFileWarnings: warnings,
         externalRefs: store.get(externalReferenceMappingAtom),
         externalItemMapping: store.get(externalReferenceItemMappingAtom),
     };
@@ -622,6 +622,8 @@ export async function executeEditNoteAction(
         }
     }
 
+    const externalRefContext = await getExternalRefContext(new_string);
+
     // 3. Get current note HTML
     const oldHtml: string = item.getNote();
 
@@ -639,10 +641,6 @@ export async function executeEditNoteAction(
     const structuralLocators = await preloadStructuralLocatorPages(new_string);
     const resolvedLocatorPages = structuralLocators.pages;
     const locatorWarning = buildUnresolvedLocatorWarning(structuralLocators.unresolved);
-
-    // Snapshot external-reference state once so every expandToRawHtml('new', ...)
-    // below can resolve `<citation external_id="..."/>` consistently.
-    const externalRefContext = getExternalRefContext();
 
     // ── rewrite mode: replace entire note body ──
     if (operation === 'rewrite') {
@@ -700,7 +698,7 @@ export async function executeEditNoteAction(
         invalidateSimplificationCache(noteId);
 
         const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-        const warnings = collectWarnings(duplicateWarning, locatorWarning);
+        const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
         return {
             library_id,
@@ -769,7 +767,7 @@ export async function executeEditNoteAction(
         invalidateSimplificationCache(noteId);
 
         const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-        const warnings = collectWarnings(duplicateWarning, locatorWarning);
+        const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
         const result: EditNoteResultData = {
             library_id,
@@ -972,7 +970,7 @@ export async function executeEditNoteAction(
 
     // 15. Check for duplicate citation warnings
     const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-    const warnings = collectWarnings(duplicateWarning, locatorWarning);
+    const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
     const result: EditNoteResultData = {
         library_id,
@@ -1078,6 +1076,11 @@ export async function undoEditNoteAction(
     await item.loadDataType('note');
     const noteId = `${library_id}-${zotero_key}`;
 
+    // Load file references before the undo snapshot, only when raw undo HTML is missing.
+    const externalRefContext = !isDeletion && resultData?.undo_new_html === undefined
+        ? await getExternalRefContext(new_string)
+        : undefined;
+
     // 3. Get current HTML
     const currentHtml = getLatestNoteHtml(item);
 
@@ -1094,7 +1097,6 @@ export async function undoEditNoteAction(
     if (expandedOld === undefined || (!isDeletion && expandedNew === undefined)) {
         const pageLabelsByItemId = await preloadNotePageLabels(currentHtml, library_id);
         const { metadata } = getOrSimplify(noteId, currentHtml, library_id, pageLabelsByItemId);
-        const externalRefContext = getExternalRefContext();
         // Resolve page labels for new_string citations so the fallback
         // expansion translates 1-based page numbers the same way the
         // original execute did.
@@ -1340,7 +1342,7 @@ async function executeBatchSingleRewrite(
     invalidateSimplificationCache(noteId);
 
     const duplicateWarning = checkDuplicateCitations(edit.new_string, metadata);
-    const warnings = collectWarnings(duplicateWarning, locatorWarning);
+    const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
     return {
         library_id,
@@ -1444,11 +1446,11 @@ export async function executeEditNoteBatchAction(
     }
 
     // 3. Snapshot the note once. Every edit resolves against this snapshot.
+    const externalRefContext = await getExternalRefContext(edits.map(edit => edit.new_string).join('\n<!-- edit boundary -->\n'));
     const oldHtml: string = item.getNote();
     const noteId = `${library_id}-${zotero_key}`;
     const pageLabelsByItemId = await preloadNotePageLabels(oldHtml, library_id);
     const { simplified, metadata } = getOrSimplify(noteId, oldHtml, library_id, pageLabelsByItemId);
-    const externalRefContext = getExternalRefContext();
 
     const existingCitationCache = extractDataCitationItems(oldHtml);
     const strippedHtml = stripDataCitationItems(oldHtml);
@@ -1536,7 +1538,7 @@ export async function executeEditNoteBatchAction(
     captureUndoContexts(finalStripped, undoDrafts, newStrippedHtml);
 
     // 8. Warnings: per-edit duplicate-citation + batch locator warnings.
-    const warnings: string[] = [...labels.locatorWarnings];
+    const warnings: string[] = [...labels.locatorWarnings, ...(externalRefContext.externalFileWarnings ?? [])];
     for (const edit of edits) {
         const dup = checkDuplicateCitations(edit.new_string, metadata);
         if (dup) warnings.push(dup);

--- a/react/utils/noteEditorDiffPreview.ts
+++ b/react/utils/noteEditorDiffPreview.ts
@@ -21,6 +21,7 @@
  *   hard backstop.
  */
 
+import { preloadExternalFileCitations } from '../../src/utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import type { EditNoteOperation } from '@beaver/agent-core/types/agentActions/editNote';
 import {
@@ -54,13 +55,12 @@ import {
     externalReferenceItemMappingAtom,
 } from '@beaver/agent-core/citations/externalReferences';
 
-/**
- * Snapshot the thread's external-reference state from the Jotai store so
- * `expandToRawHtml('new', ...)` can resolve `<citation external_id="..."/>`
- * to either an in-library Zotero item or an inline `<a>` link.
- */
-function getExternalRefContext(): ExternalRefContext {
+/** Preload external files and snapshot external-work mappings for note expansion. */
+async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
+    const { files, warnings } = await preloadExternalFileCitations(content);
     return {
+        externalFiles: files,
+        externalFileWarnings: warnings,
         externalRefs: store.get(externalReferenceMappingAtom),
         externalItemMapping: store.get(externalReferenceItemMappingAtom),
     };
@@ -401,7 +401,7 @@ export async function showDiffPreview(
         const noteId = `${libraryId}-${zoteroKey}`;
         const pageLabelsByItemId = await preloadNotePageLabels(rawHtml, libraryId);
         const { metadata } = getOrSimplify(noteId, rawHtml, libraryId, pageLabelsByItemId);
-        const externalRefContext = getExternalRefContext();
+        const externalRefContext = await getExternalRefContext(edits.map(edit => edit.newString ?? '').join('\n<!-- edit boundary -->\n'));
 
         // Resolve page labels for new-citation translation across every edit
         // up-front so the synchronous expansion below can translate 1-based

--- a/src/prosemirror/normalize.ts
+++ b/src/prosemirror/normalize.ts
@@ -16,18 +16,18 @@ import { Metadata } from './metadata';
 import { preprocessHTML, schemaTransform } from './transformer';
 import { buildToHTML } from './serializer';
 
-const ZOTERO_HREF_SHIELD_PREFIX = 'https://zotero-cite.invalid/';
+const LOCAL_HREF_SHIELD_PREFIX = 'https://zotero-cite.invalid/';
 
-function shieldZoteroHrefAttributes(html: string): string {
+function shieldLocalHrefAttributes(html: string): string {
     return html.replace(
-        /href="(zotero:\/\/[^"]*)"/g,
-        (_match, href) => `href="${ZOTERO_HREF_SHIELD_PREFIX}${encodeURIComponent(href)}"`
+        /href="((?:zotero|file):\/\/[^"]*)"/g,
+        (_match, href) => `href="${LOCAL_HREF_SHIELD_PREFIX}${encodeURIComponent(href)}"`
     );
 }
 
-function restoreZoteroHrefAttributes(html: string): string {
+function restoreLocalHrefAttributes(html: string): string {
     return html.replace(
-        new RegExp(`href="${ZOTERO_HREF_SHIELD_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^"]*)"`, 'g'),
+        new RegExp(`href="${LOCAL_HREF_SHIELD_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^"]*)"`, 'g'),
         (match, encodedHref) => {
             try {
                 return `href="${decodeURIComponent(encodedHref)}"`;
@@ -48,8 +48,9 @@ function restoreZoteroHrefAttributes(html: string): string {
 export function normalizeNoteHtml(html: string): string {
     const doc = getDocument();
 
-    // 1. Shield Zotero protocol hrefs before any chrome-document innerHTML parse.
-    const shieldedInput = shieldZoteroHrefAttributes(html);
+    // 1. Chrome-document innerHTML strips local protocol hrefs. Preserve the
+    //    Zotero and file links that the note editor itself supports.
+    const shieldedInput = shieldLocalHrefAttributes(html);
 
     // 2. Preprocess HTML (extract metadata, transform legacy content)
     const { html: preprocessedHtml, metadataAttributes } = preprocessHTML(shieldedInput, doc);
@@ -83,5 +84,5 @@ export function normalizeNoteHtml(html: string): string {
 
     // 7. Serialize back to HTML
     const toHTML = buildToHTML(schema, doc);
-    return restoreZoteroHrefAttributes(toHTML(state.doc.content, metadata));
+    return restoreLocalHrefAttributes(toHTML(state.doc.content, metadata));
 }

--- a/src/services/agentDataProvider/actions/editNote.ts
+++ b/src/services/agentDataProvider/actions/editNote.ts
@@ -1,3 +1,4 @@
+import { preloadExternalFileCitations } from '../../../utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { libraryRefForLibraryID, modelObjectIdFromReference, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
 import { searchableLibraryIdsAtom } from '../../../../react/atoms/profile';
@@ -176,14 +177,12 @@ async function findMarkdownRenderFallbackMatch(
     return findMarkdownRenderMatch({ ...matchInput, ...rendered });
 }
 
-/**
- * Snapshot the thread's external-reference state from the Jotai store so
- * `expandToRawHtml('new', ...)` can resolve `<citation external_id="..."/>`
- * to either an in-library Zotero item or an inline `<a>` link, instead of
- * throwing on attributes the simplifier doesn't natively know about.
- */
-export function getExternalRefContext(): ExternalRefContext {
+/** Load external-file labels/links and snapshot external-work mappings for note expansion. */
+export async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
+    const { files, warnings } = await preloadExternalFileCitations(content);
     return {
+        externalFiles: files,
+        externalFileWarnings: warnings,
         externalRefs: store.get(externalReferenceMappingAtom),
         externalItemMapping: store.get(externalReferenceItemMappingAtom),
     };
@@ -461,7 +460,7 @@ async function validateEditNoteAction(
 
     // Snapshot external-reference state once so every expandToRawHtml('new', ...)
     // below can resolve `<citation external_id="..."/>` consistently.
-    const externalRefContext = getExternalRefContext();
+    const externalRefContext = await getExternalRefContext(new_string);
 
     // ── rewrite mode: skip old_string matching, validate new_string only ──
     if (operation === 'rewrite') {
@@ -485,6 +484,7 @@ async function validateEditNoteAction(
                 match_count: 1,
                 old_content: simplified,
             },
+            warnings: collectWarnings(...(externalRefContext.externalFileWarnings ?? [])),
             preference,
         };
     }
@@ -521,6 +521,7 @@ async function validateEditNoteAction(
                 total_lines: totalLines,
                 match_count: 1,
             },
+            warnings: collectWarnings(...(externalRefContext.externalFileWarnings ?? [])),
             preference,
         };
     }
@@ -708,7 +709,7 @@ async function validateEditNoteAction(
     // 15. Compose new_string: merge for insert operations, otherwise carry
     //     any matcher rewrite. mergeInsertNewString is a no-op for
     //     str_replace / str_replace_all.
-    const warnings: string[] = [];
+    const warnings: string[] = [...(externalRefContext.externalFileWarnings ?? [])];
     const locatorWarning = buildUnresolvedLocatorWarning(structuralLocators.unresolved);
     if (locatorWarning) warnings.push(locatorWarning);
     if (operation === 'insert_after' || operation === 'insert_before') {
@@ -846,6 +847,8 @@ async function executeEditNoteAction(
         }
     }
 
+    const externalRefContext = await getExternalRefContext(new_string);
+
     // 3. Pre-load page labels so new citations resolve page indices to labels.
     //    Done before reading the note to avoid async gaps between read and write.
     const newPageLabels = await preloadPageLabelsForNewCitations(new_string);
@@ -868,10 +871,6 @@ async function executeEditNoteAction(
     const noteId = `${resolvedLibraryId}-${zotero_key}`;
     const pageLabelsByItemId = await preloadNotePageLabels(oldHtml, resolvedLibraryId);
     const { simplified, metadata } = getOrSimplify(noteId, oldHtml, resolvedLibraryId, pageLabelsByItemId);
-
-    // Snapshot external-reference state once so every expandToRawHtml('new', ...)
-    // below can resolve `<citation external_id="..."/>` consistently.
-    const externalRefContext = getExternalRefContext();
 
     // ── rewrite mode: replace entire note body ──
     if (operation === 'rewrite') {
@@ -956,7 +955,7 @@ async function executeEditNoteAction(
 
         // Check for duplicate citation warnings
         const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-        const warnings = collectWarnings(duplicateWarning, locatorWarning);
+        const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
         return {
             type: 'agent_action_execute_response',
@@ -1051,7 +1050,7 @@ async function executeEditNoteAction(
         invalidateSimplificationCache(noteId);
 
         const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-        const warnings = collectWarnings(duplicateWarning, locatorWarning);
+        const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
         const undoData = {
             undo_new_html: expandedNew,
             undo_before_context: undoBeforeContext,
@@ -1339,7 +1338,7 @@ async function executeEditNoteAction(
 
     // 17. Check for duplicate citation warnings
     const duplicateWarning = checkDuplicateCitations(new_string, metadata);
-    const warnings = collectWarnings(duplicateWarning, locatorWarning);
+    const warnings = collectWarnings(duplicateWarning, locatorWarning, ...(externalRefContext.externalFileWarnings ?? []));
 
     // 18. Wait for ProseMirror to normalize the note and update undo data.
     // When the note is open in the editor, PM re-normalizes after saveTx(),

--- a/src/services/agentDataProvider/actions/editNoteBatch.ts
+++ b/src/services/agentDataProvider/actions/editNoteBatch.ts
@@ -174,8 +174,8 @@ export interface PreloadedLabels {
 
 /**
  * Separator inserted between edits' strings before they're concatenated for a
- * single preload scan. It contains a literal `/`, which the citation-tag
- * regex's attribute capture (`[^/]*?`) cannot span, so a partial tag at the
+ * single preload scan. The comment closes with `>`, which the citation-tag
+ * attribute capture cannot span, so a partial tag at the
  * end of one fragment can never merge with content from the next fragment
  * into a false citation match.
  */
@@ -483,7 +483,7 @@ async function validateEditNoteBatchAction(
     const pageLabelsByItemId = await preloadNotePageLabels(rawHtml, resolvedLibraryId, { extractOnCacheMiss: true });
     const { simplified, metadata } = getOrSimplify(noteId, rawHtml, resolvedLibraryId, pageLabelsByItemId);
 
-    const externalRefContext = getExternalRefContext();
+    const externalRefContext = await getExternalRefContext(edits.map(edit => edit.new_string).join(BATCH_LABEL_SEPARATOR));
     const labels = await preloadBatchLabels(edits);
 
     // Strip data-citation-items ONCE — the shared match/apply haystack.
@@ -523,7 +523,7 @@ async function validateEditNoteBatchAction(
     for (const r of resolvedEdits) resolvedByIndex.set(r.index, r);
 
     const normalizedEdits: EditNoteBatchEditItem[] = [];
-    const warnings: string[] = [...labels.locatorWarnings];
+    const warnings: string[] = [...labels.locatorWarnings, ...(externalRefContext.externalFileWarnings ?? [])];
     let anyChanged = false;
     for (const edit of edits) {
         const r = resolvedByIndex.get(edit.index);
@@ -667,6 +667,7 @@ async function executeEditNoteBatchAction(
     }
 
     // Preload page labels for ALL edits before the final note snapshot.
+    const externalRefContext = await getExternalRefContext(edits.map(edit => edit.new_string).join(BATCH_LABEL_SEPARATOR));
     const labels = await preloadBatchLabels(edits);
 
     const preSeedHtml = item.getNote();
@@ -677,7 +678,6 @@ async function executeEditNoteBatchAction(
     const noteId = `${resolvedLibraryId}-${zotero_key}`;
     const pageLabelsByItemId = await preloadNotePageLabels(oldHtml, resolvedLibraryId);
     const { simplified, metadata } = getOrSimplify(noteId, oldHtml, resolvedLibraryId, pageLabelsByItemId);
-    const externalRefContext = getExternalRefContext();
 
     const normalizedOldHtml = normalizeNoteHtml(oldHtml);
     const existingCitationCache = extractDataCitationItems(normalizedOldHtml);
@@ -808,7 +808,7 @@ async function executeEditNoteBatchAction(
     captureUndoContexts(finalStripped, undoDrafts, newStrippedHtml);
 
     // Warnings: per-edit duplicate-citation + batch locator warnings.
-    const warnings: string[] = [...labels.locatorWarnings];
+    const warnings: string[] = [...labels.locatorWarnings, ...(externalRefContext.externalFileWarnings ?? [])];
     for (const edit of edits) {
         const dup = checkDuplicateCitations(edit.new_string, metadata);
         if (dup) warnings.push(dup);
@@ -923,7 +923,7 @@ async function executeSingleRewrite(
     clearNoteEditorSelection(resolvedLibraryId, zotero_key);
     invalidateSimplificationCache(noteId);
 
-    const warnings: string[] = [...labels.locatorWarnings];
+    const warnings: string[] = [...labels.locatorWarnings, ...(externalRefContext.externalFileWarnings ?? [])];
     const dup = checkDuplicateCitations(edit.new_string, metadata);
     if (dup) warnings.push(dup);
 

--- a/src/utils/editNoteValidation.ts
+++ b/src/utils/editNoteValidation.ts
@@ -16,6 +16,7 @@
  *                                  tags to an unresolvable-ref error
  */
 
+import { noteCitationTagPattern } from './noteCitationTags';
 import type { SimplificationMetadata } from './noteHtmlSimplifier';
 import {
     extractAttr,
@@ -76,7 +77,7 @@ export function validateNewString(
     }
 
     // Check for new compound citations (items attr without ref)
-    const compoundRegex = /<citation\s+(?!.*ref=)([^/]*items="[^"]*"[^/]*)\/>/g;
+    const compoundRegex = /<citation\s+(?![^>]*ref=)([^>]*items="[^"]*"[^>]*)\/>/g;
     let compMatch;
     while ((compMatch = compoundRegex.exec(newString)) !== null) {
         return 'Error: Cannot create new compound citations. Insert individual <citation id="..." /> tags instead.';
@@ -97,7 +98,7 @@ export function checkNewCitationItemsExist(
     newString: string,
     metadata: SimplificationMetadata,
 ): string | null {
-    const citationRegex = /<citation\s+([^/]*?)\s*\/>/g;
+    const citationRegex = noteCitationTagPattern();
     let m;
     while ((m = citationRegex.exec(newString)) !== null) {
         const attrStr = m[1];
@@ -142,7 +143,7 @@ export function checkDuplicateCitations(
     metadata: SimplificationMetadata
 ): string | null {
     // Find new citations (item_id without ref) in new_string
-    const newCitationRegex = /<citation\s+(?![^/]*\bref=)([^>]*?)\/>/g;
+    const newCitationRegex = /<citation\s+(?![^>]*\bref=)([^>]*?)\/>/g;
     let match;
     const warnings: string[] = [];
 
@@ -314,7 +315,7 @@ export function enrichOldStringCitationRefs(
     interface Replacement { start: number; end: number; replacement: string; }
     const replacements: Replacement[] = [];
 
-    const citationRe = /<citation\s+([^/]*?)\s*\/>/g;
+    const citationRe = noteCitationTagPattern();
     let m: RegExpExecArray | null;
     while ((m = citationRe.exec(oldString)) !== null) {
         const attrStr = m[1];

--- a/src/utils/externalFileCitation.ts
+++ b/src/utils/externalFileCitation.ts
@@ -1,0 +1,71 @@
+import { noteCitationTagPattern } from './noteCitationTags';
+import {
+    normalizeCitationTag,
+    parseRawCitationAttributes,
+    type Locator,
+} from '@beaver/agent-core/citations/citationGrammar';
+import { escapeAttr, unescapeAttr } from './noteHtmlEntities';
+
+export interface ExternalFileCitationData {
+    filename: string;
+    /** URI of an existing managed copy on this computer. */
+    href?: string;
+}
+
+/** Render a file reference without creating a Zotero/CSL citation. */
+export function formatExternalFileCitationHTML(
+    displayName: string,
+    locatorSuffix: string,
+    href?: string,
+): string {
+    const label = escapeAttr(displayName);
+    const body = href ? `<a href="${escapeAttr(href)}">${label}</a>` : label;
+    return `(${body}${escapeAttr(locatorSuffix)})`;
+}
+
+/** Preserve structural locators as structural locators, not page numbers. */
+export function externalFileLocatorSuffix(loc?: Locator): string {
+    if (!loc) return '';
+    const value = unescapeAttr(loc.value);
+    if (loc.kind === 'page') return `, p. ${value}`;
+    return loc.kind === 'unknown' ? `, ${unescapeAttr(loc.raw)}` : `, ${loc.kind} ${value}`;
+}
+
+/** Load each cited file once; missing copies and metadata remain readable text. */
+export async function preloadExternalFileCitations(content: string): Promise<{
+    files: Record<string, ExternalFileCitationData>;
+    warnings: string[];
+}> {
+    const keys = new Set<string>();
+    const pattern = noteCitationTagPattern();
+    for (const match of content.matchAll(pattern)) {
+        const normalized = normalizeCitationTag(parseRawCitationAttributes(match[1] || ''));
+        if (normalized.ok && normalized.ref.kind === 'external_file') keys.add(normalized.ref.ext_key);
+    }
+    const files: Record<string, ExternalFileCitationData> = {};
+    const warnings: string[] = [];
+    await Promise.all([...keys].map(async (key) => {
+        let filename = `Attached file ext-${key}`;
+        let href: string | undefined;
+        let hasFilename = false;
+        try {
+            const record = await Zotero.Beaver?.db?.getExternalFileByKey(key);
+            if (record?.filename) {
+                filename = record.filename;
+                hasFilename = true;
+            }
+            if (record?.storedPath && await IOUtils.exists(record.storedPath)) {
+                href = Zotero.File.pathToFileURI(record.storedPath);
+            }
+        } catch {
+            // File links are optional; retain the filename if it was loaded.
+        }
+        files[key] = { filename, ...(href ? { href } : {}) };
+        if (!href) {
+            warnings.push(hasFilename
+                ? `External file ext-${key} is represented as filename-and-locator text because its local file link is unavailable.`
+                : `External file ext-${key} has no available filename metadata or local file link; the reference uses its file ID and locator as plain text.`);
+        }
+    }));
+    return { files, warnings };
+}

--- a/src/utils/noteCitationExpand.ts
+++ b/src/utils/noteCitationExpand.ts
@@ -12,6 +12,12 @@
  * exclusively during expansion.
  */
 
+import { noteCitationTagPattern } from './noteCitationTags';
+import {
+    formatExternalFileCitationHTML,
+    externalFileLocatorSuffix,
+    type ExternalFileCitationData,
+} from './externalFileCitation';
 import { createCitationHTML } from './zoteroUtils';
 import { getBestPDFAttachment, getBestPDFAttachmentAsync } from './zoteroItemHelpers';
 import { getAttachmentFileStatus, checkLibraryExcluded } from '../services/agentDataProvider/utils';
@@ -93,7 +99,7 @@ export async function preloadPageLabelsForNewCitations(str: string): Promise<Pag
     if (!cache) return labelsByAttachmentId;
 
     const seen = new Set<number>();
-    const regex = /<citation\s+([^/]*?)\s*\/>/g;
+    const regex = noteCitationTagPattern();
     let match: RegExpExecArray | null;
 
     while ((match = regex.exec(str)) !== null) {
@@ -262,7 +268,7 @@ export async function preloadStructuralLocatorPages(str: string): Promise<Struct
 
     const seen = new Set<string>();
     const resultsByAttachment = new Map<number, Promise<StructuredExtractResult | null>>();
-    const regex = /<citation\s+([^/]*?)\s*\/>/g;
+    const regex = noteCitationTagPattern();
     let match: RegExpExecArray | null;
 
     while ((match = regex.exec(str)) !== null) {
@@ -448,6 +454,9 @@ function parseSimplifiedCitationAttrs(
     resolvedLocatorPages?: ResolvedLocatorPages,
 ): SimplifiedCitationAttrs {
     const normalized = normalizeCitationTag(parseRawCitationAttributes(attrStr));
+    if (normalized.ok && normalized.ref.kind === 'external_file') {
+        throw citationRefNotFoundError('External-file references are stored as links or plain text in notes. Copy the existing link or text from read_note into old_string.');
+    }
     if (!normalized.ok || normalized.ref.kind !== 'zotero') {
         throw new Error('Citation must have an "id" attribute. Legacy "item_id" / "att_id" are also accepted.');
     }
@@ -580,6 +589,9 @@ function buildCitationFromAttId(
  * helpful message instead of silently dropping the citation.
  */
 export interface ExternalRefContext {
+    /** Every external-file key in new_string must have a preloaded entry, including missing files. */
+    externalFiles?: Record<string, ExternalFileCitationData>;
+    externalFileWarnings?: string[];
     /** source_id → ExternalReference object (title, authors, urls, identifiers, ...) */
     externalRefs: Record<string, ExternalReference>;
     /** source_id → mapped Zotero item, or null if checked but not in library */
@@ -706,7 +718,7 @@ export function expandToRawHtml(
 ): string {
     // Expand citations (all self-closing: <citation ... />)
     str = str.replace(
-        /<citation\s+([^/]*?)\s*\/>/g,
+        noteCitationTagPattern(),
         (match, attrStr) => {
             const ref = extractAttr(attrStr, 'ref');
             const explicitItemId = extractAttr(attrStr, 'item_id');
@@ -715,6 +727,23 @@ export function expandToRawHtml(
             const attId = extractAttr(attrStr, 'att_id') || extractAttr(attrStr, 'attachment_id');
             const items = extractAttr(attrStr, 'items');
             const externalId = extractAttr(attrStr, 'external_id');
+
+            const normalizedCitation = normalizeCitationTag(parseRawCitationAttributes(attrStr));
+            // External files are ordinary links/text in notes, including when
+            // replacing an existing Zotero citation's identity in new_string.
+            if (context === 'new' && normalizedCitation.ok && normalizedCitation.ref.kind === 'external_file'
+                && !(ref && metadata.elements.get(ref)?.isCompound)) {
+                const fileRef = normalizedCitation.ref;
+                const file = externalRefContext?.externalFiles?.[fileRef.ext_key];
+                if (!file) {
+                    throw new Error(`External file ext-${fileRef.ext_key} was not preloaded for note expansion.`);
+                }
+                return formatExternalFileCitationHTML(
+                    file.filename,
+                    externalFileLocatorSuffix(fileRef.loc),
+                    file.href,
+                );
+            }
 
             // Case 1: Existing citation (has ref) — look up from metadata map
             if (ref) {
@@ -789,7 +818,6 @@ export function expandToRawHtml(
                 );
             }
             // New citations from the model always use 1-based page numbers → translate
-            const normalizedCitation = normalizeCitationTag(parseRawCitationAttributes(attrStr));
             if (itemId) {
                 const attrs = parseSimplifiedCitationAttrs(attrStr, resolvedLocatorPages);
                 return buildCitationFromSimplifiedAttrs(attrs, true, pageLabels);

--- a/src/utils/noteCitationTags.ts
+++ b/src/utils/noteCitationTags.ts
@@ -1,0 +1,4 @@
+/** Fresh scanner for self-closing note citation tags, including slashes in attribute values. */
+export function noteCitationTagPattern(): RegExp {
+    return /<citation\s+([^>]*?)\s*\/>/g;
+}

--- a/tests/live/editNoteExternalFiles.live.test.ts
+++ b/tests/live/editNoteExternalFiles.live.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
+import { attachExternalFileForTest, deleteExternalFileForTest, post } from '../helpers/zoteroHttpClient';
+import { createNote, deleteNote, readNote, openNoteEditor, closeNoteEditor } from './helpers/noteTestClient';
+
+const LIBRARY_ID = Number(process.env.ZOTERO_TEST_LIBRARY_ID ?? 1);
+let available = false;
+let tempDir: string;
+let file: { extKey: string; filename: string; storedPath: string };
+let note: { library_id: number; zotero_key: string } | undefined;
+
+beforeAll(async () => {
+    available = await isZoteroAvailable();
+    if (!available) return;
+    tempDir = mkdtempSync(join(tmpdir(), 'beaver-note-files-'));
+    const path = join(tempDir, 'Report & findings.txt');
+    writeFileSync(path, `A source for live note citation tests: ${tempDir}`);
+    const response = await attachExternalFileForTest(path);
+    expect(response.ok, response.error).toBe(true);
+    file = response.record!;
+});
+afterEach(async () => {
+    if (note) {
+        await post('/beaver/test/note-preview', { dismiss: true });
+        await closeNoteEditor(note.library_id, note.zotero_key);
+        await deleteNote(note.library_id, note.zotero_key);
+        note = undefined;
+    }
+});
+afterAll(async () => {
+    if (file) await deleteExternalFileForTest(file.extKey);
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+});
+
+const tag = (loc = 'page6', key = file.extKey) => `<citation id="ext-${key}" loc="${loc}"/>`;
+async function seed() {
+    const created = await createNote({ library_id: LIBRARY_ID, html: '<p>First anchor.</p><p>Second anchor.</p>' });
+    expect(created.error).toBeFalsy();
+    note = { library_id: created.library_id, zotero_key: created.zotero_key };
+}
+async function apply(actionType: string, data: any, useNormalized = true) {
+    const validation = await post<any>('/beaver/agent-action/validate', { action_type: actionType, action_data: data });
+    expect(validation.valid, JSON.stringify(validation)).toBe(true);
+    const result = await post<any>('/beaver/agent-action/execute', {
+        action_type: actionType, action_data: useNormalized ? { ...data, ...validation.normalized_action_data } : data,
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    return { validation, result };
+}
+
+function expectFileReference(html: string) {
+    expect(html).toContain('Report &amp; findings.txt</a>');
+    expect(html).toContain(pathToFileURL(file.storedPath).href.replace(/&/g, '&amp;'));
+    expect(html).toContain('p. 6');
+    expect(html).not.toContain('<citation');
+    expect(html).not.toContain('data-citation=');
+}
+
+describe('external-file note citations (live)', () => {
+    beforeEach((ctx) => skipIfNoZotero(ctx, available));
+
+    it.each(['rewrite', 'append', 'str_replace'])('supports single %s, editor round-trip, read and targeted edit', async (operation) => {
+        await seed();
+        await apply('edit_note', { ...note, operation, old_string: 'First anchor.', new_string: `<p>Source ${tag()}</p>` });
+        expectFileReference((await readNote(note!.library_id, note!.zotero_key)).saved_html);
+        await openNoteEditor(note!.library_id, note!.zotero_key);
+        await closeNoteEditor(note!.library_id, note!.zotero_key);
+        expectFileReference((await readNote(note!.library_id, note!.zotero_key)).saved_html);
+        const read = await post<any>('/beaver/note/read', { note_id: `${note!.library_id}-${note!.zotero_key}` });
+        expect(read.success, JSON.stringify(read)).toBe(true);
+        const link = read.content.match(/<a\b[^>]*>Report &amp; findings\.txt<\/a>/)?.[0];
+        expect(link, read.content).toBeTruthy();
+        await apply('edit_note', { ...note, old_string: link, new_string: link.replace('Report &amp; findings.txt', 'Renamed source') });
+        expect((await readNote(note!.library_id, note!.zotero_key)).saved_html).toContain('Renamed source</a>');
+    });
+
+    it.each([true, false])('applies a mixed batch with a file link and fallback (normalized=%s)', async (useNormalized) => {
+        await seed();
+        const { validation, result } = await apply('edit_note_batch', {
+            ...note,
+            edits: [
+                { index: 0, old_string: 'First anchor.', new_string: tag() },
+                { index: 1, old_string: 'Second anchor.', new_string: tag('s4', 'ZZZZZZZZ') },
+            ],
+        }, useNormalized);
+        const html = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+        expectFileReference(html);
+        expect(html).toContain('(Attached file ext-ZZZZZZZZ, sentence 4)');
+        expect(validation.warnings?.join(' ')).toContain('ext-ZZZZZZZZ');
+        if (!useNormalized) expect(result.result_data.warnings.join(' ')).toContain('ext-ZZZZZZZZ');
+    });
+
+    it.each(['edit_note', 'edit_note_batch'])('previews, approves and undoes a %s action with an external-file link', async (actionType) => {
+        await seed();
+        const original = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+        const opened = await openNoteEditor(note!.library_id, note!.zotero_key, false);
+        expect(opened.ok, opened.error).toBe(true);
+        const newString = tag();
+        const preview = await post<any>('/beaver/test/note-preview', {
+            ...note, edits: [{ oldString: 'First anchor.', newString }],
+        });
+        expect(preview.ok, JSON.stringify(preview)).toBe(true);
+        expect(preview.html).toContain('Report &amp; findings.txt');
+        expect(preview.html).toContain(pathToFileURL(file.storedPath).href.replace(/&/g, '&amp;'));
+        expect(preview.html).not.toContain('Attached file ext-');
+        expect((await readNote(note!.library_id, note!.zotero_key)).saved_html).toBe(original);
+        await post('/beaver/test/note-preview', { dismiss: true });
+        const edit = { index: 0, operation: 'str_replace', old_string: 'First anchor.', new_string: newString };
+        const action = {
+            id: `external-note-${actionType}`, action_type: actionType, status: 'pending',
+            proposed_data: actionType === 'edit_note' ? { ...note, ...edit } : { ...note, edits: [edit] },
+        };
+        const applied = await post<any>('/beaver/test/note-apply', { action });
+        expect(applied.ok, JSON.stringify(applied)).toBe(true);
+        expectFileReference((await readNote(note!.library_id, note!.zotero_key)).saved_html);
+        if (actionType === 'edit_note') {
+            delete applied.result_data.undo_new_html;
+            delete applied.result_data.undo_old_html;
+        }
+        const undo = await post<any>('/beaver/test/note-undo', {
+            action: { ...action, status: 'applied', result_data: applied.result_data },
+        });
+        expect(undo.ok, JSON.stringify(undo)).toBe(true);
+        const restored = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+        expect(restored).toContain('First anchor.');
+        expect(restored).not.toContain('Report &amp; findings.txt');
+    });
+
+    it.each(['edit_note', 'edit_note_batch'])('reports missing filename metadata in React %s approval', async (actionType) => {
+        await seed();
+        const edit = { index: 0, operation: 'str_replace', old_string: 'First anchor.', new_string: tag('1/2', 'ZZZZZZZZ') };
+        const applied = await post<any>('/beaver/test/note-apply', { action: {
+            id: 'external-note-missing', action_type: actionType,
+            proposed_data: actionType === 'edit_note' ? { ...note, ...edit } : { ...note, edits: [edit] },
+        } });
+        expect(applied.ok, JSON.stringify(applied)).toBe(true);
+        expect(applied.result_data.warnings.join(' ')).toContain('no available filename metadata');
+        const html = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+        expect(html).toContain('(Attached file ext-ZZZZZZZZ, 1/2)');
+        expect(html).not.toContain('<citation');
+    });
+
+    it('supports batch rewrite and preserves page ranges', async () => {
+        await seed();
+        await apply('edit_note_batch', { ...note, edits: [{ index: 0, operation: 'rewrite', new_string: `<p>${tag('page6-8')}</p>` }] });
+        const html = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+        expect(html).toContain('p. 6-8');
+        expect(html).toContain('Report &amp; findings.txt</a>');
+    });
+
+    it('uses the filename when the managed copy is deleted before execution', async () => {
+        await seed();
+        // This unique source is separate from the fixture used by other tests.
+        const path = join(tempDir, 'Missing copy.txt');
+        writeFileSync(path, `Missing copy fixture ${tempDir}`);
+        const attached = await attachExternalFileForTest(path);
+        expect(attached.ok).toBe(true);
+        const record = attached.record!;
+        try {
+            const data = { ...note, operation: 'append', new_string: `<p>${tag('paragraph2', record.extKey)}</p>` };
+            const validation = await post<any>('/beaver/agent-action/validate', { action_type: 'edit_note', action_data: data });
+            expect(validation.valid).toBe(true);
+            rmSync(record.storedPath);
+            const execution = await post<any>('/beaver/agent-action/execute', { action_type: 'edit_note', action_data: data });
+            expect(execution.success, JSON.stringify(execution)).toBe(true);
+            expect(execution.result_data.warnings.join(' ')).toContain(`ext-${record.extKey}`);
+            const html = (await readNote(note!.library_id, note!.zotero_key)).saved_html;
+            expect(html).toContain('(Missing copy.txt, paragraph 2)');
+            expect(html).not.toContain('file:');
+        } finally {
+            await deleteExternalFileForTest(record.extKey);
+        }
+    });
+});

--- a/tests/unit/host/citationExport.test.ts
+++ b/tests/unit/host/citationExport.test.ts
@@ -66,3 +66,27 @@ describe('zoteroDocumentExport.renderCitation', () => {
         expect(Zotero.Items.getByLibraryAndKey).toHaveBeenCalledWith(7, 'ABCD1234');
     });
 });
+
+describe('zoteroDocumentExport.renderExternalFileCitation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (Zotero as any).File = { pathToFileURI: vi.fn(() => 'file:///Report%20%26%20findings.pdf') };
+    });
+
+    it('uses the shared escaped file-link format', () => {
+        expect(zoteroDocumentExport.renderExternalFileCitation!({
+            externalFileKey: 'MRDTFYHP', displayName: 'Report & findings.pdf',
+            locatorSuffix: ', p. 6', localPathsByExtKey: { MRDTFYHP: '/Report & findings.pdf' },
+        })).toEqual({
+            kind: 'html',
+            html: '(<a href="file:///Report%20%26%20findings.pdf">Report &amp; findings.pdf</a>, p. 6)',
+        });
+    });
+
+    it('lets the render layer fall back to text when no local file is available', () => {
+        expect(zoteroDocumentExport.renderExternalFileCitation!({
+            externalFileKey: 'MRDTFYHP', displayName: 'Report.pdf',
+            locatorSuffix: ', p. 6', localPathsByExtKey: {},
+        })).toBeNull();
+    });
+});

--- a/tests/unit/notes/editNoteUndoRoundtrip.test.ts
+++ b/tests/unit/notes/editNoteUndoRoundtrip.test.ts
@@ -12,7 +12,7 @@
  * known limitations (e.g., replace_all with PM normalization).
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // =============================================================================
 // Module Mocks (must be before imports)
@@ -87,9 +87,12 @@ import {
 } from '../../../src/utils/noteWrapper';
 import {
     executeEditNoteAction,
+    executeEditNoteOrBatchAction,
     undoEditNoteAction,
 } from '../../../react/utils/editNoteActions';
 import type { AgentAction } from '../../../react/agents/agentActions';
+import { store } from '../../../react/store';
+import { searchableLibraryIdsAtom } from '../../../react/atoms/profile';
 import type { EditNoteResultData } from '@beaver/agent-core/types/agentActions/editNote';
 
 // =============================================================================
@@ -2194,5 +2197,67 @@ describe('manual-Apply uses the full ranked matcher', () => {
 
         expect(caught).toBeDefined();
         expect(caught.code).toBe('old_string_not_found');
+    });
+});
+
+
+describe('external-file citations through React apply and undo', () => {
+    const tag = '<citation id="ext-MRDTFYHP" loc="page6"/>';
+    let previousBeaver: any;
+    let previousFile: any;
+    let previousLibraryGet: any;
+    beforeEach(() => {
+        previousBeaver = Zotero.Beaver;
+        previousFile = Zotero.File;
+        previousLibraryGet = Zotero.Libraries.get;
+        (Zotero.Libraries as any).get = vi.fn(() => ({ editable: true }));
+        vi.mocked(store.get).mockImplementation((atom: any) => atom === searchableLibraryIdsAtom ? [1] : null);
+        (Zotero as any).Beaver = { db: { getExternalFileByKey: vi.fn(async () => ({
+            filename: 'Report.pdf', storedPath: '/stored/Report.pdf',
+        })) } };
+        (Zotero as any).File = { pathToFileURI: vi.fn(() => 'file:///stored/Report.pdf') };
+        vi.mocked(IOUtils.exists).mockResolvedValue(true);
+    });
+    afterEach(() => {
+        (Zotero as any).Beaver = previousBeaver;
+        (Zotero as any).File = previousFile;
+        Zotero.Libraries.get = previousLibraryGet;
+        vi.mocked(store.get).mockImplementation(() => null);
+    });
+
+    it('applies a filename link and can undo without stored undo HTML', async () => {
+        const { item, action } = await applyEdit({ noteHtml: wrap('<p>Anchor</p>'), oldString: 'Anchor', newString: tag });
+        expect(item._getHtml()).toContain('href="file:///stored/Report.pdf"');
+        expect(item._getHtml()).toContain('Report.pdf</a>, p. 6');
+        delete (action.result_data as any).undo_new_html;
+        delete (action.result_data as any).undo_old_html;
+        const restored = await undoEdit(item, action);
+        expect(restored).toContain('<p>Anchor</p>');
+        expect(restored).not.toContain('Report.pdf');
+    });
+
+    it.each(['rewrite', 'append', 'str_replace'])('loads external files for React %s', async (operation) => {
+        const item = createMockNoteItem(wrap('<p>Anchor</p>'));
+        (Zotero.Items.getByLibraryAndKeyAsync as any).mockResolvedValue(item);
+        const action = makeAction(1, 'TESTKEY', 'Anchor', tag);
+        (action.proposed_data as any).operation = operation;
+        const result = await executeEditNoteOrBatchAction(action);
+        expect(item._getHtml()).toContain('href="file:///stored/Report.pdf"');
+        expect(item._getHtml()).not.toContain('Attached file ext-');
+        expect(result.warnings).toBeUndefined();
+    });
+
+    it.each(['rewrite', 'str_replace'])('loads files and reports missing metadata for a React batch %s', async (operation) => {
+        vi.mocked(Zotero.Beaver.db.getExternalFileByKey).mockResolvedValue(null);
+        const item = createMockNoteItem(wrap('<p>Anchor</p>'));
+        (Zotero.Items.getByLibraryAndKeyAsync as any).mockResolvedValue(item);
+        const action = makeAction(1, 'TESTKEY', 'Anchor', tag);
+        action.action_type = 'edit_note_batch';
+        action.proposed_data = { library_id: 1, zotero_key: 'TESTKEY', edits: [
+            { index: 0, operation, old_string: 'Anchor', new_string: tag },
+        ] } as any;
+        const result = await executeEditNoteOrBatchAction(action);
+        expect(item._getHtml()).toContain('(Attached file ext-MRDTFYHP, p. 6)');
+        expect(result.warnings?.[0]).toContain('no available filename metadata');
     });
 });

--- a/tests/unit/utils/citationRenderContext.test.ts
+++ b/tests/unit/utils/citationRenderContext.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../react/utils/pageLabels', () => ({
 import {
     buildLocalCitationDataMapForContent,
     prepareCitationRenderContext,
-    resolveExternalFileLocalPaths,
+    resolveExternalFileCitations,
 } from '../../../react/utils/citationRenderContext';
 import {
     getCitationPreloadFilePath,
@@ -182,8 +182,14 @@ describe('citation render context', () => {
         expect(cache.getResult).not.toHaveBeenCalled();
     });
 
-    describe('resolveExternalFileLocalPaths', () => {
+    describe('resolveExternalFileCitations', () => {
         let db: any;
+        const record = {
+            extKey: 'AB12CD34',
+            filename: 'Field notes.pdf',
+            storedPath: '/beaver/external-files/AB12CD34.pdf',
+            contentKind: 'pdf',
+        };
 
         beforeEach(() => {
             db = { getExternalFileByKey: vi.fn() };
@@ -191,35 +197,78 @@ describe('citation render context', () => {
         });
 
         it('returns local paths for external files present on this computer', async () => {
-            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/beaver/external-files/AB12CD34.pdf' });
+            db.getExternalFileByKey.mockResolvedValue(record);
             (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
 
-            const map = await resolveExternalFileLocalPaths('See <citation id="ext-ab12cd34"/>');
+            const { localPaths } = await resolveExternalFileCitations('See <citation id="ext-ab12cd34"/>');
 
             // Ext key normalized to uppercase before the DB lookup.
             expect(db.getExternalFileByKey).toHaveBeenCalledWith('AB12CD34');
-            expect(map).toEqual({ AB12CD34: '/beaver/external-files/AB12CD34.pdf' });
+            expect(localPaths).toEqual({ AB12CD34: '/beaver/external-files/AB12CD34.pdf' });
         });
 
         it('omits external files with no local copy on this computer', async () => {
-            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/beaver/external-files/AB12CD34.pdf' });
+            db.getExternalFileByKey.mockResolvedValue(record);
             (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(false);
 
-            const map = await resolveExternalFileLocalPaths('See <citation id="ext-ab12cd34"/>');
+            const { localPaths } = await resolveExternalFileCitations('See <citation id="ext-ab12cd34"/>');
 
-            expect(map).toEqual({});
+            expect(localPaths).toEqual({});
         });
 
-        it('dedupes repeated ext keys and ignores non-external-file citations', async () => {
-            db.getExternalFileByKey.mockResolvedValue({ storedPath: '/p/AB12CD34.pdf' });
+        it('names an external file from the registry even with no local copy', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(false);
+
+            const { citationDataMap } = await resolveExternalFileCitations('See <citation id="ext-ab12cd34"/>');
+
+            expect(citationDataMap['local:extfile:AB12CD34']).toMatchObject({
+                citation_type: 'external_file',
+                content_kind: 'pdf',
+                display_name: 'Field notes.pdf',
+                resolved_ref: { kind: 'external_file', ext_key: 'AB12CD34' },
+            });
+        });
+
+        it('carries the cited page so the export keeps its locator', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
             (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
 
-            const map = await resolveExternalFileLocalPaths(
+            const { citationDataMap } = await resolveExternalFileCitations(
+                'See <citation id="ext-ab12cd34" loc="page3"/>'
+            );
+
+            const citation = citationDataMap['local:extfile:AB12CD34:page3'];
+            expect(citation).toBeDefined();
+            expect(citation.pages).toEqual([3]);
+        });
+
+        it('builds no citation for a file this device does not have', async () => {
+            db.getExternalFileByKey.mockResolvedValue(null);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(false);
+
+            const { localPaths, citationDataMap } = await resolveExternalFileCitations(
+                'See <citation id="ext-ab12cd34"/>'
+            );
+
+            expect(localPaths).toEqual({});
+            expect(citationDataMap).toEqual({});
+        });
+
+        it('reads each file once and ignores non-external-file citations', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const { localPaths, citationDataMap } = await resolveExternalFileCitations(
                 'A <citation id="ext-ab12cd34"/> B <citation id="ext-ab12cd34" loc="page2"/> C <citation id="1-ATTACH01"/>'
             );
 
             expect(db.getExternalFileByKey).toHaveBeenCalledTimes(1);
-            expect(map).toEqual({ AB12CD34: '/p/AB12CD34.pdf' });
+            expect(localPaths).toEqual({ AB12CD34: '/beaver/external-files/AB12CD34.pdf' });
+            expect(Object.keys(citationDataMap)).toEqual([
+                'local:extfile:AB12CD34',
+                'local:extfile:AB12CD34:page2',
+            ]);
         });
     });
 });

--- a/tests/unit/utils/citationRenderContext.test.ts
+++ b/tests/unit/utils/citationRenderContext.test.ts
@@ -243,6 +243,39 @@ describe('citation render context', () => {
             expect(citation.pages).toEqual([3]);
         });
 
+        it('keeps every page of a cited range so the export shows the full span', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const { citationDataMap } = await resolveExternalFileCitations(
+                'See <citation id="ext-ab12cd34" loc="page6-8"/>'
+            );
+
+            expect(citationDataMap['local:extfile:AB12CD34:page6-8'].pages).toEqual([6, 7, 8]);
+        });
+
+        it('keeps every page of a comma-separated locator', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const { citationDataMap } = await resolveExternalFileCitations(
+                'See <citation id="ext-ab12cd34" loc="page2,5-6"/>'
+            );
+
+            expect(citationDataMap['local:extfile:AB12CD34:page2,5-6'].pages).toEqual([2, 5, 6]);
+        });
+
+        it('keeps only the endpoints of an implausibly long range', async () => {
+            db.getExternalFileByKey.mockResolvedValue(record);
+            (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(true);
+
+            const { citationDataMap } = await resolveExternalFileCitations(
+                'See <citation id="ext-ab12cd34" loc="page1-999999"/>'
+            );
+
+            expect(citationDataMap['local:extfile:AB12CD34:page1-999999'].pages).toEqual([1, 999999]);
+        });
+
         it('builds no citation for a file this device does not have', async () => {
             db.getExternalFileByKey.mockResolvedValue(null);
             (globalThis as any).IOUtils.exists = vi.fn().mockResolvedValue(false);

--- a/tests/unit/utils/externalFileCitation.test.ts
+++ b/tests/unit/utils/externalFileCitation.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/utils/zoteroUtils', () => ({ createCitationHTML: vi.fn() }));
+vi.mock('../../../src/services/agentDataProvider/utils', () => ({
+    getAttachmentFileStatus: vi.fn(), checkLibraryExcluded: vi.fn(() => null),
+}));
+
+import { preloadExternalFileCitations } from '../../../src/utils/externalFileCitation';
+import { expandToRawHtml } from '../../../src/utils/noteCitationExpand';
+import { simplifyNoteHtml } from '../../../src/utils/noteHtmlSimplifier';
+
+const tag = '<citation id="ext-MRDTFYHP" loc="page6"/>';
+const metadata = () => ({ elements: new Map() } as any);
+const context = (files: any) => ({ externalRefs: {}, externalItemMapping: {}, externalFiles: files });
+const lookup = vi.fn();
+
+describe('external file citations in notes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (Zotero as any).Beaver = { db: { getExternalFileByKey: lookup } };
+        (Zotero as any).File = { pathToFileURI: vi.fn(() => 'file:///stored/Report.pdf') };
+        vi.mocked(IOUtils.exists).mockResolvedValue(true);
+        lookup.mockResolvedValue({ filename: 'Report.pdf', storedPath: '/stored/Report.pdf' });
+    });
+
+    it.each([undefined, { externalRefs: {}, externalItemMapping: {} }, context({})])(
+        'rejects external-file expansion without a completed preload', (ctx) => {
+            expect(() => expandToRawHtml(tag, metadata(), 'new', ctx)).toThrow('was not preloaded');
+        },
+    );
+
+    it('scans and expands a citation with a slash in its locator', async () => {
+        const input = tag.replace('page6', '1/2');
+        const { files } = await preloadExternalFileCitations(input);
+        expect(lookup).toHaveBeenCalledTimes(1);
+        expect(expandToRawHtml(input, metadata(), 'new', context(files)))
+            .toBe('(<a href="file:///stored/Report.pdf">Report.pdf</a>, 1/2)');
+    });
+
+    it('preloads each file once and expands to a link with a page', async () => {
+        const { files, warnings } = await preloadExternalFileCitations(tag + tag.toLowerCase());
+        expect(lookup).toHaveBeenCalledTimes(1);
+        expect(lookup).toHaveBeenCalledWith('MRDTFYHP');
+        expect(warnings).toEqual([]);
+        expect(expandToRawHtml(tag, metadata(), 'new', context(files)))
+            .toBe('(<a href="file:///stored/Report.pdf">Report.pdf</a>, p. 6)');
+    });
+
+    it.each(['page6-8', 's4', 'paragraph2', 'custom-location'])('preserves locator %s', (loc) => {
+        const expected = {
+            'page6-8': 'p. 6-8', s4: 'sentence 4', paragraph2: 'paragraph 2',
+            'custom-location': 'custom-location',
+        }[loc];
+        expect(expandToRawHtml(`<citation id="ext-MRDTFYHP" loc="${loc}"/>`, metadata(), 'new',
+            context({ MRDTFYHP: { filename: 'Report.pdf' } }))).toBe(`(Report.pdf, ${expected})`);
+    });
+
+    it('escapes filenames, locators and link attributes', () => {
+        const result = expandToRawHtml('<citation id="ext-MRDTFYHP" loc="page6&amp;7"/>', metadata(), 'new',
+            context({ MRDTFYHP: { filename: 'A <B> & "C".pdf', href: 'file:///x?y="&z' } }));
+        expect(result).toContain('A &lt;B&gt; &amp; &quot;C&quot;.pdf');
+        expect(result).toContain('href="file:///x?y=&quot;&amp;z"');
+        expect(result).toContain('p. 6&amp;7');
+    });
+
+    it('uses the filename and warns when the managed copy is missing', async () => {
+        vi.mocked(IOUtils.exists).mockResolvedValue(false);
+        const { files, warnings } = await preloadExternalFileCitations(tag);
+        expect(expandToRawHtml(tag, metadata(), 'new', context(files))).toBe('(Report.pdf, p. 6)');
+        expect(warnings).toHaveLength(1);
+        expect(Zotero.File.pathToFileURI).not.toHaveBeenCalled();
+    });
+
+    it('retains the filename when checking the file fails', async () => {
+        vi.mocked(IOUtils.exists).mockRejectedValue(new Error('unavailable'));
+        const { files } = await preloadExternalFileCitations(tag);
+        expect(expandToRawHtml(tag, metadata(), 'new', context(files))).toBe('(Report.pdf, p. 6)');
+    });
+
+    it('preserves the file identity when metadata is unavailable', async () => {
+        lookup.mockResolvedValue(null);
+        const { files, warnings } = await preloadExternalFileCitations(tag);
+        expect(expandToRawHtml(tag, metadata(), 'new', context(files)))
+            .toBe('(Attached file ext-MRDTFYHP, p. 6)');
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('no available filename metadata');
+    });
+
+    it('can replace an existing citation with a file reference', () => {
+        const meta = metadata();
+        meta.elements.set('c_existing', { rawHtml: 'old citation', originalAttrs: { item_id: 'u-ABCD1234' } });
+        expect(expandToRawHtml(tag.replace('id=', 'ref="c_existing" id='), meta, 'new',
+            context({ MRDTFYHP: { filename: 'Report.pdf' } }))).toBe('(Report.pdf, p. 6)');
+        expect(() => expandToRawHtml(tag.replace('id=', 'ref="c_existing" id='), meta, 'old'))
+            .toThrow('Copy the existing link or text from read_note');
+    });
+
+    it('keeps existing compound citations immutable', () => {
+        const meta = metadata();
+        meta.elements.set('c_existing', { rawHtml: 'compound citation', isCompound: true });
+        expect(expandToRawHtml(tag.replace('id=', 'ref="c_existing" id='), meta, 'new'))
+            .toBe('compound citation');
+    });
+
+    it('requires old_string to use the stored link, and round-trips that link', () => {
+        expect(() => expandToRawHtml(tag, metadata(), 'old')).toThrow('was not found in the note');
+        const raw = '<p>' + expandToRawHtml(tag, metadata(), 'new',
+            context({ MRDTFYHP: { filename: 'Report.pdf', href: 'file:///Report.pdf' } })) + '</p>';
+        const simplified = simplifyNoteHtml(raw, 1);
+        expect(simplified.simplified).toContain('href="file:///Report.pdf"');
+        expect(expandToRawHtml(simplified.simplified, simplified.metadata, 'old')).toContain('Report.pdf</a>');
+    });
+});

--- a/tests/unit/utils/noteEditorDiffPreview.test.ts
+++ b/tests/unit/utils/noteEditorDiffPreview.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
+
 vi.mock('../../../react/store', () => ({
     store: { get: vi.fn(() => null) },
 }));
@@ -63,6 +65,7 @@ import {
     isDiffPreviewPendingFor,
     isDiffPreviewPending,
 } from '../../../react/utils/noteEditorDiffPreview';
+import { logger } from '@beaver/agent-core/platform/logger';
 import { preloadNotePageLabels } from '../../../src/utils/noteCitationExpand';
 
 describe('constructMultiDiffHtml', () => {
@@ -309,6 +312,31 @@ describe('showDiffPreview approveAll revision-guard flow', () => {
             await p;
         } finally {
             vi.useRealTimers();
+        }
+    });
+
+    it('previews a preloaded external-file filename and link', async () => {
+        vi.useFakeTimers();
+        const h = makeHarness(NOTE);
+        const previousBeaver = Zotero.Beaver;
+        const previousFile = Zotero.File;
+        try {
+            (Zotero as any).Beaver = { db: { getExternalFileByKey: vi.fn(async () => ({
+                filename: 'Report.pdf', storedPath: '/stored/Report.pdf',
+            })) } };
+            (Zotero as any).File = { pathToFileURI: vi.fn(() => 'file:///stored/Report.pdf') };
+            vi.mocked(IOUtils.exists).mockResolvedValue(true);
+            const shown = await showDiffPreview(1, 'NOTE0001', [{
+                operation: 'append', oldString: '', newString: '<p><citation id="ext-MRDTFYHP" loc="page6"/></p>',
+            }]);
+            expect(shown, JSON.stringify(vi.mocked(logger).mock.calls)).toBe(true);
+            const html = h.applyIncrementalUpdate.mock.calls[0][0].html;
+            expect(html).toContain('href="file:///stored/Report.pdf"');
+            expect(html).toContain('Report.pdf');
+            expect(html).not.toContain('Attached file ext-');
+        } finally {
+            (Zotero as any).Beaver = previousBeaver;
+            (Zotero as any).File = previousFile;
         }
     });
 


### PR DESCRIPTION
## Summary

- Resolve external file citation tags to readable filenames and optional local file links.
- Preserve file and Zotero protocol links through note normalization and editing.
- Add external-file citation handling to note previews, edits, batches, undo flows, and exports.
- Add test-only endpoints and coverage for applying edits and rendering previews.

## Testing

- Added unit tests for external file citations, citation rendering, note previews, note editing, undo round-trips, and citation export.
- Added live coverage for editing notes containing external file citations.