### PR TITLE
feat(run-status-popup): expand minimal view for batch workflows

### DIFF
--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -346,8 +346,11 @@
 
 /* A shared card — the question card, the batch approval card — drawn inside
  * the popup: the popup is the frame, so the card gives up its own. The
- * padding is forced because the batch approval card sets its own inline. */
-.beaver-run-status-popup__embedded {
+ * padding is forced because the batch approval card sets its own inline.
+ * A card whose every click is its own (the question's options fill it) does
+ * not show the frame's pointer; one with plain copy between its controls
+ * keeps it, since that copy still opens Beaver. */
+.beaver-run-status-popup__embedded--own-clicks {
     cursor: default;
 }
 

--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -246,6 +246,13 @@
     flex-direction: column;
     padding: 10px 12px 10px 12px;
     gap: 8px;
+    /* Bound to the floating host's own limit, less the room the frame takes,
+     * and scrolled inside: the card is sized to this element's height, so a
+     * request longer than the window — the batch approval card with both
+     * warnings — reaches its controls instead of being cut at the frame. */
+    box-sizing: border-box;
+    max-height: calc(80vh - 24px);
+    overflow-y: auto;
 }
 
 .beaver-run-status-popup__header {
@@ -337,18 +344,38 @@
     overflow: hidden;
 }
 
-/* The shared question card, drawn inside the popup: the popup is the frame,
- * so the card gives up its own. */
-.beaver-run-status-popup__question {
+/* A shared card — the question card, the batch approval card — drawn inside
+ * the popup: the popup is the frame, so the card gives up its own. The
+ * padding is forced because the batch approval card sets its own inline. */
+.beaver-run-status-popup__embedded {
     cursor: default;
 }
 
-.beaver-run-status-popup__question > .user-message-display {
+.beaver-run-status-popup__embedded > .user-message-display {
     margin: 0;
-    padding: 0;
+    padding: 0 !important;
     border: 0;
     background: transparent;
     box-shadow: none;
+}
+
+/* Live batch progress under the header: the composer's bar, framed like the
+ * completed card's rows instead of docked to a composer edge. The panel
+ * renders nothing without a batch in flight, and the empty wrapper hides
+ * with it so the column's gap is not paid for a slot with nothing in it. */
+.beaver-run-status-popup__batch-progress {
+    cursor: default;
+}
+
+.beaver-run-status-popup__batch-progress:empty {
+    display: none;
+}
+
+.beaver-run-status-popup .beaver-run-status-popup__batch-progress .batch-progress-bar {
+    margin: 0;
+    border: 1px solid var(--beaver-border-subtle);
+    border-radius: 8px;
+    background: var(--beaver-fill-subtle);
 }
 
 .beaver-run-status-popup__footer {

--- a/packages/agent-ui/src/chat/BatchApprovalCard.tsx
+++ b/packages/agent-ui/src/chat/BatchApprovalCard.tsx
@@ -63,6 +63,12 @@ export interface BatchApprovalCardProps {
     approval: PendingBatchApproval;
     /** The user's decision, ready for the wire. */
     onSubmit: (response: BatchApprovalDecision) => void;
+    /**
+     * A control of the host's own at the end of the title row — a popup's
+     * close button. The card is the whole of that surface, so the row that
+     * names the batch is where such a control belongs.
+     */
+    titleTrailing?: React.ReactNode;
 }
 
 /**
@@ -105,6 +111,7 @@ export interface BatchApprovalCardProps {
 export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
     approval,
     onSubmit,
+    titleTrailing,
 }) => {
     const [draft, setDraft] = useState<BatchApprovalDraft>(
         () => initialDraft(approval.defaultMode, approval.userInstructionsPrefill),
@@ -181,9 +188,9 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
                         >
                             {approval.title}
                         </div>
+                        {(approval.creditChip || titleTrailing) && <div className="flex-1" />}
                         {approval.creditChip && (
                             <>
-                                <div className="flex-1" />
                                 {/* flex-none wrapper so the popup is not a
                                     sibling of this wrapping min-w-0 row — an
                                     in-flow tooltip is measured as a flex item,
@@ -213,6 +220,7 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
                                 </div>
                             </>
                         )}
+                        {titleTrailing && <div className="flex-none">{titleTrailing}</div>}
                     </div>
                     <div className="font-color-secondary min-w-0">
                         <span className="font-color-primary font-medium">

--- a/packages/agent-ui/src/chat/BatchApprovalCard.tsx
+++ b/packages/agent-ui/src/chat/BatchApprovalCard.tsx
@@ -63,12 +63,6 @@ export interface BatchApprovalCardProps {
     approval: PendingBatchApproval;
     /** The user's decision, ready for the wire. */
     onSubmit: (response: BatchApprovalDecision) => void;
-    /**
-     * A control of the host's own at the end of the title row — a popup's
-     * close button. The card is the whole of that surface, so the row that
-     * names the batch is where such a control belongs.
-     */
-    titleTrailing?: React.ReactNode;
 }
 
 /**
@@ -111,7 +105,6 @@ export interface BatchApprovalCardProps {
 export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
     approval,
     onSubmit,
-    titleTrailing,
 }) => {
     const [draft, setDraft] = useState<BatchApprovalDraft>(
         () => initialDraft(approval.defaultMode, approval.userInstructionsPrefill),
@@ -188,9 +181,9 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
                         >
                             {approval.title}
                         </div>
-                        {(approval.creditChip || titleTrailing) && <div className="flex-1" />}
                         {approval.creditChip && (
                             <>
+                                <div className="flex-1" />
                                 {/* flex-none wrapper so the popup is not a
                                     sibling of this wrapping min-w-0 row — an
                                     in-flow tooltip is measured as a flex item,
@@ -220,7 +213,6 @@ export const BatchApprovalCard: React.FC<BatchApprovalCardProps> = ({
                                 </div>
                             </>
                         )}
-                        {titleTrailing && <div className="flex-none">{titleTrailing}</div>}
                     </div>
                     <div className="font-color-secondary min-w-0">
                         <span className="font-color-primary font-medium">

--- a/packages/agent-ui/src/chat/BatchProgressBar.tsx
+++ b/packages/agent-ui/src/chat/BatchProgressBar.tsx
@@ -108,7 +108,9 @@ export const BatchProgressBar: React.FC<BatchProgressBarProps> = ({
             role="group"
             aria-label="Batch job progress"
         >
-            {/* Overlay so it does not stack on the composer's 1px top border. */}
+            {/* Overlay so it does not stack on the composer's 1px top border.
+                Hidden while expanded: the body draws the full track then, and
+                the hairline would only repeat it along the top edge. */}
             <div
                 className="display-flex flex-row batch-progress-hairline"
                 style={{
@@ -117,7 +119,7 @@ export const BatchProgressBar: React.FC<BatchProgressBarProps> = ({
                     left: 0,
                     right: 0,
                     height: 2,
-                    opacity: isOver ? 0 : 1,
+                    opacity: isOver || expanded ? 0 : 1,
                     overflow: 'hidden',
                     pointerEvents: 'none',
                     transition: 'opacity 0.7s ease',

--- a/packages/agent-ui/src/chat/BatchProgressBar.tsx
+++ b/packages/agent-ui/src/chat/BatchProgressBar.tsx
@@ -50,7 +50,8 @@ export interface BatchProgressBarProps {
  * goal, counts, and (when the operation has one) the outcome distribution.
  * Expansion is owned by the caller.
  *
- * Read-only — stopping is the composer's Stop button. Silent about review
+ * Stopping is the composer's Stop button, not the bar's. Rows that name a
+ * collection or tag go there on click, as the receipt's do. Silent about review
  * status: the ledger counts an item resolved once the agent has proposed the
  * edit, so "184 of 184" can sit next to 184 unreviewed changes. That belongs
  * on the run's changes card.
@@ -186,7 +187,7 @@ export const BatchProgressBar: React.FC<BatchProgressBarProps> = ({
             </div>
 
             {expanded && (
-                <BatchOutcomeBody batch={batch} maxRows={PANEL_MAX_TALLY_ROWS}>
+                <BatchOutcomeBody batch={batch} maxRows={PANEL_MAX_TALLY_ROWS} revealTargets>
                     {queuedBatches.length > 0 && (
                         <div className="display-flex flex-col gap-1 min-w-0">
                             <BatchBlockHeading>{WAITING_HEADING}</BatchBlockHeading>

--- a/react/atoms/runStatusPopup.ts
+++ b/react/atoms/runStatusPopup.ts
@@ -51,7 +51,23 @@ export type RunStatusPopupPreview =
         declineLabel?: string;
         stackDepth?: number;
     }
-    | { kind: 'batch'; threadName?: string; title?: string; scope?: string; stackDepth?: number }
+    | {
+        kind: 'batch';
+        threadName?: string;
+        /** The backend-composed copy the shared approval card renders verbatim. */
+        title?: string;
+        scopePrimary?: string;
+        scopeSecondary?: string;
+        message?: string;
+        destructiveWarning?: string;
+        costWarning?: string;
+        creditChip?: string;
+        creditTooltip?: string;
+        userInstructionsPrefill?: string;
+        /** A batch that changes nothing, so the card offers no coverage choice. */
+        readOnly?: boolean;
+        stackDepth?: number;
+    }
     | { kind: 'question'; threadName?: string; title?: string; stackDepth?: number }
     | {
         kind: 'completed';

--- a/react/components/input/BatchApprovalPanel.tsx
+++ b/react/components/input/BatchApprovalPanel.tsx
@@ -10,6 +10,25 @@ interface BatchApprovalPanelProps {
 }
 
 /**
+ * Sends a batch approval decision over the run's connection, correlated on
+ * the approval id. Shared by every surface that draws the card — this panel
+ * and the closed-sidebar status popup — so the wire binding exists once.
+ * A no-op without an id, for a surface whose card may not be up.
+ */
+export function useBatchApprovalSubmit(approvalId: string | null): (decision: BatchApprovalDecision) => void {
+    const sendResponse = useSetAtom(sendBatchApprovalResponseAtom);
+    return useCallback((decision: BatchApprovalDecision) => {
+        if (!approvalId) return;
+        sendResponse({
+            approvalId,
+            approved: decision.approved,
+            mode: decision.mode,
+            userInstructions: decision.user_instructions,
+        });
+    }, [sendResponse, approvalId]);
+}
+
+/**
  * Composer takeover for a pending batch approval.
  *
  * Rendered by Sidebar INSTEAD of InputArea while the run blocks on the user's
@@ -27,16 +46,7 @@ interface BatchApprovalPanelProps {
  * panel only binds send.
  */
 export const BatchApprovalPanel: React.FC<BatchApprovalPanelProps> = ({ approval }) => {
-    const sendResponse = useSetAtom(sendBatchApprovalResponseAtom);
-
-    const handleSubmit = useCallback((decision: BatchApprovalDecision) => {
-        sendResponse({
-            approvalId: approval.approvalId,
-            approved: decision.approved,
-            mode: decision.mode,
-            userInstructions: decision.user_instructions,
-        });
-    }, [sendResponse, approval.approvalId]);
+    const handleSubmit = useBatchApprovalSubmit(approval.approvalId);
 
     return (
         <BatchApprovalCard

--- a/react/components/input/BatchProgressPanel.tsx
+++ b/react/components/input/BatchProgressPanel.tsx
@@ -8,6 +8,16 @@ import { batchProgressAtom } from '../../atoms/agentRunAtoms';
 /** How long a finished batch's bar stays up so the completion tick is visible. */
 const COMPLETION_DWELL_MS = 2500;
 
+interface BatchProgressPanelProps {
+    /**
+     * Expansion owned by the host, for a surface that remounts this panel
+     * while the batch it draws is the same — the status popup swaps its card
+     * as the run moves between working and waiting. Uncontrolled when absent.
+     */
+    expanded?: boolean;
+    onExpandedChange?: (expanded: boolean) => void;
+}
+
 /**
  * Live batch progress above the composer.
  *
@@ -24,14 +34,16 @@ const COMPLETION_DWELL_MS = 2500;
  * the stamp, expanded or not. A collapsed panel still disappears as soon as
  * the stamp does — the receipt has it then.
  */
-const BatchProgressPanel: React.FC = () => {
+const BatchProgressPanel: React.FC<BatchProgressPanelProps> = ({ expanded, onExpandedChange }) => {
     const stamp = useAtomValue(batchProgressAtom);
 
     const { tracked, queued } = useMemo(() => selectBatchPanelGroups(stamp), [stamp]);
     const trackedIsOpen = !!tracked && !hasBatchEnded(tracked);
 
     const [held, setHeld] = useState<BatchProgressEntry | null>(null);
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [ownExpanded, setOwnExpanded] = useState(false);
+    const isExpanded = expanded ?? ownExpanded;
+    const setIsExpanded = onExpandedChange ?? setOwnExpanded;
     // True from the first open stamp we drew until that batch is parked in `held`.
     // The ending render still sees this, so the bar stays mounted (and expanded).
     const drewLiveRef = useRef(false);

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -42,13 +42,14 @@ import {
     DollarCircleIcon,
     HelpCircleIcon,
     Icon,
-    LayersIcon,
     LibraryIcon,
 } from '../icons/icons';
 import Button from '@beaver/agent-ui/primitives/Button';
 import IconButton from '@beaver/agent-ui/primitives/IconButton';
 import RunPermissionButton from '../ui/buttons/RunPermissionButton';
 import AskUserQuestionCard from '@beaver/agent-ui/chat/AskUserQuestionCard';
+import BatchApprovalCard from '@beaver/agent-ui/chat/BatchApprovalCard';
+import BatchProgressPanel from '../input/BatchProgressPanel';
 import { getAgentActionToolIcon } from '../../host/zotero/components/agentActionViewHelpers';
 import RunPulse from './RunPulse';
 import { useRunStatusPopupCard } from './useRunStatusPopupCard';
@@ -115,15 +116,23 @@ const Header: React.FC<{
     </div>
 );
 
-const RunningView: React.FC<{ card: RunningCard }> = ({ card }) => (
-    <Header
-        card={card}
-        leading={<RunPulse />}
-        detail={<StatusLine text={card.statusLine} />}
-    />
+/** Live batch progress, drawn under the header of the cards that keep the run's work visible. */
+interface WithBatchProgress {
+    batchProgress: React.ReactNode;
+}
+
+const RunningView: React.FC<{ card: RunningCard } & WithBatchProgress> = ({ card, batchProgress }) => (
+    <>
+        <Header
+            card={card}
+            leading={<RunPulse />}
+            detail={<StatusLine text={card.statusLine} />}
+        />
+        {batchProgress}
+    </>
 );
 
-const ApprovalView: React.FC<{ card: ApprovalCard }> = ({ card }) => (
+const ApprovalView: React.FC<{ card: ApprovalCard } & WithBatchProgress> = ({ card, batchProgress }) => (
     <>
         <Header
             card={card}
@@ -136,6 +145,7 @@ const ApprovalView: React.FC<{ card: ApprovalCard }> = ({ card }) => (
             detail={<span title={card.label}>{card.label}</span>}
             detailClassName="font-color-primary"
         />
+        {batchProgress}
         <div className="beaver-run-status-popup__footer">
             {card.permission && (
                 <div className="beaver-run-status-popup__permission">
@@ -201,23 +211,31 @@ const CreditView: React.FC<{ card: CreditCard }> = ({ card }) => (
     </>
 );
 
+/**
+ * The batch is approved right here, with the same card the composer shows
+ * for it: the backend's title, scope, goal and warnings, the coverage choice,
+ * and a field for instructions. The card names the batch itself, so it
+ * stands without the popup's header and takes the close button into its
+ * title row. Keyed on the request so a new one starts from a fresh draft.
+ */
 const BatchView: React.FC<{ card: BatchCard }> = ({ card }) => (
-    <>
-        <Header
-            card={card}
-            leading={<Mark icon={LayersIcon} className="font-color-secondary" />}
-            detail={<span title={card.title}>{card.title}</span>}
-            detailClassName="font-color-primary"
+    <div className="beaver-run-status-popup__embedded" data-run-status-popup-interactive>
+        <BatchApprovalCard
+            key={card.approval.approvalId}
+            approval={card.approval}
+            onSubmit={card.onSubmit}
+            titleTrailing={(
+                <div className="beaver-run-status-popup__trailing beaver-run-status-popup__dismiss">
+                    <IconButton
+                        icon={CancelIcon}
+                        variant="ghost-secondary"
+                        onClick={card.onDismiss}
+                        ariaLabel="Close"
+                    />
+                </div>
+            )}
         />
-        {card.scope && <div className="beaver-run-status-popup__body font-color-secondary">{card.scope}</div>}
-        <div className="beaver-run-status-popup__footer">
-            <span className="font-color-tertiary text-sm">Approve in Beaver</span>
-            <div className="flex-1" />
-            <Button variant="solid" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowUpRightIcon} onClick={card.onOpen}>
-                Review
-            </Button>
-        </div>
-    </>
+    </div>
 );
 
 /**
@@ -231,7 +249,7 @@ const QuestionView: React.FC<{ card: QuestionCard }> = ({ card }) => (
             leading={<Mark icon={HelpCircleIcon} className="font-color-secondary" />}
             detail={null}
         />
-        <div className="beaver-run-status-popup__question" data-run-status-popup-interactive>
+        <div className="beaver-run-status-popup__embedded" data-run-status-popup-interactive>
             <AskUserQuestionCard
                 key={card.question.questionId}
                 pendingQuestion={card.question}
@@ -306,10 +324,15 @@ const CompletedView: React.FC<{ card: CompletedCard }> = ({ card }) => {
     );
 };
 
-const CardView: React.FC<{ card: RunStatusPopupCard }> = ({ card }) => {
+/** The cards that draw the run's batch progress: the run is working, or waiting on one of its changes. */
+function showsBatchProgress(card: RunStatusPopupCard): boolean {
+    return card.kind === 'running' || card.kind === 'approval';
+}
+
+const CardView: React.FC<{ card: RunStatusPopupCard } & WithBatchProgress> = ({ card, batchProgress }) => {
     switch (card.kind) {
-        case 'running': return <RunningView card={card} />;
-        case 'approval': return <ApprovalView card={card} />;
+        case 'running': return <RunningView card={card} batchProgress={batchProgress} />;
+        case 'approval': return <ApprovalView card={card} batchProgress={batchProgress} />;
         case 'credit': return <CreditView card={card} />;
         case 'batch': return <BatchView card={card} />;
         case 'question': return <QuestionView card={card} />;
@@ -415,7 +438,26 @@ const RunStatusPopup: React.FC = () => {
     const isSidebarVisible = useAtomValue(isSidebarVisibleAtom);
     const forceVisible = useAtomValue(runStatusPopupForceVisibleAtom);
 
+    // Expansion of the batch progress lives here rather than in the panel:
+    // the card that holds the panel is swapped as the run moves between
+    // working and waiting on a change, and the panel with it. It is kept
+    // for the run it was opened on, so the next run starts collapsed.
+    const [batchExpansion, setBatchExpansion] = useState<{ runId: string; expanded: boolean } | null>(null);
+
     if (!card || (isSidebarVisible && !forceVisible)) return null;
+
+    // The panel draws nothing without a batch in flight, and the wrapper is
+    // hidden with it (see the stylesheet), so a run without a batch does not
+    // pay for the slot.
+    const batchExpanded = batchExpansion?.runId === card.runId && batchExpansion.expanded;
+    const batchProgress = showsBatchProgress(card) ? (
+        <div className="beaver-run-status-popup__batch-progress" data-run-status-popup-interactive>
+            <BatchProgressPanel
+                expanded={batchExpanded}
+                onExpandedChange={(expanded) => setBatchExpansion({ runId: card.runId, expanded })}
+            />
+        </div>
+    ) : null;
 
     // Layers behind the front card stand for the other threads still
     // running. The count is capped by the model; each layer is a sliver.
@@ -432,7 +474,7 @@ const RunStatusPopup: React.FC = () => {
                 />
             ))}
             <AnimatedCard card={card}>
-                <CardView card={card} />
+                <CardView card={card} batchProgress={batchProgress} />
             </AnimatedCard>
         </div>
     );

--- a/react/components/runStatusPopup/RunStatusPopup.tsx
+++ b/react/components/runStatusPopup/RunStatusPopup.tsx
@@ -215,25 +215,20 @@ const CreditView: React.FC<{ card: CreditCard }> = ({ card }) => (
  * The batch is approved right here, with the same card the composer shows
  * for it: the backend's title, scope, goal and warnings, the coverage choice,
  * and a field for instructions. The card names the batch itself, so it
- * stands without the popup's header and takes the close button into its
- * title row. Keyed on the request so a new one starts from a fresh draft.
+ * stands without the popup's header — and without a close button: the run
+ * is blocked on this decision, and Cancel is the way out of it. Keyed on the
+ * request so a new one starts from a fresh draft.
+ *
+ * Its controls are all buttons, links and fields, which the card's click
+ * handler leaves alone on its own, so the copy around them still opens
+ * Beaver like any other card's background.
  */
 const BatchView: React.FC<{ card: BatchCard }> = ({ card }) => (
-    <div className="beaver-run-status-popup__embedded" data-run-status-popup-interactive>
+    <div className="beaver-run-status-popup__embedded">
         <BatchApprovalCard
             key={card.approval.approvalId}
             approval={card.approval}
             onSubmit={card.onSubmit}
-            titleTrailing={(
-                <div className="beaver-run-status-popup__trailing beaver-run-status-popup__dismiss">
-                    <IconButton
-                        icon={CancelIcon}
-                        variant="ghost-secondary"
-                        onClick={card.onDismiss}
-                        ariaLabel="Close"
-                    />
-                </div>
-            )}
         />
     </div>
 );
@@ -249,7 +244,7 @@ const QuestionView: React.FC<{ card: QuestionCard }> = ({ card }) => (
             leading={<Mark icon={HelpCircleIcon} className="font-color-secondary" />}
             detail={null}
         />
-        <div className="beaver-run-status-popup__embedded" data-run-status-popup-interactive>
+        <div className="beaver-run-status-popup__embedded beaver-run-status-popup__embedded--own-clicks" data-run-status-popup-interactive>
             <AskUserQuestionCard
                 key={card.question.questionId}
                 pendingQuestion={card.question}

--- a/react/components/runStatusPopup/runStatusPopupModel.ts
+++ b/react/components/runStatusPopup/runStatusPopupModel.ts
@@ -8,6 +8,8 @@ import type { AgentRun, ToolCallPart } from '@beaver/agent-core/agents/types';
 import { isAutoLoadingToolCall, isThinkingInProgress } from '@beaver/agent-core/agents/messageVisibility';
 import { getToolCallStatus, type ToolResult } from '@beaver/agent-core/run-state/atoms';
 import type { PendingApproval } from '@beaver/agent-ui/host';
+import type { PendingBatchApproval } from '@beaver/agent-core/run-state/pendingBatchApprovals';
+import type { BatchApprovalDecision } from '@beaver/agent-core/run-state/batchApprovalAnswers';
 import type { PendingQuestion } from '@beaver/agent-core/run-state/pendingQuestions';
 import type { AskUserQuestionAnswer } from '@beaver/agent-core/protocol/agentProtocol';
 import type { RunPermissionMode } from '../ui/buttons/RunPermissionButton';
@@ -35,6 +37,8 @@ export interface RunStatusArtifact {
 }
 
 interface RunStatusCardBase {
+    /** The run the card is about, so state kept beside the card can follow it. */
+    runId: string;
     threadName: string;
     /** Further running threads layered behind this card, capped by MAX_STACK_DEPTH. */
     stackDepth: number;
@@ -86,9 +90,9 @@ export interface CreditCard extends RunStatusCardBase {
 
 export interface BatchCard extends RunStatusCardBase {
     kind: 'batch';
-    title: string;
-    /** The population, e.g. "184 items in Methods". Empty when unknown. */
-    scope: string;
+    /** The request itself; the card draws the shared approval UI for it. */
+    approval: PendingBatchApproval;
+    onSubmit: (decision: BatchApprovalDecision) => void;
 }
 
 export interface QuestionCard extends RunStatusCardBase {

--- a/react/components/runStatusPopup/useRunStatusPopupCard.ts
+++ b/react/components/runStatusPopup/useRunStatusPopupCard.ts
@@ -54,6 +54,7 @@ import {
     type RunStatusPopupPreview,
 } from '../../atoms/runStatusPopup';
 import { eventManager } from '../../events/eventManager';
+import { useBatchApprovalSubmit } from '../input/BatchApprovalPanel';
 import { resolveToolCallLabelEnrich } from '../../utils/toolCallLabelEnrich';
 import { openNoteByKey } from '../../utils/sourceUtils';
 import { resolveItemReference, resolveLibraryRef } from '../../../src/utils/libraryIdentity';
@@ -395,6 +396,7 @@ function useLiveCard(): RunStatusPopupCard | null {
     const approvalControls = useApprovalControls(liveRun?.id ?? null, approvals);
     const creditControls = useCreditControls(credit);
     const onSubmitQuestion = useQuestionControls(question);
+    const onSubmitBatch = useBatchApprovalSubmit(batch?.approvalId ?? null);
     const completed = useCompletedDetails(isLive ? null : completion?.runId ?? null);
     const setPanelState = useSetAtom(setAnnotationPanelStateAtom);
     // The changes card keys its expansion by the answer's last run, so the
@@ -427,7 +429,7 @@ function useLiveCard(): RunStatusPopupCard | null {
     };
 
     if (liveRun) {
-        const base = { threadName: threadDisplayName(threadName, liveRun), stackDepth: 0, onOpen: openBeaver, onDismiss };
+        const base = { runId: liveRun.id, threadName: threadDisplayName(threadName, liveRun), stackDepth: 0, onOpen: openBeaver, onDismiss };
         if (approvals.length > 0) {
             const summary = describePendingApprovals(approvals, singleTitle);
             const plural = summary.count > 1;
@@ -451,12 +453,7 @@ function useLiveCard(): RunStatusPopupCard | null {
             };
         }
         if (batch) {
-            return {
-                ...base,
-                kind: 'batch',
-                title: batch.title,
-                scope: [batch.scopePrimary, batch.scopeSecondary].filter(Boolean).join(' '),
-            };
+            return { ...base, kind: 'batch', approval: batch, onSubmit: onSubmitBatch };
         }
         if (credit) {
             return {
@@ -480,6 +477,7 @@ function useLiveCard(): RunStatusPopupCard | null {
         const run = completed.run;
         const outcome = run.status === 'error' ? 'error' : run.status === 'canceled' ? 'canceled' : 'completed';
         return {
+            runId: run.id,
             threadName: threadDisplayName(threadName, run),
             stackDepth: 0,
             onOpen: openBeaver,
@@ -509,6 +507,7 @@ function usePreviewCard(preview: RunStatusPopupPreview | null): RunStatusPopupCa
 
     if (!preview) return null;
     const base = {
+        runId: 'preview-run',
         threadName: preview.threadName ?? 'Summarize Legewie et al. 2024 on neighborhood effects',
         stackDepth: Math.min(Math.max(preview.stackDepth ?? 0, 0), MAX_STACK_DEPTH),
         onOpen: openBeaver,
@@ -550,8 +549,28 @@ function usePreviewCard(preview: RunStatusPopupPreview | null): RunStatusPopupCa
             return {
                 ...base,
                 kind: 'batch',
-                title: preview.title ?? 'Summarize each paper into a note',
-                scope: preview.scope ?? '568 items in Methods and its subcollections',
+                approval: {
+                    approvalId: 'preview-batch',
+                    runId: 'preview-run',
+                    toolcallId: 'preview-toolcall',
+                    batchId: 'preview-batch',
+                    title: preview.title ?? 'Summarize each paper into a note',
+                    scopePrimary: preview.scopePrimary ?? '568 items',
+                    scopeSecondary: preview.scopeSecondary ?? 'in Methods and its subcollections',
+                    message: preview.message ?? 'Write one note per item covering its question, method, and main findings.',
+                    destructiveWarning: preview.destructiveWarning ?? '',
+                    costWarning: preview.costWarning ?? '',
+                    creditChip: preview.creditChip ?? '',
+                    creditTooltip: preview.creditTooltip ?? '',
+                    defaultMode: 'ask_each_time',
+                    approveLabel: 'Start batch',
+                    declineLabel: 'Cancel',
+                    declineWithInstructionsLabel: 'Cancel and send instructions',
+                    userInstructionsPrefill: preview.userInstructionsPrefill ?? '',
+                    readOnly: preview.readOnly ?? false,
+                    timeoutSeconds: 300,
+                },
+                onSubmit: clear,
             };
         case 'question':
             return {

--- a/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
+++ b/react/hooks/httpHandlers/testRunStatusPopupHandlers.ts
@@ -9,7 +9,10 @@
  * controls only clear the preview. `{ completion: { runId } }` shows the real
  * completed card for a run of the open thread, so its rows can be exercised
  * without waiting for a run to finish with the sidebar closed. Every field but `kind` is optional and
- * falls back to sample copy — see `RunStatusPopupPreview`. `{ tip: true }`
+ * falls back to sample copy — see `RunStatusPopupPreview`. The `batch` preview
+ * draws the full approval card; combine a `running` or `approval` preview with
+ * `/beaver/test/batch-progress-preview` to see live batch progress on the
+ * card. `{ tip: true }`
  * shows the one-time onboarding tip about the popup (`tipInPanel` overrides
  * where it goes); `{ tip: false }` removes it.
  *

--- a/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
+++ b/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
@@ -4,7 +4,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { Provider, createStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ card: null as any }));
+const mocks = vi.hoisted(() => ({ card: null as any, batch: null as string | null }));
 vi.mock('../../../../react/components/runStatusPopup/useRunStatusPopupCard', () => ({
     useRunStatusPopupCard: () => mocks.card,
 }));
@@ -19,6 +19,20 @@ vi.mock('../../../../react/atoms/runStatusPopup', async () => {
 vi.mock('../../../../react/host/zotero/components/agentActionViewHelpers', () => ({ getAgentActionToolIcon: () => () => null }));
 vi.mock('../../../../react/components/ui/buttons/RunPermissionButton', () => ({ default: () => null }));
 vi.mock('@beaver/agent-ui/chat/AskUserQuestionCard', () => ({ default: () => null }));
+vi.mock('@beaver/agent-ui/chat/BatchApprovalCard', () => ({
+    default: ({ approval, onSubmit, titleTrailing }: any) => React.createElement(
+        'div', { className: 'batch-card', 'data-approval': approval.approvalId },
+        React.createElement('button', { type: 'button', onClick: () => onSubmit({ approved: true, mode: 'ask_each_time', user_instructions: null }) }, approval.approveLabel),
+        titleTrailing,
+    ),
+}));
+// The panel's stamp reading is its own test's business; here it draws a
+// disclosure whenever the mock has a batch, controlled by the popup.
+vi.mock('../../../../react/components/input/BatchProgressPanel', () => ({
+    default: ({ expanded, onExpandedChange }: any) => mocks.batch
+        ? React.createElement('div', { className: 'batch-bar', role: 'button', 'aria-expanded': expanded, onClick: () => onExpandedChange(!expanded) }, mocks.batch)
+        : null,
+}));
 vi.mock('../../../../react/components/runStatusPopup/RunPulse', () => ({ default: () => null }));
 
 import RunStatusPopup from '../../../../react/components/runStatusPopup/RunStatusPopup';
@@ -30,8 +44,9 @@ let container: HTMLDivElement;
 beforeEach(() => {
     store = createStore();
     (window as any).ResizeObserver = class { observe() {} disconnect() {} };
+    mocks.batch = null;
     mocks.card = {
-        kind: 'approval', threadName: 'Test', label: 'Create collection', stackDepth: 0,
+        kind: 'approval', runId: 'run-1', threadName: 'Test', label: 'Create collection', stackDepth: 0,
         approveLabel: 'Approve', rejectLabel: 'Reject', decideDisabled: false,
         onOpen: vi.fn(), onDecide: vi.fn(), onDismiss: vi.fn(),
     };
@@ -82,5 +97,72 @@ describe('RunStatusPopup keyboard decisions', () => {
         press(Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Reject')!);
         expect(mocks.card.onDecide).not.toHaveBeenCalled();
         expect(mocks.card.onOpen).not.toHaveBeenCalled();
+    });
+});
+
+describe('RunStatusPopup batch approval', () => {
+    beforeEach(() => {
+        mocks.card = {
+            kind: 'batch', runId: 'run-1', threadName: 'Test', stackDepth: 0,
+            approval: { approvalId: 'b1', approveLabel: 'Start batch' },
+            onSubmit: vi.fn(), onOpen: vi.fn(), onDismiss: vi.fn(),
+        };
+    });
+    it('draws the shared approval card alone, with the close button in its title row', () => {
+        render();
+        const card = container.querySelector<HTMLElement>('.batch-card')!;
+        expect(card.dataset.approval).toBe('b1');
+        expect(container.querySelector('.beaver-run-status-popup__header')).toBeNull();
+        act(() => card.click());
+        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+        act(() => card.querySelector('button')!.click());
+        expect(mocks.card.onSubmit).toHaveBeenCalledWith({ approved: true, mode: 'ask_each_time', user_instructions: null });
+        act(() => card.querySelector<HTMLButtonElement>('[aria-label="Close"]')!.click());
+        expect(mocks.card.onDismiss).toHaveBeenCalledTimes(1);
+        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+    });
+});
+
+describe('RunStatusPopup batch progress', () => {
+    const running = (runId = 'run-1') => ({
+        kind: 'running', runId, threadName: 'Test', statusLine: 'Filing items', stackDepth: 0,
+        onOpen: vi.fn(), onDismiss: vi.fn(),
+    });
+    const bar = () => container.querySelector<HTMLElement>('.batch-bar');
+
+    it('shows the progress on the working and approval cards only, and leaves it out with no batch', () => {
+        mocks.card = running();
+        render();
+        expect(bar()).toBeNull();
+        expect(container.querySelector('.beaver-run-status-popup__batch-progress')).not.toBeNull();
+
+        mocks.batch = 'Filing items 12 of 184';
+        render();
+        expect(bar()?.textContent).toBe('Filing items 12 of 184');
+
+        mocks.card = { ...mocks.card, kind: 'approval', label: 'Edit', approveLabel: 'Approve', rejectLabel: 'Reject', decideDisabled: false, onDecide: vi.fn() };
+        render();
+        expect(bar()).not.toBeNull();
+
+        mocks.card = { ...running(), kind: 'credit', title: 'T', message: 'M', approveLabel: 'Continue', declineLabel: 'Wrap up', decideDisabled: false, onDecide: vi.fn() };
+        render();
+        expect(bar()).toBeNull();
+    });
+
+    it('keeps the disclosure open while the card changes under it, and folds it for the next run', () => {
+        mocks.batch = 'Filing items';
+        mocks.card = running();
+        render();
+        act(() => bar()!.click());
+        expect(bar()?.getAttribute('aria-expanded')).toBe('true');
+        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+
+        mocks.card = { ...running(), kind: 'approval', label: 'Edit', approveLabel: 'Approve', rejectLabel: 'Reject', decideDisabled: false, onDecide: vi.fn() };
+        render();
+        expect(bar()?.getAttribute('aria-expanded')).toBe('true');
+
+        mocks.card = running('run-2');
+        render();
+        expect(bar()?.getAttribute('aria-expanded')).toBe('false');
     });
 });

--- a/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
+++ b/tests/unit/components/runStatusPopup/RunStatusPopup.test.ts
@@ -20,10 +20,9 @@ vi.mock('../../../../react/host/zotero/components/agentActionViewHelpers', () =>
 vi.mock('../../../../react/components/ui/buttons/RunPermissionButton', () => ({ default: () => null }));
 vi.mock('@beaver/agent-ui/chat/AskUserQuestionCard', () => ({ default: () => null }));
 vi.mock('@beaver/agent-ui/chat/BatchApprovalCard', () => ({
-    default: ({ approval, onSubmit, titleTrailing }: any) => React.createElement(
+    default: ({ approval, onSubmit }: any) => React.createElement(
         'div', { className: 'batch-card', 'data-approval': approval.approvalId },
         React.createElement('button', { type: 'button', onClick: () => onSubmit({ approved: true, mode: 'ask_each_time', user_instructions: null }) }, approval.approveLabel),
-        titleTrailing,
     ),
 }));
 // The panel's stamp reading is its own test's business; here it draws a
@@ -108,18 +107,21 @@ describe('RunStatusPopup batch approval', () => {
             onSubmit: vi.fn(), onOpen: vi.fn(), onDismiss: vi.fn(),
         };
     });
-    it('draws the shared approval card alone, with the close button in its title row', () => {
+    it('draws the shared approval card alone, with no header and no close button', () => {
         render();
         const card = container.querySelector<HTMLElement>('.batch-card')!;
         expect(card.dataset.approval).toBe('b1');
         expect(container.querySelector('.beaver-run-status-popup__header')).toBeNull();
+        expect(container.querySelector('[aria-label="Close"]')).toBeNull();
+    });
+    it('opens Beaver from the copy around its controls, but not from the controls', () => {
+        render();
+        const card = container.querySelector<HTMLElement>('.batch-card')!;
         act(() => card.click());
-        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+        expect(mocks.card.onOpen).toHaveBeenCalledTimes(1);
         act(() => card.querySelector('button')!.click());
         expect(mocks.card.onSubmit).toHaveBeenCalledWith({ approved: true, mode: 'ask_each_time', user_instructions: null });
-        act(() => card.querySelector<HTMLButtonElement>('[aria-label="Close"]')!.click());
-        expect(mocks.card.onDismiss).toHaveBeenCalledTimes(1);
-        expect(mocks.card.onOpen).not.toHaveBeenCalled();
+        expect(mocks.card.onOpen).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
+++ b/tests/unit/components/runStatusPopup/useRunStatusPopupCard.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     setRunPermissionMode: vi.fn(),
     sendCreditConfirmation: vi.fn(),
     sendQuestionResponse: vi.fn(),
+    sendBatchApproval: vi.fn(),
     dismissPreview: vi.fn(async () => {}),
     openNoteByKey: vi.fn(),
     artifactRows: [] as any[],
@@ -55,6 +56,7 @@ vi.mock('../../../../react/atoms/agentRunAtoms', async () => {
         setRunPermissionModeAtom: atom(null, (_get, _set, args: unknown) => mocks.setRunPermissionMode(args)),
         sendCreditConfirmationResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendCreditConfirmation(args)),
         sendAskUserQuestionResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendQuestionResponse(args)),
+        sendBatchApprovalResponseAtom: atom(null, (_get, _set, args: unknown) => mocks.sendBatchApproval(args)),
     };
 });
 vi.mock('../../../../react/host/zotero/editNotePreviewLifecycle', () => ({
@@ -191,6 +193,13 @@ describe('while a run waits on the user', () => {
     const approval = (actionId: string, actionType = 'edit_metadata') => ({
         actionId, toolcallId: `tc-${actionId}`, actionType, actionData: {},
     });
+    const batchApproval = (approvalId: string) => ({
+        approvalId, runId: 'run-1', toolcallId: `tc-${approvalId}`, batchId: 'batch', title: 'Summarize each paper',
+        scopePrimary: '184 items', scopeSecondary: 'in Methods', message: 'One note per item', destructiveWarning: '',
+        costWarning: '', creditChip: '', creditTooltip: '', defaultMode: 'ask_each_time' as const, approveLabel: 'Start',
+        declineLabel: 'Cancel', declineWithInstructionsLabel: 'Cancel', userInstructionsPrefill: '', readOnly: false,
+        timeoutSeconds: 300,
+    });
 
     it('offers the pending change with its controls', async () => {
         store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
@@ -254,16 +263,23 @@ describe('while a run waits on the user', () => {
         }]]));
         expect(latest).toMatchObject({ kind: 'credit', title: 'Continue past 50 credits?', approveLabel: 'Continue', declineLabel: 'Wrap up' });
 
-        set(pendingBatchApprovalsAtom, new Map([['b', {
-            approvalId: 'b', runId: 'run-1', toolcallId: 'tc-b', batchId: 'batch', title: 'Summarize each paper',
-            scopePrimary: '184 items', scopeSecondary: 'in Methods', message: '', destructiveWarning: '', costWarning: '',
-            creditChip: '', creditTooltip: '', defaultMode: 'ask', approveLabel: 'Start', declineLabel: 'Cancel',
-            declineWithInstructionsLabel: 'Cancel', userInstructionsPrefill: '', readOnly: false, timeoutSeconds: 300,
-        }]]));
-        expect(latest).toMatchObject({ kind: 'batch', title: 'Summarize each paper', scope: '184 items in Methods' });
+        set(pendingBatchApprovalsAtom, new Map([['b', batchApproval('b')]]));
+        expect(latest).toMatchObject({ kind: 'batch', approval: { approvalId: 'b', title: 'Summarize each paper' } });
 
         set(pendingApprovalsAtom as any, new Map([['a', approval('a')]]));
         expect(latest?.kind).toBe('approval');
+    });
+
+    it('hands the batch request to the card whole and sends its decision on the wire', () => {
+        store.set(activeRunAtom, run({ status: 'awaiting_deferred' }));
+        store.set(pendingBatchApprovalsAtom, new Map([['b', batchApproval('b')]]));
+        mount();
+
+        expect(latest?.kind).toBe('batch');
+        (latest as any).onSubmit({ approved: true, mode: 'full_access', user_instructions: 'Skip reviews' });
+        expect(mocks.sendBatchApproval).toHaveBeenCalledExactlyOnceWith({
+            approvalId: 'b', approved: true, mode: 'full_access', userInstructions: 'Skip reviews',
+        });
     });
 
     it('sends a credit decision once', () => {

--- a/tests/unit/input/batchProgressBar.test.ts
+++ b/tests/unit/input/batchProgressBar.test.ts
@@ -122,6 +122,33 @@ function outcomeBody(node: React.ReactNode): React.ReactElement<any> | null {
     return outcomeBody(props.children ?? null);
 }
 
+/** The 2px hairline along the bar's top edge, wherever it sits in the tree. */
+function hairline(node: React.ReactNode): React.ReactElement<any> | null {
+    if (Array.isArray(node)) {
+        for (const child of node) {
+            const found = hairline(child);
+            if (found) return found;
+        }
+        return null;
+    }
+    if (!React.isValidElement(node)) return null;
+    const props = (node as React.ReactElement<any>).props ?? {};
+    if (typeof props.className === 'string' && props.className.includes('batch-progress-hairline')) {
+        return node as React.ReactElement<any>;
+    }
+    return hairline(props.children ?? null);
+}
+
+describe('the batch progress bar hairline', () => {
+    it("is drawn while collapsed and gives way to the body's track when opened", () => {
+        hookState.slots = [];
+        hookState.index = 0;
+        const collapsed = hairline(BatchProgressBar({ batch: tracked, queuedBatches: [] }) as React.ReactNode);
+        expect(collapsed?.props.style.opacity).toBe(1);
+        expect(hairline(renderExpanded(tracked))?.props.style.opacity).toBe(0);
+    });
+});
+
 describe('the batch progress bar, opened', () => {
     const batch = entry({
         blocks: [

--- a/tests/unit/input/batchProgressBar.test.ts
+++ b/tests/unit/input/batchProgressBar.test.ts
@@ -143,11 +143,11 @@ describe('the batch progress bar, opened', () => {
         expect(body?.props.maxRows).toBe(5);
     });
 
-    it('does not offer its rows as places to go', () => {
+    it('offers its rows as places to go, like the receipt', () => {
         const body = outcomeBody(renderExpanded(batch));
         // Assert the body was found first: `undefined?.props` is falsy too, and
         // a walker that stopped matching would pass this test in silence.
         expect(body).not.toBeNull();
-        expect(body?.props.revealTargets).toBeFalsy();
+        expect(body?.props.revealTargets).toBe(true);
     });
 });

--- a/tests/unit/input/batchProgressPanel.test.ts
+++ b/tests/unit/input/batchProgressPanel.test.ts
@@ -200,6 +200,24 @@ describe('the live batch panel', () => {
         expect(drawn()?.batch_id).toBe('second');
     });
 
+    it('lets a host own the expansion, and folds on its own otherwise', () => {
+        stampRef.current = stamp(entry());
+        hookState.index = 0;
+        const onExpandedChange = vi.fn();
+        const controlled = BatchProgressPanel({ expanded: true, onExpandedChange }) as React.ReactElement<any>;
+        expect(controlled.props.expanded).toBe(true);
+        controlled.props.onExpandedChange(false);
+        expect(onExpandedChange).toHaveBeenCalledExactlyOnceWith(false);
+        // The host's word stands; the panel kept nothing of its own.
+        hookState.index = 0;
+        expect((BatchProgressPanel({ expanded: true, onExpandedChange }) as React.ReactElement<any>).props.expanded).toBe(true);
+
+        hookState.slots = [];
+        expect(render()!.props.expanded).toBe(false);
+        render()!.props.onExpandedChange(true);
+        expect(render()!.props.expanded).toBe(true);
+    });
+
     it('draws a batch the backend did not flag as worth showing', () => {
         // The model decided this work was a batch; the panel says so.
         expect(drawn(stamp(entry({ batch_id: 'small', show_progress: false })))?.batch_id).toBe(


### PR DESCRIPTION
## Summary

- Expand the minimal run-status popup to display full batch approval cards and live progress.
- Add batch approval submission, warnings, scope details, and instruction support.
- Improve popup scrolling and shared UI lifecycle handling across Zotero windows.
- Consolidate event, sidebar-width, and shutdown behavior around the shared runtime.

## Testing

- Updated run-status popup, batch progress, sidebar-width, service, and lifecycle tests.
- Added coverage for embedded batch approval and progress panels.
- Not run locally.