### PR TITLE
feat(quick-prompt): improve focus handoff and collection attachments

### DIFF
--- a/react/atoms/messageComposition.ts
+++ b/react/atoms/messageComposition.ts
@@ -1,3 +1,5 @@
+import { getSelectedCollections } from '../../src/utils/zoteroSelection';
+import { collectionToReference } from '../utils/zoteroReferences';
 import { atom } from "jotai";
 import { truncateText } from "@beaver/agent-ui/utils/stringUtils";
 import { allUserAttachmentKeysAtom } from "@beaver/agent-core/run-state/atoms";
@@ -582,6 +584,19 @@ async function validateItemsInBackground(
         logger(`Background validation failed: ${error.message}`, 1);
     }
 }
+
+/** Attach the active pane's selected collections from searchable libraries. */
+export const updateMessageCollectionsFromZoteroSelectionAtom = atom(null, (get, set) => {
+    try {
+        const searchableLibraryIds = get(searchableLibraryIdsAtom);
+        const collections = getSelectedCollections(Zotero.getActiveZoteroPane());
+        set(currentMessageCollectionsAtom, collections
+            .filter(collection => !collection.deleted && searchableLibraryIds.includes(collection.libraryID))
+            .map(collectionToReference));
+    } catch (error) {
+        logger(`Could not attach selected collections: ${error}`, 1);
+    }
+});
 
 /**
 * Update sources based on Zotero selection

--- a/react/atoms/threads.ts
+++ b/react/atoms/threads.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { currentMessageItemsAtom, clearComposerAtom, currentMessageCollectionsAtom, currentMessageExternalFilesAtom, updateMessageItemsFromZoteroSelectionAtom, updateReaderAttachmentAtom } from "./messageComposition";
+import { currentMessageItemsAtom, clearComposerAtom, currentMessageCollectionsAtom, currentMessageExternalFilesAtom, updateMessageItemsFromZoteroSelectionAtom, updateMessageCollectionsFromZoteroSelectionAtom, updateReaderAttachmentAtom } from "./messageComposition";
 import { isAtBottomAtom, isLibraryTabAtom, isWebSearchEnabledAtom, removePopupMessagesByTypeAtom, userScrolledAtom, windowIsAtBottomAtom, windowUserScrolledAtom } from "./ui";
 
 import { citationsAtom, citationMapAtom, processCitationsAtom, resetCitationMarkersAtom, mergePageLabelsByAttachmentIdAtom } from "@beaver/agent-core/citations/atoms";
@@ -366,6 +366,7 @@ export const newThreadAtom = atom(
                 if (isLibraryTab && addSelectedItemsOnNewThread) {
                     const maxAddAttachmentToMessage = getPref('maxAddAttachmentToMessage');
                     set(updateMessageItemsFromZoteroSelectionAtom, maxAddAttachmentToMessage);
+                    set(updateMessageCollectionsFromZoteroSelectionAtom);
                 }
                 if (!isLibraryTab) {
                     await set(updateReaderAttachmentAtom);

--- a/react/components/input/DragDropWrapper.tsx
+++ b/react/components/input/DragDropWrapper.tsx
@@ -16,6 +16,7 @@ import { SettingsIcon } from '../icons/icons';
 
 interface DragDropWrapperProps {
     children: React.ReactNode;
+    overlayBorderRadius?: number;
 }
 
 /** True when the drag carries OS files (not Zotero objects). */
