### PR TITLE
fix(citations): open standalone attachments at cited pages

### DIFF
--- a/react/hooks/httpHandlers/testNoteHandlers.ts
+++ b/react/hooks/httpHandlers/testNoteHandlers.ts
@@ -117,8 +117,9 @@ export async function handleTestNoteOpenEditorHttpRequest(request: any) {
             if (Array.isArray(instances)) {
                 inEditor = instances.some((inst: any) => {
                     if (!inst._item || inst._item.id !== item.id) return false;
-                    const frame = inst._iframeWindow?.frameElement;
-                    return frame?.isConnected === true;
+                    // Zotero can expose the content window without frameElement.
+                    const editor = inst._iframeWindow?.document?.querySelector('.ProseMirror');
+                    return editor?.isConnected === true;
                 });
             }
         } catch {

--- a/react/host/zotero/citationExport.ts
+++ b/react/host/zotero/citationExport.ts
@@ -1,4 +1,8 @@
-import { formatCitationPages, translatePageNumberToLabel } from '../../../src/utils/pageLabelTranslation';
+import {
+    firstPageNumber,
+    formatCitationPages,
+    translatePageNumberToLabel,
+} from '../../../src/utils/pageLabelTranslation';
 import { formatExternalFileCitationHTML } from '../../../src/utils/externalFileCitation';
 import { getPageLabelsForItem } from './itemData';
 import { getPageLocator } from '@beaver/agent-core/citations/citationGrammar';
@@ -44,9 +48,14 @@ function renderCitation(request: CitationExportRequest): CitationExportRender | 
                     inclusiveRange: requestedRef?.loc?.kind !== 'page'
                         && /^\d+-\d+$/.test(requestedRef?.loc?.value ?? ''),
                 });
+            // The visible locator is a display label; the link navigates by
+            // physical page, which is what the cited pages already are.
+            const navPage = requestedPage
+                ? firstPageNumber(requestedPage)
+                : (pages.length > 0 ? Math.min(...pages) : undefined);
             return { kind: 'html', html: buildZoteroCitationLinkHTML(item, page
                 ? { kind: 'page', value: page, raw: `page${page}` }
-                : undefined) };
+                : undefined, navPage) };
         }
         const itemData = Zotero.Utilities.Item.itemToCSLJSON(item.parentItem || item);
         const startPage = pages.length > 0 ? pages[0] : undefined;

--- a/react/host/zotero/citationExport.ts
+++ b/react/host/zotero/citationExport.ts
@@ -1,3 +1,4 @@
+import { formatCitationPages, translatePageNumberToLabel } from '../../../src/utils/pageLabelTranslation';
 import { formatExternalFileCitationHTML } from '../../../src/utils/externalFileCitation';
 import { getPageLabelsForItem } from './itemData';
 import { getPageLocator } from '@beaver/agent-core/citations/citationGrammar';
@@ -35,7 +36,17 @@ function renderCitation(request: CitationExportRequest): CitationExportRender | 
         const item = Zotero.Items.getByLibraryAndKey(libraryID, effectiveItemKey);
         if (!item) return null;
         if (isLinkCitationItem(item)) {
-            return { kind: 'html', html: buildZoteroCitationLinkHTML(item) };
+            const labels = getPageLabelsForItem(item, pageLabelsByAttachmentId) ?? metadata?.page_labels;
+            const requestedPage = requestedRef ? getPageLocator(requestedRef) : undefined;
+            const page = requestedPage
+                ? translatePageNumberToLabel(labels, requestedPage)
+                : formatCitationPages(pages, labels, {
+                    inclusiveRange: requestedRef?.loc?.kind !== 'page'
+                        && /^\d+-\d+$/.test(requestedRef?.loc?.value ?? ''),
+                });
+            return { kind: 'html', html: buildZoteroCitationLinkHTML(item, page
+                ? { kind: 'page', value: page, raw: `page${page}` }
+                : undefined) };
         }
         const itemData = Zotero.Utilities.Item.itemToCSLJSON(item.parentItem || item);
         const startPage = pages.length > 0 ? pages[0] : undefined;

--- a/react/utils/citationRenderContext.ts
+++ b/react/utils/citationRenderContext.ts
@@ -1,3 +1,4 @@
+import { preloadStandaloneAttachmentTitles } from '../../src/utils/zoteroLinkCitation';
 import type { Citation, PartLocation } from '@beaver/agent-core/types/citations';
 import type { RenderContextData } from './citationRenderers';
 import { store } from '../store';