@@ -43,7 +44,8 @@ const getDroppedFiles = (dataTransfer: DataTransfer): Array<{ path: string }> =>
 };
 
 const DragDropWrapper: React.FC<DragDropWrapperProps> = ({
-    children
+    children,
+    overlayBorderRadius = 6
 }) => {
     // Drag and drop states
     const [objectIcon, setObjectIcon] = useState<string | null>(null);
@@ -510,7 +512,7 @@ const DragDropWrapper: React.FC<DragDropWrapperProps> = ({
                 className="absolute inset-0 display-flex items-center justify-center z-10 bg-overlay border-popup"
                 style={{ 
                     opacity: isDragging ? 0.8 : 0, 
-                    borderRadius: '6px', 
+                    borderRadius: overlayBorderRadius,
                     transition: 'opacity 0.3s ease',
                     pointerEvents: isDragging ? 'auto' : 'none',
                     visibility: isDragging ? 'visible' : 'hidden'
@@ -552,7 +554,7 @@ const DragDropWrapper: React.FC<DragDropWrapperProps> = ({
                 style={{ 
                     background: 'var(--color-background)', 
                     opacity: dragError ? 0.6 : 0, 
-                    borderRadius: '6px', 
+                    borderRadius: overlayBorderRadius,
                     transition: 'opacity 0.3s ease',
                     pointerEvents: dragError ? 'auto' : 'none',
                     visibility: dragError ? 'visible' : 'hidden'

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -399,11 +399,11 @@ const PreferencePage: React.FC = () => {
                                 }
                             />
                             <SettingsRow
-                                title="Add Selected Items to New Threads"
-                                description="Automatically attach selected items to new thread"
+                                title="Add Selected Items and Collections to New Threads"
+                                description="Automatically attach selected items and collections to new threads"
                                 onClick={handleAddSelectedOnNewThreadToggle}
                                 hasBorder
-                                tooltip="When enabled, any items you have selected in Zotero will be automatically added as sources when you start a new conversation thread."
+                                tooltip="When enabled, selected Zotero items and collections are attached when you start a new conversation, including from the quick prompt."
                                 control={
                                     <input
                                         type="checkbox"

--- a/react/components/quickPrompt/QuickPromptPopup.tsx
+++ b/react/components/quickPrompt/QuickPromptPopup.tsx
@@ -15,11 +15,15 @@ import {
     quickPromptStateAtom,
     toggleQuickPromptAtom,
 } from '../../atoms/quickPrompt';
+import { runStatusPopupEnabledAtom } from '../../atoms/runStatusPopup';
+import { threadNavigationSeqAtom } from '../../atoms/threads';
+import { useRunFocusHandoff } from './useRunFocusHandoff';
 import { isSidebarVisibleAtom, selectedZoteroTabIdAtom } from '../../atoms/ui';
 import { eventManager } from '../../events/eventManager';
 import { useEventSubscription } from '../../hooks/useEventSubscription';
 import { uiManager } from '../../ui/UIManager';
 import InputArea from '../input/InputArea';
+import DragDropWrapper from '../input/DragDropWrapper';
 import PopupOverlayContainer from '../PopupOverlayContainer';
 import RunPulse from '../runStatusPopup/RunPulse';
 import { threadDisplayName } from '../runStatusPopup/runStatusPopupModel';
@@ -161,6 +165,16 @@ const QuickPromptPopup: React.FC = () => {
     const toggle = useSetAtom(toggleQuickPromptAtom);
     const open = useSetAtom(openQuickPromptAtom);
     const close = useSetAtom(closeQuickPromptAtom);
+    const runPopupEnabled = useAtomValue(runStatusPopupEnabledAtom);
+    const navigationSeq = useAtomValue(threadNavigationSeqAtom);
+    const activeRun = useAtomValue(activeRunAtom);
+    const requestRunFocus = useRunFocusHandoff({
+        navigationKey: `${navigationSeq}:${selectedTabId}`,
+        enabled: runPopupEnabled,
+        sidebarVisible: isSidebarVisible,
+        isPending,
+        runId: activeRun?.id ?? null,
+    });
     const rootRef = useRef<HTMLDivElement>(null);
     // The tab the popup was opened in. Its attachments — the open file, a
     // selection, selected items — belong to that tab, so it does not outlive it.
@@ -213,13 +227,24 @@ const QuickPromptPopup: React.FC = () => {
         if (isSidebarVisible) {
             close();
         } else if (state.mode === 'compose' && isPending) {
-            dismiss();
+            // Keep keyboard control with the run this composer started.
+            // Restoring focus to the toolbar makes Enter reopen Beaver.
+            const root = rootRef.current;
+            const ownsFocus = root?.ownerDocument.hasFocus() && root.contains(root.ownerDocument.activeElement);
+            if (!runPopupEnabled) {
+                if (ownsFocus) dismiss();
+                else close();
+                return;
+            }
+            const host = root?.closest<HTMLElement>('#beaver-pane-floating-popup');
+            if (ownsFocus && host) requestRunFocus(host, dismiss);
+            close();
         } else if (state.mode === 'busy' && !hasActiveWork) {
             dismiss();
         } else if (state.mode === 'blocked' && chatAccessGate === null) {
             void open();
         }
-    }, [state, isSidebarVisible, isPending, hasActiveWork, chatAccessGate, close, dismiss, open]);
+    }, [state, isSidebarVisible, isPending, hasActiveWork, chatAccessGate, close, dismiss, open, requestRunFocus, runPopupEnabled]);
 
     // Switching tabs closes the popup without touching focus: Zotero has just
     // moved it into the new tab, and the draft is kept for the next open.
@@ -263,10 +288,12 @@ const QuickPromptPopup: React.FC = () => {
             ) : (
                 <div className="beaver-quick-prompt__card">
                     <CloseButton onClose={dismiss} />
-                    <div className="beaver-quick-prompt__composer">
-                        <PopupOverlayContainer />
-                        <InputArea inputRef={inputRef} verticalPosition="above" placeholder="Ask Beaver — @ to add a source, / for actions" />
-                    </div>
+                    <DragDropWrapper overlayBorderRadius={12}>
+                        <div className="beaver-quick-prompt__composer">
+                            <PopupOverlayContainer />
+                            <InputArea inputRef={inputRef} verticalPosition="above" placeholder="Ask Beaver — @ to add a source, / for actions" />
+                        </div>
+                    </DragDropWrapper>
                 </div>
             )}
         </div>

--- a/react/components/quickPrompt/useRunFocusHandoff.ts
+++ b/react/components/quickPrompt/useRunFocusHandoff.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const HANDOFF_TIMEOUT_MS = 5000;
+
+interface FocusHandoff {
+    host: HTMLElement;
+    navigationKey: string;
+    expiresAt: number;
+    restore: () => void;
+}
+
+/** A short, window-local handoff from the composer to the run it just sent. */
+export function useRunFocusHandoff({
+    navigationKey, enabled, sidebarVisible, isPending, runId,
+}: {
+    navigationKey: string;
+    enabled: boolean;
+    sidebarVisible: boolean;
+    isPending: boolean;
+    runId: string | null;
+}) {
+    const [request, setRequest] = useState<FocusHandoff | null>(null);
+    const start = useCallback((host: HTMLElement, restore: () => void) => {
+        setRequest({ host, restore, navigationKey, expiresAt: Date.now() + HANDOFF_TIMEOUT_MS });
+    }, [navigationKey]);
+
+    useEffect(() => {
+        if (!request) return;
+        const { host, restore } = request;
+        const doc = host.ownerDocument;
+        const win = doc.defaultView;
+        if (!win || request.navigationKey !== navigationKey || sidebarVisible) {
+            setRequest(null);
+            return;
+        }
+        let finished = false;
+        const finish = (target?: HTMLElement) => {
+            if (finished) return;
+            finished = true;
+            setRequest(null);
+            // Never take focus back from something the user chose meanwhile.
+            if (doc.activeElement && doc.activeElement !== doc.body && doc.activeElement !== doc.documentElement) return;
+            if (target) target.focus();
+            else restore();
+        };
+        const attempt = () => {
+            if (!enabled || Date.now() >= request.expiresAt) {
+                finish();
+                return;
+            }
+            const card = host.querySelector<HTMLElement>('.beaver-run-status-popup__card');
+            if (card && runId) {
+                finish(card.querySelector<HTMLElement>('[data-run-status-approve]:not(:disabled)') ?? card);
+            } else if (!isPending && !runId) {
+                finish();
+            }
+        };
+        const cancel = () => { finished = true; setRequest(null); };
+        // Focus movement and fresh input end the handoff even if focus later
+        // returns to the document body before a card arrives.
+        win.addEventListener('blur', cancel);
+        doc.addEventListener('focusin', cancel);
+        doc.addEventListener('pointerdown', cancel);
+        doc.addEventListener('keydown', cancel);
+        const observer = new win.MutationObserver(attempt);
+        observer.observe(host, { childList: true, subtree: true });
+        const timer = win.setTimeout(() => finish(), Math.max(0, request.expiresAt - Date.now()));
+        attempt();
+        return () => {
+            observer.disconnect();
+            win.clearTimeout(timer);
+            win.removeEventListener('blur', cancel);
+            doc.removeEventListener('focusin', cancel);
+            doc.removeEventListener('pointerdown', cancel);
+            doc.removeEventListener('keydown', cancel);
+        };
+    }, [request, navigationKey, enabled, sidebarVisible, isPending, runId]);
+
+    return start;
+}

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { isImeKeyEvent } from '@beaver/agent-ui/primitives/ime';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 /**
  * The shimmering status line, cut with a visible ellipsis.
@@ -156,6 +157,7 @@ const ApprovalView: React.FC<{ card: ApprovalCard }> = ({ card }) => (
                 {card.rejectLabel}
             </Button>
             <Button
+                data-run-status-approve
                 variant="solid"
                 style={FOOTER_BUTTON_STYLE}
                 onClick={() => card.onDecide(true)}
@@ -187,6 +189,7 @@ const CreditView: React.FC<{ card: CreditCard }> = ({ card }) => (
                 {card.declineLabel}
             </Button>
             <Button
+                data-run-status-approve
                 variant="solid"
                 style={FOOTER_BUTTON_STYLE}
                 onClick={() => card.onDecide(true)}
@@ -320,6 +323,13 @@ const CardView: React.FC<{ card: RunStatusPopupCard }> = ({ card }) => {
  * first paint is not animated: a card appearing should not unfold from zero.
  */
 const AnimatedCard: React.FC<{ card: RunStatusPopupCard; children: React.ReactNode }> = ({ card, children }) => {
+    const cardRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const element = cardRef.current;
+        if (element?.ownerDocument.hasFocus() && element.ownerDocument.activeElement === element) {
+            element.querySelector<HTMLElement>('[data-run-status-approve]:not(:disabled)')?.focus();
+        }
+    }, [card.kind]);
     const [height, setHeight] = useState<number | null>(null);
     // The height as last measured, so a measurement that finds it unchanged
     // does not reach the setter: a setter called with the current value still
@@ -367,7 +377,7 @@ const AnimatedCard: React.FC<{ card: RunStatusPopupCard; children: React.ReactNo
     }, [card]);
 
     const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
-        if (event.target !== event.currentTarget) return;
+        if (event.target !== event.currentTarget || event.defaultPrevented || isImeKeyEvent(event.nativeEvent) || event.repeat) return;
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             card.onOpen();
@@ -376,6 +386,7 @@ const AnimatedCard: React.FC<{ card: RunStatusPopupCard; children: React.ReactNo
 
     return (
         <div
+            ref={cardRef}
             className={`beaver-run-status-popup__card beaver-run-status-popup__card--${card.kind} ${settled ? 'beaver-run-status-popup__card--settled' : ''}`}
             style={{ height: height ?? undefined }}
             role="button"

--- a/tests/unit/atoms/interruptActiveRunConfirm.test.ts
+++ b/tests/unit/atoms/interruptActiveRunConfirm.test.ts
@@ -6,6 +6,7 @@ import { createStore } from 'jotai';
 // supabase-backed services; stub everything the thread atoms touch.
 // =============================================================================
 
+const attachCollectionsMock = vi.fn();
 const cancelMock = vi.fn();
 const getThreadRunsMock = vi.fn();
 const getThreadMock = vi.fn();
@@ -40,6 +41,7 @@ vi.mock('../../../react/atoms/messageComposition', async () => {
         clearComposerAtom: atom(null, () => {}),
         currentMessageCollectionsAtom: atom<unknown[]>([]),
         currentMessageExternalFilesAtom: atom<unknown[]>([]),
+        updateMessageCollectionsFromZoteroSelectionAtom: atom(null, () => attachCollectionsMock()),
         updateMessageItemsFromZoteroSelectionAtom: atom(null, () => {}),
         updateReaderAttachmentAtom: atom(null, () => {}),
     };
@@ -177,6 +179,7 @@ import {
     currentThreadIdAtom,
     threadNavigationSeqAtom,
 } from '../../../react/atoms/threads';
+import { isLibraryTabAtom } from '../../../react/atoms/ui';
 import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { isWSChatPendingAtom } from '../../../react/atoms/agentRunAtoms';
 
@@ -206,6 +209,18 @@ describe('interrupt-active-run confirm', () => {
     });
 
     describe('newThreadAtom', () => {
+        it.each([
+            [true, true, false, true],
+            [false, true, false, false],
+            [true, false, false, false],
+            [true, true, true, false],
+        ])('auto-attaches collections only when enabled in library view (preference=%s, library=%s, skip=%s)', async (enabled, library, skip, expected) => {
+            getPrefMock.mockImplementation((name) => name === 'addSelectedItemsOnNewThread' ? enabled : 10);
+            store.set(isLibraryTabAtom, library);
+            await store.set(newThreadAtom, { skipAutoPopulate: skip });
+            expect(attachCollectionsMock).toHaveBeenCalledTimes(expected ? 1 : 0);
+        });
+
         it('does not prompt when the active run already failed', async () => {
             store.set(activeRunAtom, run('error'));
 

--- a/tests/unit/atoms/readerAttachmentExclusion.test.ts
+++ b/tests/unit/atoms/readerAttachmentExclusion.test.ts
@@ -95,6 +95,8 @@ vi.mock('../../../react/atoms/profile', () => ({
 }));
 
 const {
+    currentMessageCollectionsAtom,
+    updateMessageCollectionsFromZoteroSelectionAtom,
     currentReaderAttachmentAtom,
     updateReaderAttachmentAtom,
     clearReaderAttachmentAtom,
@@ -290,5 +292,30 @@ describe('updateReaderAttachmentAtom staleness', () => {
         await update;
 
         expect(store.get(currentReaderAttachmentAtom)).toBeNull();
+    });
+});
+
+
+describe('selected collection attachments', () => {
+    it('uses the active pane and filters excluded and deleted collections', () => {
+        const store = createStore();
+        vi.stubGlobal('Zotero', {
+            Libraries: { userLibraryID: 1 },
+            getActiveZoteroPane: () => ({ getSelectedCollections: () => [
+                { libraryID: 1, key: 'COLL0001', name: 'Selected', parentKey: 'PARENT01' },
+                { libraryID: 2, key: 'COLL0002', name: 'Excluded' },
+                { libraryID: 1, key: 'COLL0003', name: 'Deleted', deleted: true },
+            ] }),
+        });
+        store.set(updateMessageCollectionsFromZoteroSelectionAtom);
+        expect(store.get(currentMessageCollectionsAtom)).toEqual([{
+            library_id: 1, library_ref: 'u', zotero_key: 'COLL0001', name: 'Selected', parent_key: 'PARENT01',
+        }]);
+    });
+    it('does not fail when the active pane is unavailable', () => {
+        const store = createStore();
+        vi.stubGlobal('Zotero', { getActiveZoteroPane: () => { throw new Error('No pane'); } });
+        expect(() => store.set(updateMessageCollectionsFromZoteroSelectionAtom)).not.toThrow();
+        expect(store.get(currentMessageCollectionsAtom)).toEqual([]);
     });
 });

--- a/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
+++ b/tests/unit/components/quickPrompt/QuickPromptPopup.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../../react/ui/UIManager', () => ({
 vi.mock('../../../../react/atoms/threads', async () => {
     const { atom } = await import('jotai');
     return {
+        threadNavigationSeqAtom: atom(0),
         newThreadAtom: atom(null, async (_get, _set, options?: unknown) => mocks.newThread(options)),
     };
 });
@@ -40,6 +41,10 @@ vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
 vi.mock('../../../../react/atoms/chatAccess', async () => {
     const { atom } = await import('jotai');
     return { chatAccessGateAtom: atom<string | null>(null) };
+});
+vi.mock('../../../../react/atoms/runStatusPopup', async () => {
+    const { atom } = await import('jotai');
+    return { runStatusPopupEnabledAtom: atom(true) };
 });
 vi.mock('../../../../react/atoms/ui', async () => {
     const { atom } = await import('jotai');
@@ -65,7 +70,10 @@ vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
 // exposes an editor to press keys in is all these tests need.
 vi.mock('../../../../react/components/input/InputArea', () => ({
     default: () => React.createElement('div', { className: 'stub-composer' },
-        React.createElement('div', { className: 'beaver-lexical-content', contentEditable: true, 'data-testid': 'editor' })),
+        React.createElement('div', { className: 'beaver-lexical-content', contentEditable: true, tabIndex: 0, 'data-testid': 'editor' })),
+}));
+vi.mock('../../../../react/components/input/DragDropWrapper', () => ({
+    default: ({ children }: { children: React.ReactNode }) => React.createElement('div', { 'data-testid': 'drop-zone' }, children),
 }));
 vi.mock('../../../../react/components/PopupOverlayContainer', () => ({ default: () => null }));
 vi.mock('../../../../react/components/runStatusPopup/RunPulse', () => ({ default: () => null }));
@@ -75,6 +83,7 @@ import { activeRunAtom } from '@beaver/agent-core/run-state/atoms';
 import { isWSChatPendingAtom } from '../../../../react/atoms/agentRunAtoms';
 import { isSidebarVisibleAtom, selectedZoteroTabIdAtom } from '../../../../react/atoms/ui';
 import { chatAccessGateAtom } from '../../../../react/atoms/chatAccess';
+import { runStatusPopupEnabledAtom } from '../../../../react/atoms/runStatusPopup';
 import { quickPromptStateAtom } from '../../../../react/atoms/quickPrompt';
 import QuickPromptPopup from '../../../../react/components/quickPrompt/QuickPromptPopup';
 
@@ -148,7 +157,7 @@ describe('QuickPromptPopup', () => {
         mount();
         await fireShortcut();
         expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
-        expect(container.querySelector('.stub-composer')).not.toBeNull();
+        expect(container.querySelector('[data-testid="drop-zone"] .stub-composer')).not.toBeNull();
         expect(mocks.newThread).toHaveBeenCalledWith({ skipActiveRunConfirm: true, preserveDraft: true });
     });
 
@@ -209,12 +218,41 @@ describe('QuickPromptPopup', () => {
         expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
     });
 
-    it('closes once the message it composed is being sent', async () => {
+    it('closes after sending without focusing the toolbar', async () => {
         mount();
         await fireShortcut();
         act(() => { store.set(isWSChatPendingAtom, true); });
         expect(store.get(quickPromptStateAtom)).toBeNull();
-        expect(mocks.focusToggleButton).toHaveBeenCalled();
+        expect(mocks.focusToggleButton).not.toHaveBeenCalled();
+    });
+
+    it('hands focus from the sent composer to the approval button', async () => {
+        mount();
+        await fireShortcut();
+        container.querySelector<HTMLElement>('[data-testid="editor"]')!.focus();
+        act(() => { store.set(isWSChatPendingAtom, true); });
+        const card = document.createElement('div');
+        card.className = 'beaver-run-status-popup__card';
+        const approve = document.createElement('button');
+        approve.setAttribute('data-run-status-approve', '');
+        card.appendChild(approve);
+        floatingRoot.appendChild(card);
+        act(() => { store.set(activeRunAtom, run('in_progress')); });
+        expect(document.activeElement).toBe(approve);
+        expect(mocks.focusToggleButton).not.toHaveBeenCalled();
+    });
+
+    it('restores the original focus after sending when run popups are disabled', async () => {
+        store.set(runStatusPopupEnabledAtom, false);
+        const tree = document.createElement('button');
+        document.body.appendChild(tree);
+        tree.focus();
+        mount();
+        await fireShortcut();
+        container.querySelector<HTMLElement>('[data-testid="editor"]')!.focus();
+        act(() => { store.set(isWSChatPendingAtom, true); });
+        expect(document.activeElement).toBe(tree);
+        tree.remove();
     });
 
     it('closes when the sidebar opens over it', async () => {
@@ -262,6 +300,7 @@ describe('QuickPromptPopup', () => {
         expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'busy' });
         expect(container.querySelector('.beaver-quick-prompt__card--busy')?.textContent).toContain('Beaver is still working');
         expect(container.querySelector('.stub-composer')).toBeNull();
+        expect(container.querySelector('[data-testid="drop-zone"]')).toBeNull();
         act(() => { store.set(activeRunAtom, run('completed')); });
         expect(store.get(quickPromptStateAtom)).toBeNull();
     });
@@ -281,6 +320,7 @@ describe('QuickPromptPopup', () => {
         await fireShortcut();
         expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'blocked', reason: 'signed-out' });
         expect(container.querySelector('.stub-composer')).toBeNull();
+        expect(container.querySelector('[data-testid="drop-zone"]')).toBeNull();
         expect(container.textContent).toContain('Sign in to use Beaver');
         const open = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('Open Beaver'))!;
         act(() => { open.click(); });
@@ -297,7 +337,7 @@ describe('QuickPromptPopup', () => {
             await Promise.resolve();
         });
         expect(store.get(quickPromptStateAtom)).toEqual({ mode: 'compose' });
-        expect(container.querySelector('.stub-composer')).not.toBeNull();
+        expect(container.querySelector('[data-testid="drop-zone"] .stub-composer')).not.toBeNull();
     });
 
     it('toggles closed on a second shortcut press', async () => {

--- a/tests/unit/components/quickPrompt/useRunFocusHandoff.test.ts
+++ b/tests/unit/components/quickPrompt/useRunFocusHandoff.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { useRunFocusHandoff } from '../../../../react/components/quickPrompt/useRunFocusHandoff';
+
+let root: Root;
+let container: HTMLDivElement;
+let host: HTMLDivElement;
+let start: ReturnType<typeof useRunFocusHandoff>;
+let options: Parameters<typeof useRunFocusHandoff>[0];
+const restore = vi.fn();
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+function Harness() {
+    start = useRunFocusHandoff(options);
+    return null;
+}
+function render() { act(() => root.render(React.createElement(Harness))); }
+function request() { act(() => start(host, restore)); }
+function addCard(target: HTMLElement = host) {
+    const card = target.ownerDocument.createElement('div');
+    card.className = 'beaver-run-status-popup__card';
+    card.tabIndex = 0;
+    target.appendChild(card);
+    return card;
+}
+beforeEach(() => {
+    vi.useFakeTimers();
+    restore.mockClear();
+    options = { navigationKey: '1:library', enabled: true, sidebarVisible: false, isPending: true, runId: null };
+    container = document.createElement('div');
+    host = document.createElement('div');
+    document.body.append(container, host);
+    root = createRoot(container);
+    render();
+});
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    host.remove();
+    vi.useRealTimers();
+});
+it('focuses the approval button when the sent run arrives', () => {
+    request();
+    const card = addCard();
+    const approve = document.createElement('button');
+    approve.setAttribute('data-run-status-approve', '');
+    card.appendChild(approve);
+    options = { ...options, runId: 'run-1' };
+    render();
+    expect(document.activeElement).toBe(approve);
+    expect(restore).not.toHaveBeenCalled();
+});
+it('restores focus at the deadline and never focuses a later card', () => {
+    request();
+    act(() => vi.advanceTimersByTime(5000));
+    expect(restore).toHaveBeenCalledOnce();
+    const card = addCard();
+    options = { ...options, runId: 'later-run' };
+    render();
+    expect(document.activeElement).not.toBe(card);
+});
+it('restores focus if sending ends without a run', () => {
+    request();
+    options = { ...options, isPending: false };
+    render();
+    expect(restore).toHaveBeenCalledOnce();
+});
+it('restores focus if popups are disabled while waiting', () => {
+    request();
+    options = { ...options, enabled: false };
+    render();
+    expect(restore).toHaveBeenCalledOnce();
+});
+it.each(['navigation', 'sidebar', 'input', 'window blur'])('cancels on %s without stealing focus later', (reason) => {
+    request();
+    if (reason === 'navigation') options = { ...options, navigationKey: '2:library' };
+    if (reason === 'sidebar') options = { ...options, sidebarVisible: true };
+    if (reason === 'window blur') act(() => { window.dispatchEvent(new Event('blur')); });
+    if (reason === 'input') act(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' })); });
+    render();
+    const card = addCard();
+    options = { ...options, sidebarVisible: false, runId: 'later-run' };
+    render();
+    act(() => vi.advanceTimersByTime(5000));
+    expect(document.activeElement).not.toBe(card);
+    expect(restore).not.toHaveBeenCalled();
+});
+it('only considers cards in the requesting window', () => {
+    const frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    const otherCard = addCard(frame.contentDocument!.body);
+    request();
+    options = { ...options, runId: 'run-1' };
+    render();
+    expect(frame.contentDocument!.activeElement).not.toBe(otherCard);
+    const ownCard = addCard();
+    render();
+    // The observer sees the local card on the next microtask.
+    return act(async () => {
+        await Promise.resolve();
+        expect(document.activeElement).toBe(ownCard);
+        frame.remove();
+    });
+});
+it('disconnects pending work when its window unmounts', () => {
+    request();
+    act(() => root.unmount());
+    const card = addCard();
+    act(() => vi.advanceTimersByTime(5000));
+    expect(restore).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(card);
+    root = createRoot(container);
+});

--- a/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
+++ b/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Provider, createStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ card: null as any }));
+vi.mock('../../../../react/components/runStatusPopup/useRunStatusPopupCard', () => ({
+    useRunStatusPopupCard: () => mocks.card,
+}));
+vi.mock('../../../../react/atoms/ui', async () => {
+    const { atom } = await import('jotai');
+    return { isSidebarVisibleAtom: atom(false) };
+});
+vi.mock('../../../../react/atoms/runStatusPopup', async () => {
+    const { atom } = await import('jotai');
+    return { runStatusPopupForceVisibleAtom: atom(false) };
+});
+vi.mock('../../../../react/host/zotero/components/agentActionViewHelpers', () => ({ getAgentActionToolIcon: () => () => null }));
+vi.mock('../../../../react/components/ui/buttons/RunPermissionButton', () => ({ default: () => null }));
+vi.mock('@beaver/agent-ui/chat/AskUserQuestionCard', () => ({ default: () => null }));
+vi.mock('../../../../react/components/runStatusPopup/RunPulse', () => ({ default: () => null }));
+
+import RunStatusPopup from '../../../../react/components/runStatusPopup/RunStatusPopup';
+
+let store = createStore();
+let root: Root;
+let container: HTMLDivElement;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+beforeEach(() => {
+    store = createStore();
+    (window as any).ResizeObserver = class { observe() {} disconnect() {} };
+    mocks.card = {
+        kind: 'approval', threadName: 'Test', label: 'Create collection', stackDepth: 0,
+        approveLabel: 'Approve', rejectLabel: 'Reject', decideDisabled: false,
+        onOpen: vi.fn(), onDecide: vi.fn(), onDismiss: vi.fn(),
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+});
+function render() {
+    act(() => root.render(React.createElement(Provider, { store }, React.createElement(RunStatusPopup))));
+    return container.querySelector<HTMLElement>('.beaver-run-status-popup__card')!;
+}
+function press(target: HTMLElement, options: KeyboardEventInit = {}) {
+    act(() => { target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true, ...options })); });
+}
+describe('RunStatusPopup keyboard decisions', () => {
+    it('gives the card background the same Open Beaver action for mouse and keyboard', () => {
+        const card = render();
+        press(card);
+        act(() => card.click());
+        expect(card.getAttribute('aria-label')).toBe('Open Beaver: Test');
+        expect(mocks.card.onOpen).toHaveBeenCalledTimes(2);
+        expect(mocks.card.onDecide).not.toHaveBeenCalled();
+    });
+    it('moves focus from a running card to its approval button when approval arrives', () => {
+        const approval = mocks.card;
+        mocks.card = { ...approval, kind: 'running', statusLine: 'Thinking' };
+        render().focus();
+        mocks.card = approval;
+        render();
+        const button = container.querySelector<HTMLButtonElement>('[data-run-status-approve]')!;
+        expect(document.activeElement).toBe(button);
+        act(() => button.click());
+        expect(approval.onDecide).toHaveBeenCalledWith(true);
+        expect(approval.onOpen).not.toHaveBeenCalled();
+    });
+    it('ignores composing and repeated keyboard events', () => {
+        press(render(), { isComposing: true });
+        press(render(), { repeat: true });
+        expect(mocks.card.onDecide).not.toHaveBeenCalled();
+        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+    });
+    it('leaves keyboard events on child controls to those controls', () => {
+        render();
+        press(Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Reject')!);
+        expect(mocks.card.onDecide).not.toHaveBeenCalled();
+        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- Attach selected Zotero collections to new threads when enabled.
- Preserve focus handoff from the quick prompt to run approval controls.
- Add drag-and-drop support and improve keyboard handling in quick prompt and run status popups.
- Expand preferences and unit test coverage for the new behavior.

## Testing

- Added unit tests for collection attachment filtering and preference gating.
- Added focus handoff tests covering approval arrival, timeout, cancellation, navigation, and window isolation.
- Added run status popup tests for keyboard, IME, repeat-event, and child-control behavior.
- Not run.