@@ -285,6 +286,7 @@ export async function prepareCitationRenderContext(
         preloadPageLabelsForContent(content),
         buildLocalCitationDataMapForContent(content),
         resolveExternalFileCitations(content),
+        preloadStandaloneAttachmentTitles(content),
     ]);
 
     const localCitationDataMap = {

--- a/react/utils/citationRenderContext.ts
+++ b/react/utils/citationRenderContext.ts
@@ -1,4 +1,4 @@
-import { preloadStandaloneAttachmentTitles } from '../../src/utils/zoteroLinkCitation';
+import { preloadStandaloneAttachmentLinks } from '../../src/utils/zoteroLinkCitation';
 import type { Citation, PartLocation } from '@beaver/agent-core/types/citations';
 import type { RenderContextData } from './citationRenderers';
 import { store } from '../store';
@@ -286,7 +286,7 @@ export async function prepareCitationRenderContext(
         preloadPageLabelsForContent(content),
         buildLocalCitationDataMapForContent(content),
         resolveExternalFileCitations(content),
-        preloadStandaloneAttachmentTitles(content),
+        preloadStandaloneAttachmentLinks(content),
     ]);
 
     const localCitationDataMap = {

--- a/react/utils/editNoteActions.ts
+++ b/react/utils/editNoteActions.ts
@@ -3,7 +3,7 @@
  * These functions are used by AgentActionView for post-run action handling.
  */
 
-import { preloadExternalFileCitations } from '../../src/utils/externalFileCitation';
+import { getExternalRefContext } from '../../src/services/agentDataProvider/actions/editNote';
 import { AgentAction } from '../agents/agentActions';
 import type { EditNoteResultData, EditNoteOperation } from '@beaver/agent-core/types/agentActions/editNote';
 import type {
@@ -69,10 +69,6 @@ import { currentThreadIdAtom } from '../atoms/threads';
 import { addOrUpdateEditFooter, getBeaverFooterAppendPoint } from '../../src/utils/noteEditFooter';
 import { assertNoPreviewMarkers, containsPreviewMarkers, stripPreviewMarkers } from '../../src/utils/notePreviewGuard';
 import {
-    externalReferenceMappingAtom,
-    externalReferenceItemMappingAtom,
-} from '@beaver/agent-core/citations/externalReferences';
-import {
     resolveBatchEdits,
     detectOverlaps,
     applyResolvedEdits,
@@ -90,17 +86,6 @@ import {
     buildUndoList,
 } from '../../src/services/agentDataProvider/actions/editNoteBatch';
 import { checkLibraryExcluded, excludedLibraryUserMessage } from '../../src/services/agentDataProvider/utils';
-
-/** Preload external files and snapshot external-work mappings for note expansion. */
-async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
-    const { files, warnings } = await preloadExternalFileCitations(content);
-    return {
-        externalFiles: files,
-        externalFileWarnings: warnings,
-        externalRefs: store.get(externalReferenceMappingAtom),
-        externalItemMapping: store.get(externalReferenceItemMappingAtom),
-    };
-}
 
 /**
  * Undo a str_replace_all edit by locating each occurrence via its stored context anchors.

--- a/react/utils/noteEditorDiffPreview.ts
+++ b/react/utils/noteEditorDiffPreview.ts
@@ -21,7 +21,7 @@
  *   hard backstop.
  */
 
-import { preloadStandaloneAttachmentTitles } from '../../src/utils/zoteroLinkCitation';
+import { preloadStandaloneAttachmentLinks } from '../../src/utils/zoteroLinkCitation';
 import { preloadExternalFileCitations } from '../../src/utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import type { EditNoteOperation } from '@beaver/agent-core/types/agentActions/editNote';
@@ -61,7 +61,7 @@ import {
 async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
     const [{ files, warnings }] = await Promise.all([
         preloadExternalFileCitations(content),
-        preloadStandaloneAttachmentTitles(content),
+        preloadStandaloneAttachmentLinks(content),
     ]);
     return {
         externalFiles: files,

--- a/react/utils/noteEditorDiffPreview.ts
+++ b/react/utils/noteEditorDiffPreview.ts
@@ -21,6 +21,7 @@
  *   hard backstop.
  */
 
+import { preloadStandaloneAttachmentTitles } from '../../src/utils/zoteroLinkCitation';
 import { preloadExternalFileCitations } from '../../src/utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import type { EditNoteOperation } from '@beaver/agent-core/types/agentActions/editNote';
@@ -32,6 +33,7 @@ import {
     expandToRawHtml,
     preloadPageLabelsForNewCitations,
     preloadNotePageLabels,
+    preloadStructuralLocatorPages,
     type ExternalRefContext,
 } from '../../src/utils/noteCitationExpand';
 import type { PageLabelsByAttachmentId } from '@beaver/agent-core/citations/atoms';
@@ -55,9 +57,12 @@ import {
     externalReferenceItemMappingAtom,
 } from '@beaver/agent-core/citations/externalReferences';
 
-/** Preload external files and snapshot external-work mappings for note expansion. */
+/** Preload citation labels and files, and snapshot external-work mappings. */
 async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
-    const { files, warnings } = await preloadExternalFileCitations(content);
+    const [{ files, warnings }] = await Promise.all([
+        preloadExternalFileCitations(content),
+        preloadStandaloneAttachmentTitles(content),
+    ]);
     return {
         externalFiles: files,
         externalFileWarnings: warnings,
@@ -413,13 +418,17 @@ export async function showDiffPreview(
             }
         }
 
+        const { pages: structuralPages } = await preloadStructuralLocatorPages(
+            edits.map(edit => edit.newString ?? '').join('\n<!-- edit boundary -->\n'),
+        );
+
         // Expand all edits
         const expandedEdits: PreviewExpandedEdit[] = [];
         for (const edit of edits) {
             const op = edit.operation ?? 'str_replace';
             try {
                 if (op === 'rewrite' || op === 'append') {
-                    const expandedNew = edit.newString ? expandToRawHtml(edit.newString, metadata, 'new', externalRefContext, pageLabels) : '';
+                    const expandedNew = edit.newString ? expandToRawHtml(edit.newString, metadata, 'new', externalRefContext, pageLabels, structuralPages) : '';
                     expandedEdits.push({
                         expandedOld: '',
                         expandedNew,
@@ -436,7 +445,7 @@ export async function showDiffPreview(
                     //   - insert_before: new_string = new_string + old_string
                     // so computeHtmlDiff will naturally show the anchor as
                     // context and the insertion as addition.
-                    const expandedNew = edit.newString ? expandToRawHtml(edit.newString, metadata, 'new', externalRefContext, pageLabels) : '';
+                    const expandedNew = edit.newString ? expandToRawHtml(edit.newString, metadata, 'new', externalRefContext, pageLabels, structuralPages) : '';
                     if (expandedOld) {
                         expandedEdits.push({
                             expandedOld,

--- a/src/services/agentDataProvider/actions/editNote.ts
+++ b/src/services/agentDataProvider/actions/editNote.ts
@@ -1,4 +1,4 @@
-import { preloadStandaloneAttachmentTitles } from '../../../utils/zoteroLinkCitation';
+import { preloadStandaloneAttachmentLinks } from '../../../utils/zoteroLinkCitation';
 import { preloadExternalFileCitations } from '../../../utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { libraryRefForLibraryID, modelObjectIdFromReference, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
@@ -182,7 +182,7 @@ async function findMarkdownRenderFallbackMatch(
 export async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
     const [{ files, warnings }] = await Promise.all([
         preloadExternalFileCitations(content),
-        preloadStandaloneAttachmentTitles(content, libraryID => !checkLibraryExcluded(libraryID)),
+        preloadStandaloneAttachmentLinks(content, libraryID => !checkLibraryExcluded(libraryID)),
     ]);
     return {
         externalFiles: files,

--- a/src/services/agentDataProvider/actions/editNote.ts
+++ b/src/services/agentDataProvider/actions/editNote.ts
@@ -1,3 +1,4 @@
+import { preloadStandaloneAttachmentTitles } from '../../../utils/zoteroLinkCitation';
 import { preloadExternalFileCitations } from '../../../utils/externalFileCitation';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { libraryRefForLibraryID, modelObjectIdFromReference, resolveItemReference, resolveLibraryRef } from '../../../utils/libraryIdentity';
@@ -177,9 +178,12 @@ async function findMarkdownRenderFallbackMatch(
     return findMarkdownRenderMatch({ ...matchInput, ...rendered });
 }
 
-/** Load external-file labels/links and snapshot external-work mappings for note expansion. */
+/** Preload citation labels and files, and snapshot external-work mappings. */
 export async function getExternalRefContext(content: string): Promise<ExternalRefContext> {
-    const { files, warnings } = await preloadExternalFileCitations(content);
+    const [{ files, warnings }] = await Promise.all([
+        preloadExternalFileCitations(content),
+        preloadStandaloneAttachmentTitles(content, libraryID => !checkLibraryExcluded(libraryID)),
+    ]);
     return {
         externalFiles: files,
         externalFileWarnings: warnings,

--- a/src/utils/editNoteValidation.ts
+++ b/src/utils/editNoteValidation.ts
@@ -197,7 +197,7 @@ function findUniqueCitationRef(
  * Resolve an `att_id="LIB-KEY"` (attachment reference) to the parent item's
  * `item_id="LIB-PARENT_KEY"`. Returns the resolved parent id and the
  * attachment item (so callers can translate page numbers the same way
- * `buildCitationFromAttId` did at insert time), or `null` when:
+ * `buildCitation` did at insert time), or `null` when:
  *   - the id is malformed
  *   - the item doesn't exist
  *   - the item isn't an attachment
@@ -220,7 +220,7 @@ function resolveAttIdToParent(
 }
 
 /**
- * Normalize a citation page locator the way `buildCitationFromAttId` did at
+ * Normalize a citation page locator the way `buildCitation` did at
  * insert time: strip whitespace, then translate pure-numeric locators from
  * 1-based page numbers to the attachment's page labels. Mirrors
  * `resolvePageForCitation(item, page, true)` in noteCitationExpand. Returns

--- a/src/utils/noteCitationExpand.ts
+++ b/src/utils/noteCitationExpand.ts
@@ -31,6 +31,7 @@ import {
 import {
     buildZoteroCitationLinkHTML,
     isLinkCitationItem,
+    isStandaloneAttachment,
 } from './zoteroLinkCitation';
 import type { SimplificationMetadata } from './noteHtmlSimplifier';
 import type { ExternalReference } from '@beaver/agent-core/types/externalReferences';
@@ -47,7 +48,7 @@ import {
 } from '@beaver/agent-core/citations/citationGrammar';
 import type { PageLabels } from '../services/documentCache';
 import type { StructuredExtractResult } from '@beaver/agent-core/extract/schema';
-import { translatePageNumberToLabel } from './pageLabelTranslation';
+import { formatCitationPages, translatePageNumberToLabel } from './pageLabelTranslation';
 import { extractItemKeyFromUri } from './zoteroUri';
 import {
     modelObjectId,
@@ -236,16 +237,19 @@ export async function preloadNotePageLabels(
 function resolvePageFromStructuredResult(
     result: StructuredExtractResult,
     locator: Locator,
+    includeRange = false,
 ): string | null {
     const index = result.document.citationIndex ?? {};
+    const pages: number[] = [];
+    const labels: PageLabels = {};
     for (const id of citationIndexCandidateIdsForLocator(locator)) {
         const entry = index[id];
         if (!entry || !Number.isInteger(entry.pageIndex) || entry.pageIndex < 0) continue;
-        return entry.pageLabel && entry.pageLabel.trim() !== ''
-            ? entry.pageLabel
-            : String(entry.pageIndex + 1);
+        pages.push(entry.pageIndex + 1);
+        if (entry.pageLabel) labels[entry.pageIndex] = entry.pageLabel;
+        if (!includeRange) break;
     }
-    return null;
+    return formatCitationPages(pages, labels, { inclusiveRange: includeRange }) ?? null;
 }
 
 /**
@@ -321,7 +325,7 @@ export async function preloadStructuralLocatorPages(str: string): Promise<Struct
             const result = await resultPromise;
             if (!result) { unresolved.push(describe); continue; }
 
-            const page = resolvePageFromStructuredResult(result, loc);
+            const page = resolvePageFromStructuredResult(result, loc, isStandaloneAttachment(item));
             if (page == null) { unresolved.push(describe); continue; }
             pages[citationKey] = page;
         } catch {
@@ -422,7 +426,7 @@ interface SimplifiedCitationAttrs {
     cslLabel?: string;
     /**
      * True when `page` was resolved from a structural locator and is already a
-     * final page label — `buildCitationFromSimplifiedAttrs` must store it
+     * final page label — `buildCitation` must store it
      * verbatim and skip the 1-based-page-number → label translation.
      */
     pageIsResolvedLabel?: boolean;
@@ -502,71 +506,50 @@ function resolvePageForCitation(
     return resolved;
 }
 
-/** Build a new citation from simplified attributes (item_id: portable "u-KEY" / "gGROUP-KEY", or legacy "LIB-KEY") */
-function buildCitationFromSimplifiedAttrs(
-    attrs: SimplifiedCitationAttrs,
-    shouldTranslatePage: boolean,
-    pageLabels?: PageLabelsByAttachmentId,
-): string {
-    const ref = resolveObjectId(attrs.item_id);
+/** Build a citation or item link, preserving the source attribute in errors. */
+function buildCitation({
+    item_id,
+    page,
+    pageIsResolvedLabel,
+    attrName = 'item_id',
+    shouldTranslatePage = true,
+    pageLabels,
+}: SimplifiedCitationAttrs & {
+    attrName?: 'item_id' | 'att_id';
+    shouldTranslatePage?: boolean;
+    pageLabels?: PageLabelsByAttachmentId;
+}): string {
+    const ref = resolveObjectId(item_id);
     if (!ref) {
-        throw new Error(`Invalid item_id format: "${attrs.item_id}". Expected "libraryID-itemKey".`);
+        throw new Error(`Invalid ${attrName} format: "${item_id}". Expected "libraryID-itemKey".`);
     }
     if (ref.library_id === UNRESOLVED_LIBRARY_ID) {
-        throw new Error(`Cannot cite item_id="${attrs.item_id}": its library is not available on this computer.`);
+        throw new Error(`Cannot cite ${attrName}="${item_id}": its library is not available on this computer.`);
     }
-    // Never resolve a citation target in a library the user excluded from
-    // Beaver — building the citation would embed the item's metadata.
+    // Reject excluded targets before reading metadata to embed in the note.
     const excluded = checkLibraryExcluded(ref.library_id);
     if (excluded) {
-        throw new Error(`Cannot cite item_id="${attrs.item_id}": ${excluded.message}`);
+        throw new Error(`Cannot cite ${attrName}="${item_id}": ${excluded.message}`);
     }
     const item = Zotero.Items.getByLibraryAndKey(ref.library_id, ref.zotero_key);
     if (!item) {
-        throw new Error(`Item not found: ${attrs.item_id}`);
+        throw new Error(`${attrName === 'att_id' ? 'Attachment' : 'Item'} not found: ${item_id}`);
     }
     if (isLinkCitationItem(item)) {
-        return buildZoteroCitationLinkHTML(item);
+        // Item links can display full ranges; native CSL navigation needs a single page.
+        const displayPage = isStandaloneAttachment(item) && page
+            ? pageIsResolvedLabel || !shouldTranslatePage
+                ? page
+                : translatePageNumberToLabel(pageLabels?.[item.id], page)
+            : undefined;
+        return buildZoteroCitationLinkHTML(item, displayPage
+            ? { kind: 'page', value: displayPage, raw: `page${displayPage}` }
+            : undefined);
     }
-    // A page resolved from a structural locator is already a final label;
-    // translating it again would mangle a numeric label into the wrong page.
-    const resolvedPage = attrs.pageIsResolvedLabel
-        ? attrs.page
-        : resolvePageForCitation(item, attrs.page, shouldTranslatePage, pageLabels);
-    return stripInlineItemDataFromDataCitations(createCitationHTML(item, resolvedPage));
-}
-
-/** Build a new citation from an attachment ID (att_id: portable "u-KEY" / "gGROUP-KEY", or legacy "LIB-KEY") */
-function buildCitationFromAttId(
-    attId: string,
-    page?: string,
-    shouldTranslatePage = true,
-    pageLabels?: PageLabelsByAttachmentId,
-    pageIsResolvedLabel = false,
-): string {
-    const ref = resolveObjectId(attId);
-    if (!ref) {
-        throw new Error(`Invalid att_id format: "${attId}". Expected "libraryID-itemKey".`);
-    }
-    if (ref.library_id === UNRESOLVED_LIBRARY_ID) {
-        throw new Error(`Cannot cite att_id="${attId}": its library is not available on this computer.`);
-    }
-    // Never resolve a citation target in a library the user excluded from
-    // Beaver — building the citation would embed the item's metadata.
-    const excluded = checkLibraryExcluded(ref.library_id);
-    if (excluded) {
-        throw new Error(`Cannot cite att_id="${attId}": ${excluded.message}`);
-    }
-    const item = Zotero.Items.getByLibraryAndKey(ref.library_id, ref.zotero_key);
-    if (!item) {
-        throw new Error(`Attachment not found: ${attId}`);
-    }
-    // A page resolved from a structural locator is already a final label and
-    // must be stored verbatim rather than re-translated.
+    // Structural locators already resolve to final labels; do not translate twice.
     const resolvedPage = pageIsResolvedLabel
         ? page
         : resolvePageForCitation(item, page, shouldTranslatePage, pageLabels);
-    // createCitationHTML handles attachment-to-parent resolution internally
     return stripInlineItemDataFromDataCitations(createCitationHTML(item, resolvedPage));
 }
 
@@ -763,11 +746,7 @@ export function expandToRawHtml(
                             // like a newly inserted citation.
                             const shouldTranslatePage = stored.originalAttrs?.pageConvention === 'number'
                                 && (stored.originalAttrs.cslLabel == null || stored.originalAttrs.cslLabel === 'page');
-                            return buildCitationFromSimplifiedAttrs(
-                                newAttrs,
-                                shouldTranslatePage,
-                                pageLabels,
-                            );
+                            return buildCitation({ ...newAttrs, shouldTranslatePage, pageLabels });
                         }
                     }
                     return stored.rawHtml; // exact original
@@ -820,7 +799,7 @@ export function expandToRawHtml(
             // New citations from the model always use 1-based page numbers → translate
             if (itemId) {
                 const attrs = parseSimplifiedCitationAttrs(attrStr, resolvedLocatorPages);
-                return buildCitationFromSimplifiedAttrs(attrs, true, pageLabels);
+                return buildCitation({ ...attrs, pageLabels });
             }
             if (attId) {
                 // Resolve structural locators on legacy att_id/attachment_id
@@ -828,11 +807,17 @@ export function expandToRawHtml(
                 const { page, pageIsResolvedLabel } = normalizedCitation.ok
                     ? resolveLocatorPageAttr(normalizedCitation.ref, resolvedLocatorPages)
                     : { page: extractAttr(attrStr, 'page'), pageIsResolvedLabel: false };
-                return buildCitationFromAttId(attId, page, true, pageLabels, pageIsResolvedLabel);
+                return buildCitation({
+                    item_id: attId,
+                    attrName: 'att_id',
+                    page,
+                    pageLabels,
+                    pageIsResolvedLabel,
+                });
             }
             if (normalizedCitation.ok && normalizedCitation.ref.kind === 'zotero') {
                 const attrs = parseSimplifiedCitationAttrs(attrStr, resolvedLocatorPages);
-                return buildCitationFromSimplifiedAttrs(attrs, true, pageLabels);
+                return buildCitation({ ...attrs, pageLabels });
             }
             // external_id: chat-side external work ID (e.g. OpenAlex W-id). Two-tier
             // fallback so the model's research effort isn't lost when it tries to
@@ -845,7 +830,11 @@ export function expandToRawHtml(
                 const mappedItemRef = externalRefContext?.externalItemMapping?.[externalId];
                 if (mappedItemRef) {
                     const itemIdStr = modelObjectIdFromReference(mappedItemRef);
-                    return buildCitationFromSimplifiedAttrs({ item_id: itemIdStr, page }, true, pageLabels);
+                    return buildCitation({
+                        item_id: itemIdStr,
+                        page,
+                        pageLabels,
+                        });
                 }
 
                 // Tier 2: emit an inline hyperlink from the ExternalReference

--- a/src/utils/noteCitationExpand.ts
+++ b/src/utils/noteCitationExpand.ts
@@ -48,7 +48,12 @@ import {
 } from '@beaver/agent-core/citations/citationGrammar';
 import type { PageLabels } from '../services/documentCache';
 import type { StructuredExtractResult } from '@beaver/agent-core/extract/schema';
-import { formatCitationPages, translatePageNumberToLabel } from './pageLabelTranslation';
+import {
+    firstPageNumber,
+    formatCitationPages,
+    translatePageLabelToNumber,
+    translatePageNumberToLabel,
+} from './pageLabelTranslation';
 import { extractItemKeyFromUri } from './zoteroUri';
 import {
     modelObjectId,
@@ -59,15 +64,23 @@ import {
 
 export { translatePageNumberToLabel } from './pageLabelTranslation';
 
+/** The page a structural locator was resolved to, for display and navigation. */
+export interface ResolvedLocatorPage {
+    /** Display page label stored as the citation's locator; may be a range. */
+    label: string;
+    /** First physical 1-based page, for links that navigate the reader. */
+    page?: number;
+}
+
 /**
- * Map of `requestedCitationKey` (e.g. `zotero:1-KEY:s4`) → resolved page string
- * for citations whose locator is a non-page structural locator (sentence,
+ * Map of `requestedCitationKey` (e.g. `zotero:1-KEY:s4`) → resolved page for
+ * citations whose locator is a non-page structural locator (sentence,
  * paragraph, heading, …). Native Zotero citations only store page locators, so
  * structural locators are resolved to the page they appear on (via the
  * structured extraction cache) before being stored. Resolve up-front with
  * `preloadStructuralLocatorPages`.
  */
-export type ResolvedLocatorPages = Record<string, string>;
+export type ResolvedLocatorPages = Record<string, ResolvedLocatorPage>;
 
 export interface StructuralLocatorPreload {
     pages: ResolvedLocatorPages;
@@ -230,15 +243,15 @@ export async function preloadNotePageLabels(
 
 /**
  * Map a non-page (structural) locator to the page it appears on, using the
- * document's structured citation index. Returns the page's display label when
- * available, otherwise the 1-based page number; null when the locator is not
- * indexed.
+ * document's structured citation index. The label is the page's display label
+ * when available, otherwise the 1-based page number; null when the locator is
+ * not indexed.
  */
 function resolvePageFromStructuredResult(
     result: StructuredExtractResult,
     locator: Locator,
     includeRange = false,
-): string | null {
+): ResolvedLocatorPage | null {
     const index = result.document.citationIndex ?? {};
     const pages: number[] = [];
     const labels: PageLabels = {};
@@ -249,7 +262,11 @@ function resolvePageFromStructuredResult(
         if (entry.pageLabel) labels[entry.pageIndex] = entry.pageLabel;
         if (!includeRange) break;
     }
-    return formatCitationPages(pages, labels, { inclusiveRange: includeRange }) ?? null;
+    const label = formatCitationPages(pages, labels, { inclusiveRange: includeRange });
+    // The physical page is kept alongside the label: a label cannot be
+    // translated back once the extraction result is out of scope, and link
+    // citations navigate the reader by physical page.
+    return label ? { label, page: Math.min(...pages) } : null;
 }
 
 /**
@@ -325,9 +342,9 @@ export async function preloadStructuralLocatorPages(str: string): Promise<Struct
             const result = await resultPromise;
             if (!result) { unresolved.push(describe); continue; }
 
-            const page = resolvePageFromStructuredResult(result, loc, isStandaloneAttachment(item));
-            if (page == null) { unresolved.push(describe); continue; }
-            pages[citationKey] = page;
+            const resolved = resolvePageFromStructuredResult(result, loc, isStandaloneAttachment(item));
+            if (resolved == null) { unresolved.push(describe); continue; }
+            pages[citationKey] = resolved;
         } catch {
             unresolved.push(describe);
         }
@@ -430,6 +447,11 @@ interface SimplifiedCitationAttrs {
      * verbatim and skip the 1-based-page-number → label translation.
      */
     pageIsResolvedLabel?: boolean;
+    /**
+     * Physical 1-based page behind `page`, carried alongside a resolved label
+     * so link citations can still navigate the reader to it.
+     */
+    navPage?: number;
 }
 
 /**
@@ -442,13 +464,13 @@ interface SimplifiedCitationAttrs {
 function resolveLocatorPageAttr(
     ref: CitationRef,
     resolvedLocatorPages?: ResolvedLocatorPages,
-): { page?: string; pageIsResolvedLabel?: boolean } {
+): { page?: string; pageIsResolvedLabel?: boolean; navPage?: number } {
     const page = getPageLocator(ref);
     if (page) return { page };
 
     if (ref.loc && ref.loc.kind !== 'page' && resolvedLocatorPages) {
         const resolved = resolvedLocatorPages[requestedCitationKey(ref)];
-        if (resolved) return { page: resolved, pageIsResolvedLabel: true };
+        if (resolved) return { page: resolved.label, pageIsResolvedLabel: true, navPage: resolved.page };
     }
     return {};
 }
@@ -465,8 +487,8 @@ function parseSimplifiedCitationAttrs(
         throw new Error('Citation must have an "id" attribute. Legacy "item_id" / "att_id" are also accepted.');
     }
     const item_id = modelObjectIdFromReference(normalized.ref);
-    const { page, pageIsResolvedLabel } = resolveLocatorPageAttr(normalized.ref, resolvedLocatorPages);
-    return { item_id, ...(page ? { page, pageIsResolvedLabel } : {}) };
+    const { page, pageIsResolvedLabel, navPage } = resolveLocatorPageAttr(normalized.ref, resolvedLocatorPages);
+    return { item_id, ...(page ? { page, pageIsResolvedLabel, navPage } : {}) };
 }
 
 /** Check if citation attributes have changed */
@@ -511,6 +533,7 @@ function buildCitation({
     item_id,
     page,
     pageIsResolvedLabel,
+    navPage,
     attrName = 'item_id',
     shouldTranslatePage = true,
     pageLabels,
@@ -537,14 +560,23 @@ function buildCitation({
     }
     if (isLinkCitationItem(item)) {
         // Item links can display full ranges; native CSL navigation needs a single page.
+        const labels = pageLabels?.[item.id];
+        // `page` is a physical page number from the model, but a page already
+        // resolved from a structural locator — or read back from a note, where
+        // locators are stored as labels — is a display label.
+        const pageIsLabel = pageIsResolvedLabel === true || !shouldTranslatePage;
         const displayPage = isStandaloneAttachment(item) && page
-            ? pageIsResolvedLabel || !shouldTranslatePage
-                ? page
-                : translatePageNumberToLabel(pageLabels?.[item.id], page)
+            ? pageIsLabel ? page : translatePageNumberToLabel(labels, page)
+            : undefined;
+        // The link navigates by physical page, so a label has to be translated
+        // back. Without labels the translation is a no-op and the displayed
+        // number is the best available guess.
+        const linkPage = displayPage
+            ? navPage ?? firstPageNumber(pageIsLabel ? translatePageLabelToNumber(labels, displayPage) : page)
             : undefined;
         return buildZoteroCitationLinkHTML(item, displayPage
             ? { kind: 'page', value: displayPage, raw: `page${displayPage}` }
-            : undefined);
+            : undefined, linkPage);
     }
     // Structural locators already resolve to final labels; do not translate twice.
     const resolvedPage = pageIsResolvedLabel
@@ -804,15 +836,16 @@ export function expandToRawHtml(
             if (attId) {
                 // Resolve structural locators on legacy att_id/attachment_id
                 // citations the same way as the unified id path.
-                const { page, pageIsResolvedLabel } = normalizedCitation.ok
+                const { page, pageIsResolvedLabel, navPage } = normalizedCitation.ok
                     ? resolveLocatorPageAttr(normalizedCitation.ref, resolvedLocatorPages)
-                    : { page: extractAttr(attrStr, 'page'), pageIsResolvedLabel: false };
+                    : { page: extractAttr(attrStr, 'page'), pageIsResolvedLabel: false, navPage: undefined };
                 return buildCitation({
                     item_id: attId,
                     attrName: 'att_id',
                     page,
                     pageLabels,
                     pageIsResolvedLabel,
+                    navPage,
                 });
             }
             if (normalizedCitation.ok && normalizedCitation.ref.kind === 'zotero') {

--- a/src/utils/noteCitationExpand.ts
+++ b/src/utils/noteCitationExpand.ts
@@ -32,6 +32,9 @@ import {
     buildZoteroCitationLinkHTML,
     isLinkCitationItem,
     isStandaloneAttachment,
+    parseLinkCitationPageSuffix,
+    parseZoteroCitationLinkHref,
+    zoteroLinkCitationPattern,
 } from './zoteroLinkCitation';
 import type { SimplificationMetadata } from './noteHtmlSimplifier';
 import type { ExternalReference } from '@beaver/agent-core/types/externalReferences';
@@ -165,7 +168,8 @@ export async function preloadPageLabelsForNewCitations(str: string): Promise<Pag
 }
 
 /**
- * Load cached page labels for citations already stored in a raw Zotero note.
+ * Load cached page labels for citations already stored in a raw Zotero note,
+ * both native ones and the plain links used for standalone attachments.
  *
  * This path is cache-first. Warm-cache reads only consult `documentCache`
  * metadata; callers can opt into local metadata seeding on a cache miss when
@@ -188,6 +192,42 @@ export async function preloadNotePageLabels(
     if (!cache) return labelsByItemId;
 
     const seen = new Set<string>();
+    // Keyed with the simplifier's portable item id so lookups in
+    // `simplifyNoteHtml` (which builds the same id via `modelObjectId`)
+    // resolve to the labels seeded here.
+    const loadLabels = async (targetLibraryID: number, itemKey: string): Promise<void> => {
+        const itemId = modelObjectId(targetLibraryID, itemKey);
+        if (seen.has(itemId)) return;
+        seen.add(itemId);
+        try {
+            const item = Zotero.Items.getByLibraryAndKey(targetLibraryID, itemKey);
+            const attachmentItem = item && typeof item !== 'boolean'
+                ? (item.isAttachment() ? item : await getBestPDFAttachmentAsync(item))
+                : null;
+            if (!attachmentItem) return;
+
+            const localFilePath = await attachmentItem.getFilePathAsync();
+            const filePath = localFilePath || makeRemoteFilePath(attachmentItem);
+            const isRemoteOnly = !localFilePath || isRemoteFilePath(filePath);
+            let record = await cache.getMetadata({
+                libraryId: attachmentItem.libraryID,
+                zoteroKey: attachmentItem.key,
+            }, filePath);
+            if (!record && extractOnCacheMiss && (!isRemoteOnly || allowRemoteDownloads)) {
+                await getAttachmentFileStatus(attachmentItem, false);
+                record = await cache.getMetadata({
+                    libraryId: attachmentItem.libraryID,
+                    zoteroKey: attachmentItem.key,
+                }, filePath);
+            }
+            if (record?.pageLabels && Object.keys(record.pageLabels).length > 0) {
+                labelsByItemId[itemId] = { ...record.pageLabels };
+            }
+        } catch {
+            // Skip attachments whose file or metadata cannot be read.
+        }
+    };
+
     const regex = /data-citation="([^"]*)"/g;
     let match: RegExpExecArray | null;
 
@@ -202,40 +242,28 @@ export async function preloadNotePageLabels(
                 const uri = ci?.uris?.[0] || '';
                 const itemKey = extractItemKeyFromUri(uri);
                 if (!itemKey) continue;
-                // Keyed with the simplifier's portable item id so lookups in
-                // `simplifyNoteHtml` (which builds the same id via `modelObjectId`)
-                // resolve to the labels seeded here.
-                const itemId = modelObjectId(libraryID, itemKey);
-                if (seen.has(itemId)) continue;
-                seen.add(itemId);
-
-                const item = Zotero.Items.getByLibraryAndKey(libraryID, itemKey);
-                const attachmentItem = item && typeof item !== 'boolean'
-                    ? (item.isAttachment() ? item : await getBestPDFAttachmentAsync(item))
-                    : null;
-                if (!attachmentItem) continue;
-
-                const localFilePath = await attachmentItem.getFilePathAsync();
-                const filePath = localFilePath || makeRemoteFilePath(attachmentItem);
-                const isRemoteOnly = !localFilePath || isRemoteFilePath(filePath);
-                let record = await cache.getMetadata({
-                    libraryId: attachmentItem.libraryID,
-                    zoteroKey: attachmentItem.key,
-                }, filePath);
-                if (!record && extractOnCacheMiss && (!isRemoteOnly || allowRemoteDownloads)) {
-                    await getAttachmentFileStatus(attachmentItem, false);
-                    record = await cache.getMetadata({
-                        libraryId: attachmentItem.libraryID,
-                        zoteroKey: attachmentItem.key,
-                    }, filePath);
-                }
-                if (record?.pageLabels && Object.keys(record.pageLabels).length > 0) {
-                    labelsByItemId[itemId] = { ...record.pageLabels };
-                }
+                await loadLabels(libraryID, itemKey);
             }
         } catch {
             // Skip malformed citation metadata or attachments that can't load.
         }
+    }
+
+    // Link citations (standalone attachments) carry no `data-citation`, so their
+    // labels have to come from the link itself. Without them the simplifier
+    // cannot translate the stored label into the physical page number the agent
+    // writes, and a later locator edit would be read in the wrong convention.
+    // The link names its own library, which need not be the note's.
+    for (const link of rawHtml.matchAll(zoteroLinkCitationPattern())) {
+        const [, openParen, , rawHref, rawSuffix, closeParen] = link;
+        // Only the wrapped form carries a locator into the simplified citation.
+        if (!openParen || !closeParen) continue;
+        if (parseLinkCitationPageSuffix(rawSuffix) === null) continue;
+        const parsed = parseZoteroCitationLinkHref(rawHref);
+        // Reading an excluded library's cached extraction is off limits; the
+        // citation still renders, only its locator convention is left as stored.
+        if (!parsed || checkLibraryExcluded(parsed.libraryId)) continue;
+        await loadLabels(parsed.libraryId, parsed.itemKey);
     }
 
     return labelsByItemId;

--- a/src/utils/noteHtmlSimplifier.ts
+++ b/src/utils/noteHtmlSimplifier.ts
@@ -390,27 +390,57 @@ export function simplifyNoteHtml(
                 return `__BEAVER_LINK_SHIELD_${idx}__`;
             }
         );
+        // Link citations (notes, annotations, standalone attachments) are written
+        // as `(<a …>label</a>, p. 6)`. The parenthesized form collapses into one
+        // token, carrying the locator as `loc` rather than leaving `, p. 6` as
+        // loose text: the link navigates to the page it was built with, so a
+        // locator the agent can edit outside the token would move the visible
+        // page while the link stayed behind. Only Beaver's own shape is
+        // absorbed; any other text around the anchor is left where it was.
         simplified = simplified.replace(
-            /<a\s+[^>]*href="(zotero:\/\/[^"]*)"[^>]*>([\s\S]*?)<\/a>/g,
-            (match, rawHref, innerHtml) => {
+            /(\()?(<a\s+[^>]*href="(zotero:\/\/[^"]*)"[^>]*>[\s\S]*?<\/a>)(,[^<()]*)?(\))?/g,
+            (match, openParen, anchor, rawHref, rawSuffix, closeParen) => {
                 const parsed = parseZoteroCitationLinkHref(rawHref);
                 if (!parsed) return match;
+
+                const suffix: string = rawSuffix ?? '';
+                const locatorMatch = suffix ? /^,\s*p\.\s*(\S[^<]*?)\s*$/.exec(suffix) : null;
+                const wrapped = !!openParen && !!closeParen && (!suffix || !!locatorMatch);
 
                 const itemId = modelObjectId(parsed.libraryId, parsed.itemKey);
                 const occurrence = citationKeyCounts.get(parsed.itemKey) || 0;
                 citationKeyCounts.set(parsed.itemKey, occurrence + 1);
                 const ref = `c_${parsed.itemKey}_${occurrence}`;
-                const label = innerHtml.replace(/<[^>]+>/g, '').trim();
+
+                // The stored locator is a display label. Show the agent physical
+                // page numbers where labels are known, as native citations do.
+                const rawPage = wrapped && locatorMatch ? unescapeAttr(locatorMatch[1]) : '';
+                let page = rawPage;
+                let pageConvention: 'number' | 'label' | undefined = page ? 'label' : undefined;
+                const pageLabels = pageLabelsByItemId?.[itemId];
+                if (page && pageLabels) {
+                    const translated = translatePageLabelToNumber(pageLabels, page);
+                    if (translated !== rawPage) {
+                        page = translated;
+                        pageConvention = 'number';
+                    }
+                }
 
                 metadata.elements.set(ref, {
-                    rawHtml: match,
+                    rawHtml: wrapped ? match : anchor,
                     type: 'citation',
                     // Link citation labels are derived from the target item and
                     // preserved from rawHtml while the target id is unchanged.
-                    originalAttrs: { item_id: itemId },
+                    originalAttrs: {
+                        item_id: itemId,
+                        ...(page ? { page, pageConvention } : {}),
+                    },
                 });
 
-                return `<citation id="${itemId}" ref="${ref}"/>`;
+                const tag = `<citation id="${itemId}"`
+                    + (page ? ` loc="${escapeAttr(`page${page}`)}"` : '')
+                    + ` ref="${ref}"/>`;
+                return wrapped ? tag : `${openParen ?? ''}${tag}${suffix}${closeParen ?? ''}`;
             }
         );
         simplified = simplified.replace(

--- a/src/utils/noteHtmlSimplifier.ts
+++ b/src/utils/noteHtmlSimplifier.ts
@@ -14,7 +14,11 @@ import { stripBeaverEditFooter, stripBeaverCreatedFooter } from './noteEditFoote
 import { escapeAttr, unescapeAttr } from './noteHtmlEntities';
 import { stripDataCitationItems, stripNoteWrapperDiv } from './noteWrapper';
 import { normalizeNoteHtml } from '../prosemirror/normalize';
-import { parseZoteroCitationLinkHref } from './zoteroLinkCitation';
+import {
+    parseLinkCitationPageSuffix,
+    parseZoteroCitationLinkHref,
+    zoteroLinkCitationPattern,
+} from './zoteroLinkCitation';
 import { translatePageLabelToNumber } from './pageLabelTranslation';
 import { extractItemKeyFromUri } from './zoteroUri';
 import { modelObjectId } from './libraryIdentity';
@@ -398,14 +402,14 @@ export function simplifyNoteHtml(
         // page while the link stayed behind. Only Beaver's own shape is
         // absorbed; any other text around the anchor is left where it was.
         simplified = simplified.replace(
-            /(\()?(<a\s+[^>]*href="(zotero:\/\/[^"]*)"[^>]*>[\s\S]*?<\/a>)(,[^<()]*)?(\))?/g,
+            zoteroLinkCitationPattern(),
             (match, openParen, anchor, rawHref, rawSuffix, closeParen) => {
                 const parsed = parseZoteroCitationLinkHref(rawHref);
                 if (!parsed) return match;
 
                 const suffix: string = rawSuffix ?? '';
-                const locatorMatch = suffix ? /^,\s*p\.\s*(\S[^<]*?)\s*$/.exec(suffix) : null;
-                const wrapped = !!openParen && !!closeParen && (!suffix || !!locatorMatch);
+                const suffixPage = parseLinkCitationPageSuffix(suffix);
+                const wrapped = !!openParen && !!closeParen && (!suffix || suffixPage !== null);
 
                 const itemId = modelObjectId(parsed.libraryId, parsed.itemKey);
                 const occurrence = citationKeyCounts.get(parsed.itemKey) || 0;
@@ -414,7 +418,7 @@ export function simplifyNoteHtml(
 
                 // The stored locator is a display label. Show the agent physical
                 // page numbers where labels are known, as native citations do.
-                const rawPage = wrapped && locatorMatch ? unescapeAttr(locatorMatch[1]) : '';
+                const rawPage = wrapped && suffixPage ? suffixPage : '';
                 let page = rawPage;
                 let pageConvention: 'number' | 'label' | undefined = page ? 'label' : undefined;
                 const pageLabels = pageLabelsByItemId?.[itemId];

--- a/src/utils/pageLabelTranslation.ts
+++ b/src/utils/pageLabelTranslation.ts
@@ -70,3 +70,25 @@ export function translatePageLabelToNumber(
 
     return translatedAny ? translatedParts.join('') : locStr;
 }
+
+/** Format distinct physical pages as compact ranges, using display labels when available. */
+export function formatCitationPages(
+    pages: number[],
+    labels?: PageLabels | null,
+    { inclusiveRange = false }: { inclusiveRange?: boolean } = {},
+): string | undefined {
+    const sorted = [...new Set(pages.filter(page => Number.isInteger(page) && page > 0))].sort((a, b) => a - b);
+    const ranges: string[] = [];
+    const label = (page: number) => labels?.[page - 1]?.trim() || String(page);
+    // Structural spans may supply only endpoint pages, with interior pages omitted.
+    if (inclusiveRange && sorted.length > 1) {
+        return `${label(sorted[0])}-${label(sorted[sorted.length - 1])}`;
+    }
+    for (let i = 0; i < sorted.length; i++) {
+        const start = sorted[i];
+        let end = start;
+        while (sorted[i + 1] === end + 1) end = sorted[++i];
+        ranges.push(start === end ? label(start) : `${label(start)}-${label(end)}`);
+    }
+    return ranges.length ? ranges.join(', ') : undefined;
+}

--- a/src/utils/pageLabelTranslation.ts
+++ b/src/utils/pageLabelTranslation.ts
@@ -71,6 +71,20 @@ export function translatePageLabelToNumber(
     return translatedAny ? translatedParts.join('') : locStr;
 }
 
+/**
+ * First physical 1-based page in a page locator ("12", "12-15", "3, 7"), or
+ * undefined when the locator is not a physical page number ("xii", "§3.2").
+ *
+ * Reader navigation addresses pages by position, so a display label has to be
+ * translated back with `translatePageLabelToNumber` before it lands here.
+ */
+export function firstPageNumber(pageStr: string | null | undefined): number | undefined {
+    const match = pageStr?.match(/^\s*(\d+)/);
+    if (!match) return undefined;
+    const page = parseInt(match[1], 10);
+    return page > 0 ? page : undefined;
+}
+
 /** Format distinct physical pages as compact ranges, using display labels when available. */
 export function formatCitationPages(
     pages: number[],

--- a/src/utils/zoteroLinkCitation.ts
+++ b/src/utils/zoteroLinkCitation.ts
@@ -1,3 +1,7 @@
+import { normalizeCitationTag, parseRawCitationAttributes, type Locator } from '@beaver/agent-core/citations/citationGrammar';
+import { noteCitationTagPattern } from './noteCitationTags';
+import { UNRESOLVED_LIBRARY_ID } from './libraryIdentity';
+import { externalFileLocatorSuffix } from './externalFileCitation';
 import { escapeAttr } from './noteHtmlEntities';
 
 const MAX_LABEL_SNIPPET_LENGTH = 120;
@@ -52,7 +56,7 @@ function getCompactItemDisplayName(item: any): string {
     if (item.isNote?.() === true) {
         return truncateLabel(safeGetNoteTitle(item) || 'Note', MAX_NOTE_TITLE_LENGTH);
     }
-    if (item.isAttachment?.() === true && !safeGetProperty(item, 'parentItem')) {
+    if (isStandaloneAttachment(item)) {
         const title = safeGetField(item, 'title') || safeGetProperty(item, 'attachmentFilename') || 'attachment';
         return truncateLabel(title, MAX_ATTACHMENT_TITLE_LENGTH);
     }
@@ -71,21 +75,24 @@ function decodeHrefAttrValue(href: string): string {
     return href.replace(/&amp;/g, '&');
 }
 
-/**
- * Return true when the Zotero item should be represented as a plain zotero:// link.
- */
+/** Whether the attachment has no bibliographic parent to cite. */
+export function isStandaloneAttachment(item: any): boolean {
+    return item?.isAttachment?.() === true && !item.parentID;
+}
+
+/** Whether to represent the item as a plain Zotero link instead of CSL. */
 export function isLinkCitationItem(item: any): boolean {
-    return item?.isNote?.() === true || isAnnotationItem(item);
+    return item?.isNote?.() === true || isAnnotationItem(item) || isStandaloneAttachment(item);
 }
 
 /**
- * Build a Zotero protocol URI for note and annotation citations.
+ * Build a Zotero protocol URI for note, annotation, and standalone attachment citations.
  */
 export function buildZoteroCitationLinkURI(item: any): string | null {
     if (!item || !item.key || !item.libraryID) return null;
 
     const segment = librarySegment(item.libraryID);
-    if (item.isNote?.() === true) {
+    if (item.isNote?.() === true || isStandaloneAttachment(item)) {
         return `zotero://select/${segment}/items/${item.key}`;
     }
 
@@ -99,9 +106,12 @@ export function buildZoteroCitationLinkURI(item: any): string | null {
 }
 
 /**
- * Build the visible label for a note or annotation citation link.
+ * Build the visible label for a note, annotation, or attachment citation link.
  */
 export function buildZoteroCitationLinkLabel(item: any): string {
+    if (isStandaloneAttachment(item)) {
+        return getCompactItemDisplayName(item);
+    }
     if (item?.isNote?.() === true) {
         const noteTitle = truncateLabel(safeGetNoteTitle(item) || 'Note', MAX_NOTE_TITLE_LENGTH);
         const parentItem = safeGetProperty(item, 'parentItem');
@@ -124,17 +134,21 @@ export function buildZoteroCitationLinkLabel(item: any): string {
 }
 
 /**
- * Build plain HTML for a note or annotation citation link.
+ * Build plain HTML for a note, annotation, or attachment citation link.
  */
-export function buildZoteroCitationLinkHTML(item: any, label?: string): string {
+export function buildZoteroCitationLinkHTML(item: any, locator?: Locator): string {
     const uri = buildZoteroCitationLinkURI(item);
     if (!uri) {
         throw new Error(
             `Error: Zotero item "${item?.libraryID ?? ''}-${item?.key ?? ''}" cannot be embedded as a note link.`
         );
     }
-    const visibleLabel = label || buildZoteroCitationLinkLabel(item);
-    return `(<a href="${escapeAttr(uri)}" rel="noopener noreferrer">${escapeAttr(visibleLabel)}</a>)`;
+    const visibleLabel = buildZoteroCitationLinkLabel(item);
+    const standalone = isStandaloneAttachment(item);
+    const suffix = standalone ? externalFileLocatorSuffix(locator) : '';
+    // Match the note normalizer so a newly saved link is also an exact edit anchor.
+    const rel = 'noopener noreferrer nofollow';
+    return `(<a href="${escapeAttr(uri)}" rel="${rel}">${escapeAttr(visibleLabel)}</a>${escapeAttr(suffix)})`;
 }
 
 /**
@@ -169,4 +183,34 @@ export function parseZoteroCitationLinkHref(
     }
 
     return null;
+}
+
+/** Load attachment titles before synchronous rendering; no file access is needed. */
+export async function preloadStandaloneAttachmentTitles(
+    content: string,
+    allowLibrary: (libraryID: number) => boolean = () => true,
+): Promise<void> {
+    const seen = new Set<string>();
+    const items: Zotero.Item[] = [];
+    for (const match of content.matchAll(noteCitationTagPattern())) {
+        const normalized = normalizeCitationTag(parseRawCitationAttributes(match[1]));
+        if (!normalized.ok || normalized.ref.kind !== 'zotero') continue;
+        const { library_id: libraryID, zotero_key: key } = normalized.ref;
+        if (libraryID === UNRESOLVED_LIBRARY_ID || !allowLibrary(libraryID)) continue;
+        const identity = `${libraryID}-${key}`;
+        if (seen.has(identity)) continue;
+        seen.add(identity);
+        try {
+            const item = Zotero.Items.getByLibraryAndKey(libraryID, key);
+            if (item && isStandaloneAttachment(item)) items.push(item);
+        } catch {
+            // Skip unavailable targets without preventing other titles from loading.
+        }
+    }
+    if (items.length === 0) return;
+    try {
+        await Zotero.Items.loadDataTypes(items, ['itemData']);
+    } catch {
+        // Rendering can still use filenames when title data is unavailable.
+    }
 }

--- a/src/utils/zoteroLinkCitation.ts
+++ b/src/utils/zoteroLinkCitation.ts
@@ -2,7 +2,7 @@ import { normalizeCitationTag, parseRawCitationAttributes, type Locator } from '
 import { noteCitationTagPattern } from './noteCitationTags';
 import { UNRESOLVED_LIBRARY_ID } from './libraryIdentity';
 import { externalFileLocatorSuffix } from './externalFileCitation';
-import { escapeAttr } from './noteHtmlEntities';
+import { escapeAttr, unescapeAttr } from './noteHtmlEntities';
 
 const MAX_LABEL_SNIPPET_LENGTH = 120;
 const MAX_NOTE_TITLE_LENGTH = 50;
@@ -177,6 +177,30 @@ export function buildZoteroCitationLinkHTML(item: any, locator?: Locator, navPag
     // Match the note normalizer so a newly saved link is also an exact edit anchor.
     const rel = 'noopener noreferrer nofollow';
     return `(<a href="${escapeAttr(uri)}" rel="${rel}">${escapeAttr(visibleLabel)}</a>${escapeAttr(suffix)})`;
+}
+
+/**
+ * Match a link citation in note HTML — the anchor plus the parentheses and
+ * locator suffix `buildZoteroCitationLinkHTML` writes around it. Capture
+ * groups: opening parenthesis, anchor, href, locator suffix, closing
+ * parenthesis; every one but the anchor and href is optional, so a bare link
+ * matches too and the caller decides what to do with a partial wrapper.
+ *
+ * Shared so the note simplifier and the page-label preload agree on which text
+ * belongs to a citation.
+ */
+export function zoteroLinkCitationPattern(): RegExp {
+    return /(\()?(<a\s+[^>]*href="(zotero:\/\/[^"]*)"[^>]*>[\s\S]*?<\/a>)(,[^<()]*)?(\))?/g;
+}
+
+/**
+ * The page a link citation's locator suffix displays (", p. 6-8" → "6-8"), or
+ * null when the suffix is absent or is not a page locator. The value is a
+ * display label, as stored in the note.
+ */
+export function parseLinkCitationPageSuffix(suffix: string | undefined): string | null {
+    const match = suffix ? /^,\s*p\.\s*(\S[^<]*?)\s*$/.exec(suffix) : null;
+    return match ? unescapeAttr(match[1]) : null;
 }
 
 /**

--- a/src/utils/zoteroLinkCitation.ts
+++ b/src/utils/zoteroLinkCitation.ts
@@ -86,14 +86,38 @@ export function isLinkCitationItem(item: any): boolean {
 }
 
 /**
- * Build a Zotero protocol URI for note, annotation, and standalone attachment citations.
+ * Build a Zotero protocol URI for note, annotation, and standalone attachment
+ * citations.
+ *
+ * A standalone attachment opens its file rather than revealing the library row:
+ * the note already names the attachment, the reader is what the citation points
+ * at, and opening leaves the note itself on screen instead of navigating the
+ * item pane away from it. `navPage` is the cited *physical* 1-based page, which
+ * is how Zotero reads `?page=`; it is only passed for PDFs, because the EPUB
+ * view resolves the same parameter through its own page mapping.
+ *
+ * Selecting is the fallback whenever opening would do nothing: an attachment
+ * with no file (a linked URL), and one whose file this computer does not have
+ * (never downloaded, or a linked file on a disconnected volume) — Zotero's
+ * `open` handler gives up silently when it cannot resolve a path. Availability
+ * is read from Zotero's cached file state, which
+ * `preloadStandaloneAttachmentLinks` primes for every cited attachment; an
+ * unchecked attachment reads as null and still opens.
  */
-export function buildZoteroCitationLinkURI(item: any): string | null {
+export function buildZoteroCitationLinkURI(item: any, navPage?: number): string | null {
     if (!item || !item.key || !item.libraryID) return null;
 
     const segment = librarySegment(item.libraryID);
-    if (item.isNote?.() === true || isStandaloneAttachment(item)) {
+    if (item.isNote?.() === true) {
         return `zotero://select/${segment}/items/${item.key}`;
+    }
+
+    if (isStandaloneAttachment(item)) {
+        if (item.isFileAttachment?.() !== true || item.fileExistsCached?.() === false) {
+            return `zotero://select/${segment}/items/${item.key}`;
+        }
+        const pageQuery = navPage && item.isPDFAttachment?.() === true ? `?page=${navPage}` : '';
+        return `zotero://open/${segment}/items/${item.key}${pageQuery}`;
     }
 
     if (isAnnotationItem(item)) {
@@ -135,9 +159,13 @@ export function buildZoteroCitationLinkLabel(item: any): string {
 
 /**
  * Build plain HTML for a note, annotation, or attachment citation link.
+ *
+ * `locator` is what the reader sees (a page label, possibly a range); `navPage`
+ * is the physical page the link navigates to. They are resolved separately
+ * because Zotero's `?page=` counts pages by position, not by label.
  */
-export function buildZoteroCitationLinkHTML(item: any, locator?: Locator): string {
-    const uri = buildZoteroCitationLinkURI(item);
+export function buildZoteroCitationLinkHTML(item: any, locator?: Locator, navPage?: number): string {
+    const uri = buildZoteroCitationLinkURI(item, navPage);
     if (!uri) {
         throw new Error(
             `Error: Zotero item "${item?.libraryID ?? ''}-${item?.key ?? ''}" cannot be embedded as a note link.`
@@ -170,23 +198,28 @@ export function parseZoteroCitationLinkHref(
         return { libraryId, itemKey: selectMatch[3] };
     }
 
-    const openPdfMatch = decodedHref.match(/^zotero:\/\/open-pdf\/(library|groups\/(\d+))\/items\/([^/?#]+)(?:\?([^#]*))?/);
-    if (openPdfMatch) {
-        const libraryId = openPdfMatch[1] === 'library'
+    // `open` / `open-pdf` name the attachment; an `annotation` query names the
+    // annotation inside it, which is the citation target in that case.
+    const openMatch = decodedHref.match(/^zotero:\/\/open(?:-pdf)?\/(library|groups\/(\d+))\/items\/([^/?#]+)(?:\?([^#]*))?/);
+    if (openMatch) {
+        const libraryId = openMatch[1] === 'library'
             ? Zotero.Libraries.userLibraryID
-            : Zotero.Groups.getLibraryIDFromGroupID(Number(openPdfMatch[2]));
+            : Zotero.Groups.getLibraryIDFromGroupID(Number(openMatch[2]));
         if (!libraryId) return null;
 
-        const params = new URLSearchParams(openPdfMatch[4] || '');
-        const annotationKey = params.get('annotation');
-        return annotationKey ? { libraryId, itemKey: annotationKey } : null;
+        const params = new URLSearchParams(openMatch[4] || '');
+        return { libraryId, itemKey: params.get('annotation') || openMatch[3] };
     }
 
     return null;
 }
 
-/** Load attachment titles before synchronous rendering; no file access is needed. */
-export async function preloadStandaloneAttachmentTitles(
+/**
+ * Prepare cited standalone attachments for synchronous link rendering: load the
+ * titles the label needs, and resolve each file once so Zotero's cached file
+ * state can tell `buildZoteroCitationLinkURI` whether opening it would work.
+ */
+export async function preloadStandaloneAttachmentLinks(
     content: string,
     allowLibrary: (libraryID: number) => boolean = () => true,
 ): Promise<void> {
@@ -213,4 +246,13 @@ export async function preloadStandaloneAttachmentTitles(
     } catch {
         // Rendering can still use filenames when title data is unavailable.
     }
+    // Resolving the path is what populates `fileExistsCached()`. Failures leave
+    // it unknown, which renders an open link — the same as before this check.
+    await Promise.all(items.map(async (item) => {
+        try {
+            await item.getFilePathAsync?.();
+        } catch {
+            // A file that cannot be checked is not a reason to drop the link.
+        }
+    }));
 }

--- a/tests/live/standaloneNoteCitations.live.test.ts
+++ b/tests/live/standaloneNoteCitations.live.test.ts
@@ -60,14 +60,18 @@ describe.skipIf(!key)('standalone attachment note links (live)', () => {
             const read = await post<any>('/beaver/note/read', { note_id: `${libraryID}-${noteKey}` });
             expect(read.success, JSON.stringify(read)).toBe(true);
             expect(read.content).toContain(`ref="c_${key}_0"`);
+            // The locator is part of the citation tag, so editing it rebuilds
+            // the link rather than leaving it on the page it was built with.
+            expect(read.content).toContain('loc="page6"');
             const edit = await post<any>('/beaver/agent-action/execute', { action_type: 'edit_note', action_data: {
                 library_id: libraryID, zotero_key: noteKey, operation: 'str_replace',
-                old_string: ', p. 6', new_string: ', p. 7',
+                old_string: 'loc="page6"', new_string: 'loc="page7"',
             } });
             expect(edit.success, JSON.stringify(edit)).toBe(true);
             const html = (await readNote(libraryID, noteKey)).saved_html;
             expect(html).toContain(`href="${href}`);
             expect(html).toContain('p. 7');
+            expect(html).not.toContain('?page=6');
         }
     });
 

--- a/tests/live/standaloneNoteCitations.live.test.ts
+++ b/tests/live/standaloneNoteCitations.live.test.ts
@@ -3,17 +3,19 @@ import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability
 import { post } from '../helpers/zoteroHttpClient';
 import { createNote, executeCreateNote, deleteNote, readNote, openNoteEditor, closeNoteEditor } from './helpers/noteTestClient';
 
-// Supply an existing standalone attachment in the isolated test library.
+// Supply an existing standalone *file* attachment in the isolated test library.
 const key = process.env.ZOTERO_TEST_STANDALONE_KEY;
 const libraryID = Number(process.env.ZOTERO_TEST_LIBRARY_ID ?? 1);
 const notes: string[] = [];
 let available = false;
 const tag = (loc = 'page6') => `<citation id="${libraryID}-${key}" loc="${loc}"/>`;
-const href = `zotero://select/library/items/${key}`;
+// A standalone attachment link opens the file. Matched as a prefix because a
+// PDF also carries the cited `?page=`, while other file types do not.
+const href = `zotero://open/library/items/${key}`;
 
 async function assertSavedLink(noteKey: string) {
     const html = (await readNote(libraryID, noteKey)).saved_html;
-    expect(html).toContain(`href="${href}"`);
+    expect(html).toContain(`href="${href}`);
     expect(html).not.toContain('data-citation=');
     expect(html).toContain('p. 6');
     return html.match(/<a\b[^>]*>[^<]*<\/a>/g)?.find(link => link.includes(href));
@@ -64,7 +66,7 @@ describe.skipIf(!key)('standalone attachment note links (live)', () => {
             } });
             expect(edit.success, JSON.stringify(edit)).toBe(true);
             const html = (await readNote(libraryID, noteKey)).saved_html;
-            expect(html).toContain(`href="${href}"`);
+            expect(html).toContain(`href="${href}`);
             expect(html).toContain('p. 7');
         }
     });
@@ -97,7 +99,7 @@ describe.skipIf(!key)('standalone attachment note links (live)', () => {
         expect(applied.success, JSON.stringify(applied)).toBe(true);
         for (const noteKey of notes) {
             const html = (await readNote(libraryID, noteKey)).saved_html;
-            expect(html).toContain(`href="${href}"`);
+            expect(html).toContain(`href="${href}`);
             expect(html).toContain(`, p. ${expectedPage}`);
             expect(html).not.toContain('sentence ');
         }

--- a/tests/live/standaloneNoteCitations.live.test.ts
+++ b/tests/live/standaloneNoteCitations.live.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
+import { post } from '../helpers/zoteroHttpClient';
+import { createNote, executeCreateNote, deleteNote, readNote, openNoteEditor, closeNoteEditor } from './helpers/noteTestClient';
+
+// Supply an existing standalone attachment in the isolated test library.
+const key = process.env.ZOTERO_TEST_STANDALONE_KEY;
+const libraryID = Number(process.env.ZOTERO_TEST_LIBRARY_ID ?? 1);
+const notes: string[] = [];
+let available = false;
+const tag = (loc = 'page6') => `<citation id="${libraryID}-${key}" loc="${loc}"/>`;
+const href = `zotero://select/library/items/${key}`;
+
+async function assertSavedLink(noteKey: string) {
+    const html = (await readNote(libraryID, noteKey)).saved_html;
+    expect(html).toContain(`href="${href}"`);
+    expect(html).not.toContain('data-citation=');
+    expect(html).toContain('p. 6');
+    return html.match(/<a\b[^>]*>[^<]*<\/a>/g)?.find(link => link.includes(href));
+}
+
+beforeAll(async () => { available = await isZoteroAvailable(); });
+afterEach(async () => {
+    await post('/beaver/test/note-preview', { dismiss: true });
+    for (const noteKey of notes.splice(0)) {
+        await closeNoteEditor(libraryID, noteKey);
+        await deleteNote(libraryID, noteKey);
+    }
+});
+
+describe.skipIf(!key)('standalone attachment note links (live)', () => {
+    beforeEach(ctx => skipIfNoZotero(ctx, available));
+
+    it('creates and edits the same link, preserving it through editor saves and read-back edits', async () => {
+        const created = await executeCreateNote({ library_id: libraryID, title: 'Standalone citation test', content: `Source ${tag()}` });
+        expect(created.success, JSON.stringify(created)).toBe(true);
+        const createdKey = created.result_data!.zotero_key;
+        notes.push(createdKey);
+        const createdLink = await assertSavedLink(createdKey);
+
+        const edited = await createNote({ library_id: libraryID, html: '<p>Anchor</p>' });
+        notes.push(edited.zotero_key);
+        const data = { library_id: libraryID, zotero_key: edited.zotero_key,
+            operation: 'append', new_string: `<p>Source ${tag()}</p>` };
+        const validation = await post<any>('/beaver/agent-action/validate', { action_type: 'edit_note', action_data: data });
+        expect(validation.valid, JSON.stringify(validation)).toBe(true);
+        const result = await post<any>('/beaver/agent-action/execute', {
+            action_type: 'edit_note', action_data: { ...data, ...validation.normalized_action_data },
+        });
+        expect(result.success, JSON.stringify(result)).toBe(true);
+        expect(await assertSavedLink(edited.zotero_key)).toBe(createdLink);
+        for (const noteKey of notes) {
+            const opened = await openNoteEditor(libraryID, noteKey);
+            expect(opened.ok, JSON.stringify(opened)).toBe(true);
+            expect(opened.in_editor, JSON.stringify(opened)).toBe(true);
+            expect((await closeNoteEditor(libraryID, noteKey)).ok).toBe(true);
+            await assertSavedLink(noteKey);
+            const read = await post<any>('/beaver/note/read', { note_id: `${libraryID}-${noteKey}` });
+            expect(read.success, JSON.stringify(read)).toBe(true);
+            expect(read.content).toContain(`ref="c_${key}_0"`);
+            const edit = await post<any>('/beaver/agent-action/execute', { action_type: 'edit_note', action_data: {
+                library_id: libraryID, zotero_key: noteKey, operation: 'str_replace',
+                old_string: ', p. 6', new_string: ', p. 7',
+            } });
+            expect(edit.success, JSON.stringify(edit)).toBe(true);
+            const html = (await readNote(libraryID, noteKey)).saved_html;
+            expect(html).toContain(`href="${href}"`);
+            expect(html).toContain('p. 7');
+        }
+    });
+
+    it.skipIf(!process.env.ZOTERO_TEST_SENTENCE_LOCATOR)('uses the same resolved page display for sentence citations in create, edit, and preview', async () => {
+        const content = tag(process.env.ZOTERO_TEST_SENTENCE_LOCATOR!);
+        const expectedPage = process.env.ZOTERO_TEST_SENTENCE_PAGE!;
+        const created = await executeCreateNote({ library_id: libraryID, title: 'Sentence locator test', content });
+        expect(created.success, JSON.stringify(created)).toBe(true);
+        notes.push(created.result_data!.zotero_key);
+        const edited = await createNote({ library_id: libraryID, html: '<p>Anchor</p>' });
+        notes.push(edited.zotero_key);
+        const preview = await post<any>('/beaver/test/note-preview', {
+            library_id: libraryID, zotero_key: edited.zotero_key,
+            edits: [{ oldString: 'Anchor', newString: content }],
+        });
+        expect(preview.ok, JSON.stringify(preview)).toBe(true);
+        expect(preview.html).toContain(`, p. ${expectedPage}`);
+        expect(preview.html).not.toContain('sentence ');
+        await post('/beaver/test/note-preview', { dismiss: true });
+        const data = {
+            library_id: libraryID, zotero_key: edited.zotero_key,
+            edits: [{ index: 0, operation: 'str_replace', old_string: 'Anchor', new_string: content }],
+        };
+        const validation = await post<any>('/beaver/agent-action/validate', { action_type: 'edit_note_batch', action_data: data });
+        expect(validation.valid, JSON.stringify(validation)).toBe(true);
+        const applied = await post<any>('/beaver/agent-action/execute', { action_type: 'edit_note_batch',
+            action_data: { ...data, ...validation.normalized_action_data },
+        });
+        expect(applied.success, JSON.stringify(applied)).toBe(true);
+        for (const noteKey of notes) {
+            const html = (await readNote(libraryID, noteKey)).saved_html;
+            expect(html).toContain(`href="${href}"`);
+            expect(html).toContain(`, p. ${expectedPage}`);
+            expect(html).not.toContain('sentence ');
+        }
+    });
+
+    it('previews and applies a batch link with the same title and locator, then undoes it', async () => {
+        const note = await createNote({ library_id: libraryID, html: '<p>Anchor</p>' });
+        notes.push(note.zotero_key);
+        const edit = { index: 0, operation: 'str_replace', old_string: 'Anchor', new_string: tag() };
+        const preview = await post<any>('/beaver/test/note-preview', {
+            library_id: libraryID, zotero_key: note.zotero_key,
+            edits: [{ oldString: edit.old_string, newString: edit.new_string }],
+        });
+        expect(preview.ok, JSON.stringify(preview)).toBe(true);
+        expect(preview.html).toContain(href);
+        await post('/beaver/test/note-preview', { dismiss: true });
+        const action = { id: 'standalone-link-test', action_type: 'edit_note_batch', proposed_data: {
+            library_id: libraryID, zotero_key: note.zotero_key, edits: [edit],
+        } };
+        const applied = await post<any>('/beaver/test/note-apply', { action });
+        expect(applied.ok, JSON.stringify(applied)).toBe(true);
+        const link = await assertSavedLink(note.zotero_key);
+        expect(preview.html).toContain(link);
+        const undo = await post<any>('/beaver/test/note-undo', {
+            action: { ...action, status: 'applied', result_data: applied.result_data },
+        });
+        expect(undo.ok, JSON.stringify(undo)).toBe(true);
+        expect((await readNote(libraryID, note.zotero_key)).saved_html).toContain('Anchor');
+    });
+});

--- a/tests/unit/host/citationExport.test.ts
+++ b/tests/unit/host/citationExport.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../../src/utils/zoteroLinkCitation', () => ({
 
 vi.mock('@beaver/agent-core/platform/logger', () => ({ logger: vi.fn() }));
 
+import { buildZoteroCitationLinkHTML } from '../../../src/utils/zoteroLinkCitation';
 import { zoteroDocumentExport } from '../../../react/host/zotero/citationExport';
 
 function citationRequest(overrides: Record<string, unknown> = {}) {
@@ -58,6 +59,46 @@ describe('zoteroDocumentExport.renderCitation', () => {
             html: '<a href="https://example.com">Example</a>',
         });
         expect(Zotero.Items.getByLibraryAndKey).toHaveBeenCalledWith(42, 'ABCD1234');
+    });
+
+    it('uses resolved pages for structural locators', () => {
+        const loc = { kind: 'sentence', value: '4', raw: 's4' };
+        zoteroDocumentExport.renderCitation(citationRequest({ requestedRef: { loc }, pages: [6] }));
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, { kind: 'page', value: '6', raw: 'page6' });
+    });
+
+    it('retains all metadata pages when no requested locator exists', () => {
+        zoteroDocumentExport.renderCitation(citationRequest({ pages: [6, 7] }));
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
+            { kind: 'page', value: '6-7', raw: 'page6-7' });
+    });
+
+    it.each([
+        { pages: [2, 4], labels: undefined, expected: '2-4' },
+        { pages: [2, 4, 2], labels: { 1: 'iv', 3: 'vi' }, expected: 'iv-vi' },
+        { pages: [2, 2], labels: { 1: 'iv' }, expected: 'iv' },
+    ])('formats structural spans as inclusive page ranges: $expected', ({ pages, labels, expected }) => {
+        zoteroDocumentExport.renderCitation(citationRequest({
+            requestedRef: { loc: { kind: 'sentence', value: '1-5', raw: 's1-s5' } },
+            pages, metadata: { page_labels: labels },
+        }));
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
+            { kind: 'page', value: expected, raw: `page${expected}` });
+    });
+
+    it.each([null, { loc: { kind: 'page', value: '2, 4', raw: 'page2, 4' } }])(
+        'preserves separate cited pages without a structural span (%j)', (requestedRef) => {
+            zoteroDocumentExport.renderCitation(citationRequest({ requestedRef, pages: [2, 4] }));
+            expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
+                { kind: 'page', value: '2, 4', raw: 'page2, 4' });
+        },
+    );
+
+    it('omits unresolved structural locators rather than displaying sentence numbers', () => {
+        zoteroDocumentExport.renderCitation(citationRequest({
+            requestedRef: { loc: { kind: 'sentence', value: '1-5', raw: 's1-s5' } },
+        }));
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, undefined);
     });
 
     it('falls back to the legacy local library id when no portable ref exists', () => {

--- a/tests/unit/host/citationExport.test.ts
+++ b/tests/unit/host/citationExport.test.ts
@@ -64,13 +64,13 @@ describe('zoteroDocumentExport.renderCitation', () => {
     it('uses resolved pages for structural locators', () => {
         const loc = { kind: 'sentence', value: '4', raw: 's4' };
         zoteroDocumentExport.renderCitation(citationRequest({ requestedRef: { loc }, pages: [6] }));
-        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, { kind: 'page', value: '6', raw: 'page6' });
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, { kind: 'page', value: '6', raw: 'page6' }, 6);
     });
 
     it('retains all metadata pages when no requested locator exists', () => {
         zoteroDocumentExport.renderCitation(citationRequest({ pages: [6, 7] }));
         expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
-            { kind: 'page', value: '6-7', raw: 'page6-7' });
+            { kind: 'page', value: '6-7', raw: 'page6-7' }, 6);
     });
 
     it.each([
@@ -83,14 +83,14 @@ describe('zoteroDocumentExport.renderCitation', () => {
             pages, metadata: { page_labels: labels },
         }));
         expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
-            { kind: 'page', value: expected, raw: `page${expected}` });
+            { kind: 'page', value: expected, raw: `page${expected}` }, 2);
     });
 
     it.each([null, { loc: { kind: 'page', value: '2, 4', raw: 'page2, 4' } }])(
         'preserves separate cited pages without a structural span (%j)', (requestedRef) => {
             zoteroDocumentExport.renderCitation(citationRequest({ requestedRef, pages: [2, 4] }));
             expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item,
-                { kind: 'page', value: '2, 4', raw: 'page2, 4' });
+                { kind: 'page', value: '2, 4', raw: 'page2, 4' }, 2);
         },
     );
 
@@ -98,7 +98,7 @@ describe('zoteroDocumentExport.renderCitation', () => {
         zoteroDocumentExport.renderCitation(citationRequest({
             requestedRef: { loc: { kind: 'sentence', value: '1-5', raw: 's1-s5' } },
         }));
-        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, undefined);
+        expect(buildZoteroCitationLinkHTML).toHaveBeenCalledWith(item, undefined, undefined);
     });
 
     it('falls back to the legacy local library id when no portable ref exists', () => {

--- a/tests/unit/notes/editNoteUndoRoundtrip.test.ts
+++ b/tests/unit/notes/editNoteUndoRoundtrip.test.ts
@@ -2242,17 +2242,17 @@ describe('external-file citations through React apply and undo', () => {
             '<a href="zotero://open/library/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 6)');
         expect(item._getHtml()).not.toContain('data-citation=');
         const { simplified } = simplifyNoteHtml(item._getHtml(), 1);
-        expect(simplified).toContain('ref="c_ATTACH12_0"');
-        const nextAction = makeAction(1, 'TESTKEY', simplified, simplified.replace(', p. 6)', ', p. 7)'));
+        // The saved locator reaches the agent inside the citation tag.
+        expect(simplified).toContain('<citation id="u-ATTACH12" loc="page6" ref="c_ATTACH12_0"/>');
+        const nextAction = makeAction(1, 'TESTKEY', simplified, simplified.replace('loc="page6"', 'loc="page7"'));
         const result = await executeEditNoteAction(nextAction);
         nextAction.result_data = result as any;
-        // Known limitation: the locator suffix is plain text outside the link, so
-        // editing it moves the visible page but leaves the link on the page the
-        // citation originally named.
+        // Editing it moves the link with the visible page.
         expect(item._getHtml()).toContain(
-            '<a href="zotero://open/library/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 7)');
+            '<a href="zotero://open/library/items/ATTACH12?page=7" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 7)');
         await undoEdit(item, nextAction);
-        expect(item._getHtml()).toContain('Report.pdf</a>, p. 6)');
+        expect(item._getHtml()).toContain(
+            '<a href="zotero://open/library/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 6)');
         const restored = await undoEdit(item, action);
         expect(restored).toContain('<p>Anchor</p>');
         expect(restored).not.toContain('Report.pdf');

--- a/tests/unit/notes/editNoteUndoRoundtrip.test.ts
+++ b/tests/unit/notes/editNoteUndoRoundtrip.test.ts
@@ -2225,6 +2225,34 @@ describe('external-file citations through React apply and undo', () => {
         vi.mocked(store.get).mockImplementation(() => null);
     });
 
+    it('applies a standalone attachment link, edits its saved locator, and undoes both edits', async () => {
+        (Zotero.Libraries as any).userLibraryID = 1;
+        (Zotero.Items as any).loadDataTypes = vi.fn().mockResolvedValue(undefined);
+        const attachment = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, getField: () => 'Report.pdf',
+            loadDataType: vi.fn().mockResolvedValue(undefined),
+        };
+        vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(attachment as any);
+        const original = wrap('<p>Anchor</p>');
+        const { item, action } = await applyEdit({ noteHtml: original, oldString: 'Anchor',
+            newString: '<citation id="u-ATTACH12" loc="page6"/>',
+        });
+        expect(item._getHtml()).toContain('Report.pdf</a>, p. 6)');
+        expect(item._getHtml()).not.toContain('data-citation=');
+        const { simplified } = simplifyNoteHtml(item._getHtml(), 1);
+        expect(simplified).toContain('ref="c_ATTACH12_0"');
+        const nextAction = makeAction(1, 'TESTKEY', simplified, simplified.replace(', p. 6)', ', p. 7)'));
+        const result = await executeEditNoteAction(nextAction);
+        nextAction.result_data = result as any;
+        expect(item._getHtml()).toContain('Report.pdf</a>, p. 7)');
+        await undoEdit(item, nextAction);
+        expect(item._getHtml()).toContain('Report.pdf</a>, p. 6)');
+        const restored = await undoEdit(item, action);
+        expect(restored).toContain('<p>Anchor</p>');
+        expect(restored).not.toContain('Report.pdf');
+        expect(Zotero.Items.loadDataTypes).toHaveBeenCalledWith([attachment], ['itemData']);
+    });
+
     it('applies a filename link and can undo without stored undo HTML', async () => {
         const { item, action } = await applyEdit({ noteHtml: wrap('<p>Anchor</p>'), oldString: 'Anchor', newString: tag });
         expect(item._getHtml()).toContain('href="file:///stored/Report.pdf"');

--- a/tests/unit/notes/editNoteUndoRoundtrip.test.ts
+++ b/tests/unit/notes/editNoteUndoRoundtrip.test.ts
@@ -2229,7 +2229,8 @@ describe('external-file citations through React apply and undo', () => {
         (Zotero.Libraries as any).userLibraryID = 1;
         (Zotero.Items as any).loadDataTypes = vi.fn().mockResolvedValue(undefined);
         const attachment = { libraryID: 1, key: 'ATTACH12', parentID: false,
-            isAttachment: () => true, getField: () => 'Report.pdf',
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report.pdf',
             loadDataType: vi.fn().mockResolvedValue(undefined),
         };
         vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(attachment as any);
@@ -2237,20 +2238,47 @@ describe('external-file citations through React apply and undo', () => {
         const { item, action } = await applyEdit({ noteHtml: original, oldString: 'Anchor',
             newString: '<citation id="u-ATTACH12" loc="page6"/>',
         });
-        expect(item._getHtml()).toContain('Report.pdf</a>, p. 6)');
+        expect(item._getHtml()).toContain(
+            '<a href="zotero://open/library/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 6)');
         expect(item._getHtml()).not.toContain('data-citation=');
         const { simplified } = simplifyNoteHtml(item._getHtml(), 1);
         expect(simplified).toContain('ref="c_ATTACH12_0"');
         const nextAction = makeAction(1, 'TESTKEY', simplified, simplified.replace(', p. 6)', ', p. 7)'));
         const result = await executeEditNoteAction(nextAction);
         nextAction.result_data = result as any;
-        expect(item._getHtml()).toContain('Report.pdf</a>, p. 7)');
+        // Known limitation: the locator suffix is plain text outside the link, so
+        // editing it moves the visible page but leaves the link on the page the
+        // citation originally named.
+        expect(item._getHtml()).toContain(
+            '<a href="zotero://open/library/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 7)');
         await undoEdit(item, nextAction);
         expect(item._getHtml()).toContain('Report.pdf</a>, p. 6)');
         const restored = await undoEdit(item, action);
         expect(restored).toContain('<p>Anchor</p>');
         expect(restored).not.toContain('Report.pdf');
         expect(Zotero.Items.loadDataTypes).toHaveBeenCalledWith([attachment], ['itemData']);
+    });
+
+    it('selects instead of opening when the cited attachment has no local file', async () => {
+        (Zotero.Libraries as any).userLibraryID = 1;
+        (Zotero.Items as any).loadDataTypes = vi.fn().mockResolvedValue(undefined);
+        // Mirrors Zotero: resolving the path is what records the file state, and
+        // a file this computer does not have resolves to false.
+        let fileState: boolean | null = null;
+        const attachment = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report.pdf',
+            getFilePathAsync: vi.fn(async () => { fileState = false; return false; }),
+            fileExistsCached: () => fileState,
+            loadDataType: vi.fn().mockResolvedValue(undefined),
+        };
+        vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(attachment as any);
+        const { item } = await applyEdit({ noteHtml: wrap('<p>Anchor</p>'), oldString: 'Anchor',
+            newString: '<citation id="u-ATTACH12" loc="page6"/>',
+        });
+        expect(attachment.getFilePathAsync).toHaveBeenCalled();
+        expect(item._getHtml()).toContain(
+            '<a href="zotero://select/library/items/ATTACH12" rel="noopener noreferrer nofollow">Report.pdf</a>, p. 6)');
     });
 
     it('applies a filename link and can undo without stored undo HTML', async () => {

--- a/tests/unit/notes/noteEditRoundtrip.test.ts
+++ b/tests/unit/notes/noteEditRoundtrip.test.ts
@@ -2175,8 +2175,9 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'Test Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
-            parentItem: null,
+            parentItem: { id: 999, isRegularItem: () => true },
             getAttachments: vi.fn(() => []),
         };
         (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => mockItem);
@@ -2202,8 +2203,9 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'Test Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
-            parentItem: null,
+            parentItem: { id: 999, isRegularItem: () => true },
             getAttachments: vi.fn(() => []),
         };
         (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => mockItem);
@@ -2227,8 +2229,9 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'Test Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
-            parentItem: null,
+            parentItem: { id: 999, isRegularItem: () => true },
             getAttachments: vi.fn(() => []),
         };
         (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => mockItem);
@@ -2270,6 +2273,7 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'New Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
             getAttachments: vi.fn(() => []),
         };
@@ -2300,6 +2304,7 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'New Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
             getAttachments: vi.fn(() => []),
         };
@@ -2332,8 +2337,9 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
-            parentItem: null,
+            parentItem: { id: 999, isRegularItem: () => true },
             getAttachments: vi.fn(() => []),
         };
         (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => mockItem);
@@ -2380,8 +2386,9 @@ describe('Page label translation during citation expansion', () => {
             libraryID: 1,
             getField: vi.fn(() => 'Paper'),
             isAttachment: vi.fn(() => true),
+            parentID: 999,
             isRegularItem: vi.fn(() => false),
-            parentItem: null,
+            parentItem: { id: 999, isRegularItem: () => true },
             getAttachments: vi.fn(() => []),
         };
         (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => mockItem);

--- a/tests/unit/notes/noteHtmlSimplifier.test.ts
+++ b/tests/unit/notes/noteHtmlSimplifier.test.ts
@@ -629,7 +629,7 @@ describe('expandToRawHtml', () => {
         const { metadata } = makeMetadata();
         // Sentence locator s4 was pre-resolved to page "9".
         const input = '<citation id="1-EX1" loc="s4" label="(Author, 2024)" ref="c_EX1_new"/>';
-        const resolvedLocatorPages = { 'zotero:u-EX1:s4': '9' };
+        const resolvedLocatorPages = { 'zotero:u-EX1:s4': { label: '9', page: 9 } };
         expandToRawHtml(input, metadata, 'new', undefined, undefined, resolvedLocatorPages);
         expect(createCitationHTML).toHaveBeenCalledWith(
             expect.objectContaining({ key: 'EX1' }),
@@ -654,7 +654,7 @@ describe('expandToRawHtml', () => {
         // page is already a final label and must be stored verbatim.
         const input = '<citation id="1-EX1" loc="s4" label="(Author, 2024)" ref="c_EX1_new"/>';
         const pageLabels = { '1-EX1': { 8: 'ix' } };
-        const resolvedLocatorPages = { 'zotero:u-EX1:s4': '9' };
+        const resolvedLocatorPages = { 'zotero:u-EX1:s4': { label: '9', page: 9 } };
         expandToRawHtml(input, metadata, 'new', undefined, pageLabels as any, resolvedLocatorPages);
         expect(createCitationHTML).toHaveBeenCalledWith(
             expect.objectContaining({ key: 'EX1' }),
@@ -666,7 +666,7 @@ describe('expandToRawHtml', () => {
         const { metadata } = makeMetadata();
         // c_EX1_1 originally has page="10"; change its locator to sentence s4.
         const input = '<citation id="1-EX1" loc="s4" label="(Author, 2024, p. 10)" ref="c_EX1_1"/>';
-        const resolvedLocatorPages = { 'zotero:u-EX1:s4': '3' };
+        const resolvedLocatorPages = { 'zotero:u-EX1:s4': { label: '3', page: 3 } };
         expandToRawHtml(input, metadata, 'new', undefined, undefined, resolvedLocatorPages);
         expect(createCitationHTML).toHaveBeenCalledWith(
             expect.objectContaining({ key: 'EX1' }),
@@ -677,7 +677,7 @@ describe('expandToRawHtml', () => {
     it('substitutes a resolved page for a legacy att_id structural locator', () => {
         const { metadata } = makeMetadata();
         const input = '<citation att_id="1-ATT1" loc="s4" label="(Author, 2024)"/>';
-        const resolvedLocatorPages = { 'zotero:u-ATT1:s4': '9' };
+        const resolvedLocatorPages = { 'zotero:u-ATT1:s4': { label: '9', page: 9 } };
         expandToRawHtml(input, metadata, 'new', undefined, undefined, resolvedLocatorPages);
         expect(createCitationHTML).toHaveBeenCalledWith(
             expect.objectContaining({ key: 'ATT1' }),
@@ -689,7 +689,7 @@ describe('expandToRawHtml', () => {
         const { metadata } = makeMetadata();
         // The `sid` attribute is the legacy alias for a structural locator.
         const input = '<citation att_id="1-ATT1" sid="s4" label="(Author, 2024)"/>';
-        const resolvedLocatorPages = { 'zotero:u-ATT1:s4': '9' };
+        const resolvedLocatorPages = { 'zotero:u-ATT1:s4': { label: '9', page: 9 } };
         expandToRawHtml(input, metadata, 'new', undefined, undefined, resolvedLocatorPages);
         expect(createCitationHTML).toHaveBeenCalledWith(
             expect.objectContaining({ key: 'ATT1' }),
@@ -797,20 +797,20 @@ describe('expandToRawHtml', () => {
     });
 
     it.each([
-        ['id="u-ATTACH12" loc="page6-8"', ', p. 6-8'],
-        ['att_id="1-ATTACH12" page="6"', ', p. 6'],
-        ['attachment_id="1-ATTACH12" loc="s4"', ''],
-        ['item_id="1-ATTACH12"', ''],
-    ])('stores standalone attachment %s as an editable link', (attrs, suffix) => {
+        ['id="u-ATTACH12" loc="page6-8"', ', p. 6-8', '?page=6'],
+        ['att_id="1-ATTACH12" page="6"', ', p. 6', '?page=6'],
+        ['attachment_id="1-ATTACH12" loc="s4"', '', ''],
+        ['item_id="1-ATTACH12"', '', ''],
+    ])('stores standalone attachment %s as an editable link', (attrs, suffix, pageQuery) => {
         const item = {
             key: 'ATTACH12', libraryID: 1, parentID: false,
-            isAttachment: () => true,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
             getField: () => 'Report & findings.pdf',
         };
         vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(item as any);
         (Zotero.Libraries as any).get = vi.fn(() => ({ isGroup: false }));
         const html = expandToRawHtml(`<citation ${attrs}/>`, { elements: new Map() }, 'new');
-        expect(html).toBe(`(<a href="zotero://select/library/items/ATTACH12" rel="noopener noreferrer nofollow">Report &amp; findings.pdf</a>${suffix})`);
+        expect(html).toBe(`(<a href="zotero://open/library/items/ATTACH12${pageQuery}" rel="noopener noreferrer nofollow">Report &amp; findings.pdf</a>${suffix})`);
         expect(createCitationHTML).not.toHaveBeenCalled();
         const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${html}</p>`), 1);
         expect(simplified).toContain(`<citation id="u-ATTACH12" ref="c_ATTACH12_0"/>${suffix}`);
@@ -830,7 +830,8 @@ describe('expandToRawHtml', () => {
         const previousBeaver = Zotero.Beaver;
         vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue({
             id: 42, key: 'ATTACH12', libraryID: 1, parentID: false,
-            isAttachment: () => true, getField: () => 'Report.pdf',
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report.pdf',
             getFilePathAsync: async () => '/report.pdf',
         } as any);
         (Zotero.Libraries as any).get = vi.fn(() => ({ isGroup: false }));
@@ -851,12 +852,15 @@ describe('expandToRawHtml', () => {
                 expect(resolved.unresolved).toEqual([]);
                 const html = expandToRawHtml(input, { elements: new Map() }, 'new', undefined, undefined, resolved.pages);
                 expect(html).toContain(`Report.pdf</a>, p. ${withLabels ? 'iv-vi' : '2-4'})`);
+                // The span displays labels but opens the first physical page.
+                expect(html).toContain('href="zotero://open/library/items/ATTACH12?page=2"');
                 expect(html).not.toContain('sentence');
             }
             const input = '<citation id="1-ATTACH12" loc="page2-3"/>';
             const labels = await preloadPageLabelsForNewCitations(input);
-            expect(expandToRawHtml(input, { elements: new Map() }, 'new', undefined, labels))
-                .toContain('Report.pdf</a>, p. iv-v)');
+            const pageHtml = expandToRawHtml(input, { elements: new Map() }, 'new', undefined, labels);
+            expect(pageHtml).toContain('Report.pdf</a>, p. iv-v)');
+            expect(pageHtml).toContain('href="zotero://open/library/items/ATTACH12?page=2"');
         } finally {
             (Zotero as any).Beaver = previousBeaver;
         }

--- a/tests/unit/notes/noteHtmlSimplifier.test.ts
+++ b/tests/unit/notes/noteHtmlSimplifier.test.ts
@@ -327,6 +327,32 @@ describe('simplifyNoteHtml', () => {
         );
     });
 
+    it('absorbs the parentheses Beaver writes around a link citation', () => {
+        const html = wrap('<p>Source (<a href="zotero://select/library/items/NOTE1234">Note: Project note</a>)</p>');
+        const { simplified, metadata } = simplifyNoteHtml(html, 1);
+
+        expect(simplified).toContain('<p>Source <citation id="u-NOTE1234" ref="c_NOTE1234_0"/></p>');
+        expect(expandToRawHtml(simplified, metadata, 'old')).toContain(
+            'Source (<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer nofollow">Note: Project note</a>)'
+        );
+    });
+
+    it.each([
+        ['a parenthesis that is not part of the citation', 'Text (see LINK) after.'],
+        ['prose that is not a page locator', 'Text (LINK, see also the appendix) after.'],
+        ['a locator the agent may still edit as text', 'Text LINK, p. 6 after.'],
+    ])('leaves %s outside the citation token', (_label, template) => {
+        const link = '<a href="zotero://select/library/items/NOTE1234">Note: Project note</a>';
+        const text = template.replace('LINK', link);
+        const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${text}</p>`), 1);
+
+        expect(simplified).toContain('<citation id="u-NOTE1234" ref="c_NOTE1234_0"/>');
+        expect(simplified).toContain(template.replace('LINK', '<citation id="u-NOTE1234" ref="c_NOTE1234_0"/>'));
+        expect(expandToRawHtml(simplified, metadata, 'old')).toContain(
+            text.replace('">Note', '" rel="noopener noreferrer nofollow">Note')
+        );
+    });
+
     it('preserves Zotero citation link hrefs during an unrelated str_replace edit', () => {
         const noteLink = '<a href="zotero://select/library/items/NOTE1234">Note: Project note</a>';
         const annotationLink = '<a href="zotero://open-pdf/library/items/ATTACH12?annotation=ANNOT123">Annotation: Highlight</a>';
@@ -797,11 +823,11 @@ describe('expandToRawHtml', () => {
     });
 
     it.each([
-        ['id="u-ATTACH12" loc="page6-8"', ', p. 6-8', '?page=6'],
-        ['att_id="1-ATTACH12" page="6"', ', p. 6', '?page=6'],
-        ['attachment_id="1-ATTACH12" loc="s4"', '', ''],
-        ['item_id="1-ATTACH12"', '', ''],
-    ])('stores standalone attachment %s as an editable link', (attrs, suffix, pageQuery) => {
+        ['id="u-ATTACH12" loc="page6-8"', ', p. 6-8', '?page=6', ' loc="page6-8"'],
+        ['att_id="1-ATTACH12" page="6"', ', p. 6', '?page=6', ' loc="page6"'],
+        ['attachment_id="1-ATTACH12" loc="s4"', '', '', ''],
+        ['item_id="1-ATTACH12"', '', '', ''],
+    ])('stores standalone attachment %s as an editable link', (attrs, suffix, pageQuery, loc) => {
         const item = {
             key: 'ATTACH12', libraryID: 1, parentID: false,
             isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
@@ -813,9 +839,11 @@ describe('expandToRawHtml', () => {
         expect(html).toBe(`(<a href="zotero://open/library/items/ATTACH12${pageQuery}" rel="noopener noreferrer nofollow">Report &amp; findings.pdf</a>${suffix})`);
         expect(createCitationHTML).not.toHaveBeenCalled();
         const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${html}</p>`), 1);
-        expect(simplified).toContain(`<citation id="u-ATTACH12" ref="c_ATTACH12_0"/>${suffix}`);
+        // The locator lives in the token, not as text the agent can edit apart
+        // from the link, and the parentheses come back with it.
+        expect(simplified).toContain(`<p><citation id="u-ATTACH12"${loc} ref="c_ATTACH12_0"/></p>`);
         const saved = expandToRawHtml(simplified, metadata, 'new');
-        expect(saved).toContain(`Report &amp; findings.pdf</a>${suffix}`);
+        expect(saved).toContain(`Report &amp; findings.pdf</a>${suffix})`);
         expect(expandToRawHtml(simplified, metadata, 'old')).toBe(saved);
     });
 
@@ -855,6 +883,10 @@ describe('expandToRawHtml', () => {
                 // The span displays labels but opens the first physical page.
                 expect(html).toContain('href="zotero://open/library/items/ATTACH12?page=2"');
                 expect(html).not.toContain('sentence');
+                // A non-numeric label survives the round trip as the tag's locator.
+                const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${html}</p>`), 1);
+                expect(simplified).toContain(`loc="page${withLabels ? 'iv-vi' : '2-4'}"`);
+                expect(expandToRawHtml(simplified, metadata, 'old')).toContain(html);
             }
             const input = '<citation id="1-ATTACH12" loc="page2-3"/>';
             const labels = await preloadPageLabelsForNewCitations(input);

--- a/tests/unit/notes/noteHtmlSimplifier.test.ts
+++ b/tests/unit/notes/noteHtmlSimplifier.test.ts
@@ -847,6 +847,31 @@ describe('expandToRawHtml', () => {
         expect(expandToRawHtml(simplified, metadata, 'old')).toBe(saved);
     });
 
+    it('keeps the physical-page convention for a link citation whose labels are offset', () => {
+        // Front matter puts printed page 3 on physical page 5. The agent works
+        // in physical pages, so that is what the simplified locator must show,
+        // and an edit to it must land on the physical page it names.
+        const labels = { 4: '3', 5: '4' };
+        const item = {
+            id: 42, key: 'ATTACH12', libraryID: 1, parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report.pdf',
+        };
+        vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(item as any);
+        (Zotero.Libraries as any).get = vi.fn(() => ({ isGroup: false }));
+        const saved = '(<a href="zotero://open/library/items/ATTACH12?page=5"'
+            + ' rel="noopener noreferrer nofollow">Report.pdf</a>, p. 3)';
+
+        const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${saved}</p>`), 1, { 'u-ATTACH12': labels });
+        expect(simplified).toContain('<citation id="u-ATTACH12" loc="page5" ref="c_ATTACH12_0"/>');
+
+        const edited = expandToRawHtml(
+            simplified.replace('loc="page5"', 'loc="page6"'), metadata, 'new', undefined, { 42: labels },
+        );
+        expect(edited).toContain('<a href="zotero://open/library/items/ATTACH12?page=6"'
+            + ' rel="noopener noreferrer nofollow">Report.pdf</a>, p. 4)');
+    });
+
     it.each(['id', 'att_id'])('rejects excluded attachment %s before looking up its metadata', (attribute) => {
         vi.mocked(checkLibraryExcluded).mockReturnValueOnce({ message: 'Library excluded' });
         expect(() => expandToRawHtml(`<citation ${attribute}="1-ATTACH12" loc="page6"/>`,

--- a/tests/unit/notes/noteHtmlSimplifier.test.ts
+++ b/tests/unit/notes/noteHtmlSimplifier.test.ts
@@ -60,8 +60,11 @@ import {
 import {
     expandToRawHtml,
     translatePageNumberToLabel,
+    preloadPageLabelsForNewCitations,
+    preloadStructuralLocatorPages,
     buildUnresolvedLocatorWarning,
 } from '../../../src/utils/noteCitationExpand';
+import { checkLibraryExcluded } from '../../../src/services/agentDataProvider/utils';
 import { translatePageLabelToNumber } from '../../../src/utils/pageLabelTranslation';
 import {
     isNoteInEditor,
@@ -746,7 +749,7 @@ describe('expandToRawHtml', () => {
         );
     });
 
-    it('creates note and annotation citation links from item_id in new context', () => {
+    it.each(['id', 'att_id'])('creates note and annotation citation links from %s in new context', (attrName) => {
         const metadata: SimplificationMetadata = { elements: new Map() };
         const note = {
             key: 'NOTE1234',
@@ -779,18 +782,84 @@ describe('expandToRawHtml', () => {
         (globalThis as any).Zotero.Libraries.get = vi.fn(() => ({ isGroup: false }));
 
         const result = expandToRawHtml(
-            '<citation id="1-NOTE1234"/> <citation id="1-ANNOT123"/>',
+            `<citation ${attrName}="1-NOTE1234"/> <citation ${attrName}="1-ANNOT123"/>`,
             metadata,
             'new'
         );
 
         expect(result).toContain(
-            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer">Note: Project note</a>)'
+            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer nofollow">Note: Project note</a>)'
         );
         expect(result).toContain(
-            '(<a href="zotero://open-pdf/library/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer">Annotation in Smith 2019, page 12</a>)'
+            '(<a href="zotero://open-pdf/library/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer nofollow">Annotation in Smith 2019, page 12</a>)'
         );
         expect(createCitationHTML).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['id="u-ATTACH12" loc="page6-8"', ', p. 6-8'],
+        ['att_id="1-ATTACH12" page="6"', ', p. 6'],
+        ['attachment_id="1-ATTACH12" loc="s4"', ''],
+        ['item_id="1-ATTACH12"', ''],
+    ])('stores standalone attachment %s as an editable link', (attrs, suffix) => {
+        const item = {
+            key: 'ATTACH12', libraryID: 1, parentID: false,
+            isAttachment: () => true,
+            getField: () => 'Report & findings.pdf',
+        };
+        vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue(item as any);
+        (Zotero.Libraries as any).get = vi.fn(() => ({ isGroup: false }));
+        const html = expandToRawHtml(`<citation ${attrs}/>`, { elements: new Map() }, 'new');
+        expect(html).toBe(`(<a href="zotero://select/library/items/ATTACH12" rel="noopener noreferrer nofollow">Report &amp; findings.pdf</a>${suffix})`);
+        expect(createCitationHTML).not.toHaveBeenCalled();
+        const { simplified, metadata } = simplifyNoteHtml(wrap(`<p>${html}</p>`), 1);
+        expect(simplified).toContain(`<citation id="u-ATTACH12" ref="c_ATTACH12_0"/>${suffix}`);
+        const saved = expandToRawHtml(simplified, metadata, 'new');
+        expect(saved).toContain(`Report &amp; findings.pdf</a>${suffix}`);
+        expect(expandToRawHtml(simplified, metadata, 'old')).toBe(saved);
+    });
+
+    it.each(['id', 'att_id'])('rejects excluded attachment %s before looking up its metadata', (attribute) => {
+        vi.mocked(checkLibraryExcluded).mockReturnValueOnce({ message: 'Library excluded' });
+        expect(() => expandToRawHtml(`<citation ${attribute}="1-ATTACH12" loc="page6"/>`,
+            { elements: new Map() }, 'new')).toThrow('Library excluded');
+        expect(Zotero.Items.getByLibraryAndKey).not.toHaveBeenCalled();
+    });
+
+    it.each([true, false])('resolves standalone spans across three pages (labels: %s) for both ID spellings', async (withLabels) => {
+        const previousBeaver = Zotero.Beaver;
+        vi.mocked(Zotero.Items.getByLibraryAndKey).mockReturnValue({
+            id: 42, key: 'ATTACH12', libraryID: 1, parentID: false,
+            isAttachment: () => true, getField: () => 'Report.pdf',
+            getFilePathAsync: async () => '/report.pdf',
+        } as any);
+        (Zotero.Libraries as any).get = vi.fn(() => ({ isGroup: false }));
+        (Zotero as any).Beaver = { documentCache: {
+            getMetadata: async () => ({ pageLabels: { 1: 'iv', 2: 'v' } }),
+            getResult: async () => ({ mode: 'structured', document: { citationIndex: {
+                s1: { pageIndex: 1, ...(withLabels ? { pageLabel: 'iv' } : {}) },
+                s2: { pageIndex: 1, pageLabel: 'iv' },
+                s3: { pageIndex: 2, pageLabel: 'v' },
+                s4: { pageIndex: 2, pageLabel: 'v' },
+                s5: { pageIndex: 3, ...(withLabels ? { pageLabel: 'vi' } : {}) },
+            } } }),
+        } };
+        try {
+            for (const attribute of ['id', 'att_id']) {
+                const input = `<citation ${attribute}="1-ATTACH12" loc="s1-s5"/>`;
+                const resolved = await preloadStructuralLocatorPages(input);
+                expect(resolved.unresolved).toEqual([]);
+                const html = expandToRawHtml(input, { elements: new Map() }, 'new', undefined, undefined, resolved.pages);
+                expect(html).toContain(`Report.pdf</a>, p. ${withLabels ? 'iv-vi' : '2-4'})`);
+                expect(html).not.toContain('sentence');
+            }
+            const input = '<citation id="1-ATTACH12" loc="page2-3"/>';
+            const labels = await preloadPageLabelsForNewCitations(input);
+            expect(expandToRawHtml(input, { elements: new Map() }, 'new', undefined, labels))
+                .toContain('Report.pdf</a>, p. iv-v)');
+        } finally {
+            (Zotero as any).Beaver = previousBeaver;
+        }
     });
 
     it('throws for new citation with item_id in old context', () => {
@@ -933,7 +1002,7 @@ describe('expandToRawHtml', () => {
             },
         };
         const result = expandToRawHtml(input, metadata, 'new', externalRefContext);
-        // Auto-resolve goes through buildCitationFromSimplifiedAttrs → real Zotero citation
+        // Auto-resolve goes through buildCitation → real Zotero citation
         expect(createCitationHTML).toHaveBeenCalled();
         expect(result).toContain('data-citation=');
         // Confirm Items.getByLibraryAndKey was called with the mapped key

--- a/tests/unit/utils/citationRenderContext.test.ts
+++ b/tests/unit/utils/citationRenderContext.test.ts
@@ -132,6 +132,20 @@ describe('citation render context', () => {
         });
     });
 
+    it('resolves a cited standalone attachment file so link rendering knows it is reachable', async () => {
+        // Note creation renders citations synchronously; a standalone
+        // attachment link only opens the file when this preload has confirmed
+        // the file is here.
+        attachment.parentID = false;
+        attachment.isAttachment = () => true;
+        attachment.getFilePathAsync = vi.fn().mockResolvedValue('/storage/ATTACH01/file.pdf');
+        (Zotero as any).Items.loadDataTypes = vi.fn().mockResolvedValue(undefined);
+
+        await prepareCitationRenderContext('Claim <citation id="1-ATTACH01" loc="page6"/>', {});
+
+        expect(attachment.getFilePathAsync).toHaveBeenCalled();
+    });
+
     it('merges local citation metadata with explicit render context', async () => {
         const existing = { citation_id: 'c1', run_id: 'r1', locations: [] } as any;
         mockPreloadPageLabelsForContent.mockResolvedValue({ 42: { 2: '7' } });

--- a/tests/unit/utils/editNoteValidation.test.ts
+++ b/tests/unit/utils/editNoteValidation.test.ts
@@ -286,7 +286,7 @@ describe('enrichOldStringCitationRefs (att_id)', () => {
     });
 
     it('translates 1-based page number to the attachment\'s display label', () => {
-        // Repro of the reviewer's concern: when buildCitationFromAttId ran at
+        // Repro of the reviewer's concern: when buildCitation ran at
         // insert time, it converted `page="3"` → the attachment's label
         // "iii" (roman frontmatter). Stored metadata carries the label; the
         // model's follow-up old_string still uses the raw number. Without

--- a/tests/unit/utils/noteCitationExpand.preload.test.ts
+++ b/tests/unit/utils/noteCitationExpand.preload.test.ts
@@ -6,9 +6,10 @@ vi.mock('../../../src/utils/zoteroUtils', () => ({
 
 vi.mock('../../../src/services/agentDataProvider/utils', () => ({
     getAttachmentFileStatus: vi.fn().mockResolvedValue(undefined),
+    checkLibraryExcluded: vi.fn(() => null),
 }));
 
-import { getAttachmentFileStatus } from '../../../src/services/agentDataProvider/utils';
+import { checkLibraryExcluded, getAttachmentFileStatus } from '../../../src/services/agentDataProvider/utils';
 import { preloadNotePageLabels } from '../../../src/utils/noteCitationExpand';
 
 const mockGetAttachmentFileStatus = vi.mocked(getAttachmentFileStatus);
@@ -64,11 +65,58 @@ describe('preloadNotePageLabels', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         (globalThis as any).Zotero.Beaver = undefined;
+        // Left unresolvable so item ids keep their legacy numeric form; the
+        // link-citation tests opt in through `makeLinkCitation`.
+        delete (globalThis as any).Zotero.Libraries.userLibraryID;
         (globalThis as any).Zotero.Items = {
             getByLibraryAndKey: vi.fn(),
             getAsync: vi.fn(),
             loadDataTypes: vi.fn().mockResolvedValue(undefined),
         };
+    });
+
+    /**
+     * A saved standalone-attachment citation. Its library comes from the
+     * `zotero://` scope, so the user library has to be resolvable.
+     */
+    function makeLinkCitation(key: string, suffix = ', p. 3'): string {
+        (globalThis as any).Zotero.Libraries.userLibraryID = 1;
+        return `<p>Source (<a href="zotero://open/library/items/${key}?page=5"`
+            + ` rel="noopener noreferrer nofollow">Report.pdf</a>${suffix})</p>`;
+    }
+
+    it('seeds labels from a standalone attachment link, which carries no data-citation', async () => {
+        const attachment = makeAttachment(42, 'ABCD1234');
+        const cache = { getMetadata: vi.fn().mockResolvedValue({ pageLabels: { 4: '3' } }) };
+        (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => attachment);
+        (globalThis as any).Zotero.Beaver = { documentCache: cache };
+
+        const labels = await preloadNotePageLabels(makeLinkCitation('ABCD1234'), 1);
+
+        expect(labels).toEqual({ 'u-ABCD1234': { 4: '3' } });
+    });
+
+    it.each([
+        ['a link with no locator', ''],
+        ['a locator that is not a page', ', section 2'],
+    ])('skips %s', async (_label, suffix) => {
+        const cache = { getMetadata: vi.fn() };
+        (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => makeAttachment(42, 'ABCD1234'));
+        (globalThis as any).Zotero.Beaver = { documentCache: cache };
+
+        expect(await preloadNotePageLabels(makeLinkCitation('ABCD1234', suffix), 1)).toEqual({});
+        expect(cache.getMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not read an excluded library\'s cached extraction', async () => {
+        vi.mocked(checkLibraryExcluded).mockReturnValue({ message: 'Library excluded' } as any);
+        const cache = { getMetadata: vi.fn() };
+        (globalThis as any).Zotero.Items.getByLibraryAndKey = vi.fn(() => makeAttachment(42, 'ABCD1234'));
+        (globalThis as any).Zotero.Beaver = { documentCache: cache };
+
+        expect(await preloadNotePageLabels(makeLinkCitation('ABCD1234'), 1)).toEqual({});
+        expect(cache.getMetadata).not.toHaveBeenCalled();
+        vi.mocked(checkLibraryExcluded).mockReturnValue(null);
     });
 
     it('returns cached labels without extracting on a cache hit', async () => {

--- a/tests/unit/utils/noteEditorDiffPreview.test.ts
+++ b/tests/unit/utils/noteEditorDiffPreview.test.ts
@@ -326,7 +326,7 @@ describe('showDiffPreview approveAll revision-guard flow', () => {
         let titleLoaded = false;
         const attachment = {
             libraryID: 1, key: 'ATTACH12', parentID: false,
-            isAttachment: () => true,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
             attachmentFilename: 'fallback.pdf',
             getField: vi.fn(() => {
                 if (!titleLoaded) throw new Error('Item data not loaded');
@@ -347,7 +347,7 @@ describe('showDiffPreview approveAll revision-guard flow', () => {
             expect(shown, JSON.stringify(vi.mocked(logger).mock.calls)).toBe(true);
             expect(Zotero.Items.loadDataTypes).toHaveBeenCalledWith([attachment], ['itemData']);
             const html = h.applyIncrementalUpdate.mock.calls[0][0].html;
-            expect(html).toContain('zotero://select/library/items/ATTACH12');
+            expect(html).toContain('zotero://open/library/items/ATTACH12?page=6');
             expect(html).toContain('Full report title');
             expect(html).toContain(', p. 6');
             expect(html).not.toContain('fallback.pdf');

--- a/tests/unit/utils/noteEditorDiffPreview.test.ts
+++ b/tests/unit/utils/noteEditorDiffPreview.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../../src/utils/noteCitationExpand', async () => {
     return {
         ...actual,
         preloadNotePageLabels: vi.fn(async () => ({})),
+        preloadStructuralLocatorPages: vi.fn(async () => ({ pages: {}, unresolved: [] })),
         preloadPageLabelsForNewCitations: vi.fn(async () => ({})),
     };
 });
@@ -66,6 +67,8 @@ import {
     isDiffPreviewPending,
 } from '../../../react/utils/noteEditorDiffPreview';
 import { logger } from '@beaver/agent-core/platform/logger';
+import { store } from '../../../react/store';
+import { searchableLibraryIdsAtom } from '../../../react/atoms/profile';
 import { preloadNotePageLabels } from '../../../src/utils/noteCitationExpand';
 
 describe('constructMultiDiffHtml', () => {
@@ -312,6 +315,45 @@ describe('showDiffPreview approveAll revision-guard flow', () => {
             await p;
         } finally {
             vi.useRealTimers();
+        }
+    });
+
+    it('preloads a standalone attachment title before rendering the proposed edit', async () => {
+        vi.useFakeTimers();
+        const h = makeHarness(NOTE);
+        const previousLibraries = Zotero.Libraries;
+        vi.mocked(store.get).mockImplementation((atom: any) => atom === searchableLibraryIdsAtom ? [1] : null);
+        let titleLoaded = false;
+        const attachment = {
+            libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true,
+            attachmentFilename: 'fallback.pdf',
+            getField: vi.fn(() => {
+                if (!titleLoaded) throw new Error('Item data not loaded');
+                return 'Full report title';
+            }),
+        };
+        (Zotero as any).Libraries = { userLibraryID: 1, get: () => ({ isGroup: false }) };
+        (Zotero.Items as any).getByLibraryAndKey = vi.fn(() => attachment);
+        (Zotero.Items as any).loadDataTypes = vi.fn(async () => {
+            await Promise.resolve();
+            titleLoaded = true;
+        });
+        try {
+            const shown = await showDiffPreview(1, 'NOTE0001', [{
+                operation: 'append', oldString: '',
+                newString: '<p><citation id="u-ATTACH12" loc="page6"/></p>',
+            }]);
+            expect(shown, JSON.stringify(vi.mocked(logger).mock.calls)).toBe(true);
+            expect(Zotero.Items.loadDataTypes).toHaveBeenCalledWith([attachment], ['itemData']);
+            const html = h.applyIncrementalUpdate.mock.calls[0][0].html;
+            expect(html).toContain('zotero://select/library/items/ATTACH12');
+            expect(html).toContain('Full report title');
+            expect(html).toContain(', p. 6');
+            expect(html).not.toContain('fallback.pdf');
+        } finally {
+            (Zotero as any).Libraries = previousLibraries;
+            vi.mocked(store.get).mockImplementation(() => null);
         }
     });
 

--- a/tests/unit/utils/zoteroLinkCitation.test.ts
+++ b/tests/unit/utils/zoteroLinkCitation.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     buildZoteroCitationLinkHTML,
+    isLinkCitationItem,
+    preloadStandaloneAttachmentTitles,
     buildZoteroCitationLinkLabel,
     buildZoteroCitationLinkURI,
     parseZoteroCitationLinkHref,
@@ -36,7 +38,7 @@ describe('zoteroLinkCitation', () => {
         expect(buildZoteroCitationLinkURI(note)).toBe('zotero://select/library/items/NOTE1234');
         expect(buildZoteroCitationLinkLabel(note)).toBe('Note: Project note');
         expect(buildZoteroCitationLinkHTML(note)).toBe(
-            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer">Note: Project note</a>)'
+            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer nofollow">Note: Project note</a>)'
         );
     });
 
@@ -67,7 +69,7 @@ describe('zoteroLinkCitation', () => {
 
         expect(buildZoteroCitationLinkLabel(note)).toBe('Note: Note');
         expect(buildZoteroCitationLinkHTML(note)).toBe(
-            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer">Note: Note</a>)'
+            '(<a href="zotero://select/library/items/NOTE1234" rel="noopener noreferrer nofollow">Note: Note</a>)'
         );
     });
 
@@ -94,7 +96,7 @@ describe('zoteroLinkCitation', () => {
         );
         expect(buildZoteroCitationLinkLabel(annotation)).toBe('Annotation in Smith 2019, page 12');
         expect(buildZoteroCitationLinkHTML(annotation)).toBe(
-            '(<a href="zotero://open-pdf/groups/42/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer">Annotation in Smith 2019, page 12</a>)'
+            '(<a href="zotero://open-pdf/groups/42/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer nofollow">Annotation in Smith 2019, page 12</a>)'
         );
     });
 
@@ -139,7 +141,7 @@ describe('zoteroLinkCitation', () => {
 
         expect(buildZoteroCitationLinkLabel(annotation)).toBe('Annotation in Smith 2019');
         expect(buildZoteroCitationLinkHTML(annotation)).toBe(
-            '(<a href="zotero://open-pdf/library/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer">Annotation in Smith 2019</a>)'
+            '(<a href="zotero://open-pdf/library/items/ATTACH12?annotation=ANNOT123" rel="noopener noreferrer nofollow">Annotation in Smith 2019</a>)'
         );
     });
 
@@ -156,6 +158,55 @@ describe('zoteroLinkCitation', () => {
             libraryId: 1,
             itemKey: 'ANNOT123',
         });
+    });
+
+    it.each([1, 7])('links standalone attachments in library %s without accessing their files', (libraryID) => {
+        const item = { libraryID, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, getField: () => 'Report <draft>',
+            getFilePathAsync: vi.fn(() => { throw new Error('Missing file'); }),
+        };
+        expect(isLinkCitationItem(item)).toBe(true);
+        const uri = buildZoteroCitationLinkURI(item)!;
+        expect(uri).toBe(`zotero://select/${libraryID === 7 ? 'groups/42' : 'library'}/items/ATTACH12`);
+        expect(parseZoteroCitationLinkHref(uri)).toEqual({ libraryId: libraryID, itemKey: 'ATTACH12' });
+        expect(buildZoteroCitationLinkHTML(item, { kind: 'page', value: '6-8', raw: 'page6-8' }))
+            .toContain('Report &lt;draft&gt;</a>, p. 6-8)');
+        expect(item.getFilePathAsync).not.toHaveBeenCalled();
+        expect(isLinkCitationItem({ ...item, parentID: 42 })).toBe(false);
+    });
+
+    it('uses a filename when attachment title data is unavailable', () => {
+        expect(buildZoteroCitationLinkLabel({ isAttachment: () => true, parentID: false,
+            getField: () => { throw new Error('Not loaded'); }, attachmentFilename: 'Report.pdf',
+        })).toBe('Report.pdf');
+    });
+
+    it('batch loads unique standalone attachments while skipping excluded and child items', async () => {
+        const item = { isAttachment: () => true, parentID: false };
+        const second = { ...item };
+        const child = { ...item, parentID: 42 };
+        (Zotero as any).Items = {
+            getByLibraryAndKey: vi.fn((_libraryID, key) =>
+                key === 'ATTACH12' ? item : key === 'ATTACH34' ? second : child),
+            loadDataTypes: vi.fn().mockResolvedValue(undefined),
+        };
+        await preloadStandaloneAttachmentTitles(
+            '<citation id="u-ATTACH12"/><citation att_id="1-ATTACH12"/>'
+                + '<citation id="u-ATTACH34"/><citation id="u-CHILDPDF"/><citation id="g42-BLOCKED1"/>',
+            libraryID => libraryID === 1,
+        );
+        expect(Zotero.Items.getByLibraryAndKey).toHaveBeenCalledTimes(3);
+        expect(Zotero.Items.loadDataTypes).toHaveBeenCalledExactlyOnceWith([item, second], ['itemData']);
+    });
+
+    it('keeps filename fallback available when batch title loading fails', async () => {
+        const item = { isAttachment: () => true, parentID: false, attachmentFilename: 'Report.pdf' };
+        (Zotero as any).Items = {
+            getByLibraryAndKey: vi.fn(() => item),
+            loadDataTypes: vi.fn().mockRejectedValue(new Error('Unavailable')),
+        };
+        await expect(preloadStandaloneAttachmentTitles('<citation id="u-ATTACH12"/>')).resolves.toBeUndefined();
+        expect(buildZoteroCitationLinkLabel(item)).toBe('Report.pdf');
     });
 
     it('rejects Beaver and unrelated Zotero links', () => {

--- a/tests/unit/utils/zoteroLinkCitation.test.ts
+++ b/tests/unit/utils/zoteroLinkCitation.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     buildZoteroCitationLinkHTML,
     isLinkCitationItem,
-    preloadStandaloneAttachmentTitles,
+    preloadStandaloneAttachmentLinks,
     buildZoteroCitationLinkLabel,
     buildZoteroCitationLinkURI,
     parseZoteroCitationLinkHref,
@@ -158,21 +158,81 @@ describe('zoteroLinkCitation', () => {
             libraryId: 1,
             itemKey: 'ANNOT123',
         });
+        // Without an annotation the link names the attachment itself.
+        expect(parseZoteroCitationLinkHref('zotero://open/groups/42/items/ATTACH12?page=6')).toEqual({
+            libraryId: 7,
+            itemKey: 'ATTACH12',
+        });
+        expect(parseZoteroCitationLinkHref('zotero://open-pdf/library/items/ATTACH12')).toEqual({
+            libraryId: 1,
+            itemKey: 'ATTACH12',
+        });
     });
 
-    it.each([1, 7])('links standalone attachments in library %s without accessing their files', (libraryID) => {
+    it.each([1, 7])('opens standalone PDFs in library %s at the cited page, without accessing their files', (libraryID) => {
         const item = { libraryID, key: 'ATTACH12', parentID: false,
-            isAttachment: () => true, getField: () => 'Report <draft>',
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report <draft>',
             getFilePathAsync: vi.fn(() => { throw new Error('Missing file'); }),
         };
+        const scope = libraryID === 7 ? 'groups/42' : 'library';
         expect(isLinkCitationItem(item)).toBe(true);
-        const uri = buildZoteroCitationLinkURI(item)!;
-        expect(uri).toBe(`zotero://select/${libraryID === 7 ? 'groups/42' : 'library'}/items/ATTACH12`);
+        const uri = buildZoteroCitationLinkURI(item, 6)!;
+        expect(uri).toBe(`zotero://open/${scope}/items/ATTACH12?page=6`);
         expect(parseZoteroCitationLinkHref(uri)).toEqual({ libraryId: libraryID, itemKey: 'ATTACH12' });
-        expect(buildZoteroCitationLinkHTML(item, { kind: 'page', value: '6-8', raw: 'page6-8' }))
-            .toContain('Report &lt;draft&gt;</a>, p. 6-8)');
+        expect(buildZoteroCitationLinkHTML(item, { kind: 'page', value: '6-8', raw: 'page6-8' }, 6))
+            .toBe(`(<a href="zotero://open/${scope}/items/ATTACH12?page=6" rel="noopener noreferrer nofollow">`
+                + 'Report &lt;draft&gt;</a>, p. 6-8)');
         expect(item.getFilePathAsync).not.toHaveBeenCalled();
         expect(isLinkCitationItem({ ...item, parentID: 42 })).toBe(false);
+    });
+
+    it('opens a standalone PDF without a page when none was cited', () => {
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            getField: () => 'Report.pdf',
+        };
+        expect(buildZoteroCitationLinkURI(item)).toBe('zotero://open/library/items/ATTACH12');
+    });
+
+    it('omits the page for a non-PDF file attachment, whose reader pages it differently', () => {
+        // Zotero reads `?page=` as a physical page index; the EPUB view resolves
+        // it through its own page mapping, where a cited PDF-style page is wrong.
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => false,
+            getField: () => 'Book.epub',
+        };
+        expect(buildZoteroCitationLinkURI(item, 6)).toBe('zotero://open/library/items/ATTACH12');
+    });
+
+    it('selects a PDF whose file this computer does not have', () => {
+        // A synced file that was never downloaded: Zotero's open handler cannot
+        // resolve a path and returns without doing anything.
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            fileExistsCached: () => false,
+            getField: () => 'Report.pdf',
+        };
+        expect(buildZoteroCitationLinkURI(item, 6)).toBe('zotero://select/library/items/ATTACH12');
+    });
+
+    it('opens a PDF whose file has been checked and is present', () => {
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            fileExistsCached: () => true,
+            getField: () => 'Report.pdf',
+        };
+        expect(buildZoteroCitationLinkURI(item, 6)).toBe('zotero://open/library/items/ATTACH12?page=6');
+    });
+
+    it('selects an attachment with no file, which zotero://open cannot open', () => {
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => false, isPDFAttachment: () => false,
+            getField: () => 'Linked page',
+        };
+        const uri = buildZoteroCitationLinkURI(item, 6)!;
+        expect(uri).toBe('zotero://select/library/items/ATTACH12');
+        expect(parseZoteroCitationLinkHref(uri)).toEqual({ libraryId: 1, itemKey: 'ATTACH12' });
     });
 
     it('uses a filename when attachment title data is unavailable', () => {
@@ -182,21 +242,39 @@ describe('zoteroLinkCitation', () => {
     });
 
     it('batch loads unique standalone attachments while skipping excluded and child items', async () => {
-        const item = { isAttachment: () => true, parentID: false };
-        const second = { ...item };
-        const child = { ...item, parentID: 42 };
+        const item = { isAttachment: () => true, parentID: false, getFilePathAsync: vi.fn().mockResolvedValue('/a.pdf') };
+        const second = { ...item, getFilePathAsync: vi.fn().mockResolvedValue('/b.pdf') };
+        const child = { ...item, parentID: 42, getFilePathAsync: vi.fn().mockResolvedValue('/c.pdf') };
         (Zotero as any).Items = {
             getByLibraryAndKey: vi.fn((_libraryID, key) =>
                 key === 'ATTACH12' ? item : key === 'ATTACH34' ? second : child),
             loadDataTypes: vi.fn().mockResolvedValue(undefined),
         };
-        await preloadStandaloneAttachmentTitles(
+        await preloadStandaloneAttachmentLinks(
             '<citation id="u-ATTACH12"/><citation att_id="1-ATTACH12"/>'
                 + '<citation id="u-ATTACH34"/><citation id="u-CHILDPDF"/><citation id="g42-BLOCKED1"/>',
             libraryID => libraryID === 1,
         );
         expect(Zotero.Items.getByLibraryAndKey).toHaveBeenCalledTimes(3);
         expect(Zotero.Items.loadDataTypes).toHaveBeenCalledExactlyOnceWith([item, second], ['itemData']);
+        // Resolving each path is what populates the file state the link builder reads.
+        expect(item.getFilePathAsync).toHaveBeenCalledOnce();
+        expect(second.getFilePathAsync).toHaveBeenCalledOnce();
+        expect(child.getFilePathAsync).not.toHaveBeenCalled();
+    });
+
+    it('renders a link for an attachment whose file could not be checked', async () => {
+        const item = { libraryID: 1, key: 'ATTACH12', parentID: false,
+            isAttachment: () => true, isFileAttachment: () => true, isPDFAttachment: () => true,
+            fileExistsCached: () => null, getField: () => 'Report.pdf',
+            getFilePathAsync: vi.fn().mockRejectedValue(new Error('Volume unavailable')),
+        };
+        (Zotero as any).Items = {
+            getByLibraryAndKey: vi.fn(() => item),
+            loadDataTypes: vi.fn().mockResolvedValue(undefined),
+        };
+        await expect(preloadStandaloneAttachmentLinks('<citation id="u-ATTACH12"/>')).resolves.toBeUndefined();
+        expect(buildZoteroCitationLinkURI(item, 6)).toBe('zotero://open/library/items/ATTACH12?page=6');
     });
 
     it('keeps filename fallback available when batch title loading fails', async () => {
@@ -205,7 +283,7 @@ describe('zoteroLinkCitation', () => {
             getByLibraryAndKey: vi.fn(() => item),
             loadDataTypes: vi.fn().mockRejectedValue(new Error('Unavailable')),
         };
-        await expect(preloadStandaloneAttachmentTitles('<citation id="u-ATTACH12"/>')).resolves.toBeUndefined();
+        await expect(preloadStandaloneAttachmentLinks('<citation id="u-ATTACH12"/>')).resolves.toBeUndefined();
         expect(buildZoteroCitationLinkLabel(item)).toBe('Report.pdf');
     });
 


### PR DESCRIPTION
## Summary
- Open standalone attachment citations at their referenced page.
- Preserve external citation page ranges and page-label handling.
- Add coverage for standalone-note citation links and citation export behavior.

## Testing
- Not run.