### PR TITLE
fix(background-processing): reconcile files before processing now

### DIFF
--- a/react/components/preferences/BackgroundProcessingSection.tsx
+++ b/react/components/preferences/BackgroundProcessingSection.tsx
@@ -208,9 +208,10 @@ export default function BackgroundProcessingSection(): React.ReactElement | null
         Zotero.Beaver?.backgroundExtractor?.notify();
     };
 
-    const processNow = () => {
+    const processNow = async () => {
+        await Zotero.Beaver?.processingReconciler?.reconcileNow();
         Zotero.Beaver?.backgroundExtractor?.requestImmediateDrain();
-        void refresh();
+        await refresh();
     };
 
     const cache = status.documentCache;

--- a/react/components/preferences/ProcessingIssueList.tsx
+++ b/react/components/preferences/ProcessingIssueList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useSetAtom } from 'jotai';
-import { isItemRow, type ItemListRow } from '@beaver/agent-core/run-state/toolResultViews';
+import { type ItemListRow } from '@beaver/agent-core/run-state/toolResultViews';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { effectiveMaxFileSizeMB, effectiveMaxPageCount } from '@beaver/agent-core/transport/attachmentLimits';
 import Button from '@beaver/agent-ui/primitives/Button';
@@ -37,7 +37,7 @@ function reasonCopy(reason: ProcessingIssueReason, hasOcrAccess: boolean): Reaso
         case 'no_text':
             return {
                 title: 'No readable text',
-                description: 'Neither the file nor OCR produced any text Beaver can use.',
+                description: 'The file did not yield any readable text.',
             };
         case 'file_unavailable':
             return {
@@ -76,18 +76,6 @@ function reasonCopy(reason: ProcessingIssueReason, hasOcrAccess: boolean): Reaso
                 description: 'Beaver ran into an error while reading these files.',
             };
     }
-}
-
-/**
- * OCR is PDF-only today. EPUBs can still land in the scanned group (no text
- * layer), so reuse the item-row's right-aligned slot to say OCR will not help.
- */
-function withNoOcrLabel(rows: ItemListRow[]): ItemListRow[] {
-    return rows.map((row) => (
-        isItemRow(row) && row.content_kind === 'epub'
-            ? { ...row, location_label: 'No OCR' }
-            : row
-    ));
 }
 
 /**
@@ -136,7 +124,7 @@ const ProcessingIssuePage: React.FC<{
         void load()
             .then((hydrated) => {
                 if (!cancelled) {
-                    setRows(reason === 'scanned' ? withNoOcrLabel(hydrated) : hydrated);
+                    setRows(hydrated);
                 }
             })
             .catch((error) => {

--- a/react/components/preferences/processingStatusSentence.ts
+++ b/react/components/preferences/processingStatusSentence.ts
@@ -9,7 +9,7 @@ export type StatusTone = 'idle' | 'busy' | 'waiting' | 'error';
 interface StatusSentence {
     tone: StatusTone;
     headline: string;
-    /** Second line; `processNow` appends the one-off idle-bypass link. */
+    /** Second line; `processNow` appends the reconciliation and immediate-drain action. */
     caption: string;
     processNow: boolean;
 }
@@ -18,8 +18,8 @@ interface StatusSentence {
  * Reduce the status snapshot to the one sentence the status row shows.
  *
  * Order matters: an unreadable status wins, then running work, then work
- * queued behind the idle gate (the only state that offers "process now"),
- * then the settled summary.
+ * queued behind the idle gate, then the settled summary. Unavailable files
+ * retain a manual recheck once queued work has finished.
  */
 export function describeStatus(
     status: BackgroundProcessingStatus,
@@ -72,11 +72,14 @@ export function describeStatus(
     }
     const { total, readable, unreadable, awaitingOcr, oldestPendingAt } = status.ledger;
     if (unreadable > 0 || status.issues.some((group) => group.count > 0)) {
+        const hasUnavailableFiles = status.issues.some((group) => group.reason === 'file_unavailable' && group.count > 0);
         return {
             tone: 'error',
             headline: 'Some files could not be processed',
-            caption: 'Some attachments need attention before processing can finish.',
-            processNow: false,
+            caption: hasUnavailableFiles
+                ? 'After restoring access to unavailable files, process now to check them again.'
+                : 'Some attachments need attention before processing can finish.',
+            processNow: hasUnavailableFiles && !blocker,
         };
     }
     // A reconcile pass may not have queued every unfinished ledger stage yet.

--- a/src/services/backgroundProcessing/issues.ts
+++ b/src/services/backgroundProcessing/issues.ts
@@ -35,6 +35,7 @@ export interface BackgroundQueueDeadRow {
 
 /** One ledger row that did not reach a readable state. */
 export interface AttachmentProcessingIssueRow {
+    contentKind: string | null;
     libraryId: number;
     zoteroKey: string;
     extractStatus: string | null;
@@ -75,10 +76,14 @@ export function processingIssuesSql(entitlements: IssueEntitlements): string {
                     WHEN ${hasCodeSql('encrypted')} THEN 'encrypted'
                     WHEN ${anyCodeSql(TOO_LARGE_CODES)} THEN 'too_large'
                     WHEN instr(last_error, 'unsupported_') = 1 OR instr(last_error, ': unsupported_') > 0 THEN 'unsupported'
-                    WHEN ${anyCodeSql(NO_TEXT_CODES)} THEN '${entitlements.hasOcrAccess ? 'no_text' : 'scanned'}'
+                    WHEN ${anyCodeSql(NO_TEXT_CODES)} THEN CASE
+                        WHEN content_kind = 'pdf' AND ${entitlements.hasOcrAccess ? 0 : 1} THEN 'scanned'
+                        ELSE 'no_text' END
                     ELSE 'extract_failed' END
                 WHEN upsert_status = 'failed' AND ${entitlements.hasSearchIndexAccess ? 1 : 0} THEN 'index_failed'
-                WHEN ocr_status = 'failed' THEN 'ocr_failed'
+                WHEN ocr_status = 'failed' THEN CASE
+                    WHEN ${anyCodeSql(FILE_UNAVAILABLE_CODES)} THEN 'file_unavailable'
+                    ELSE 'ocr_failed' END
                 WHEN ocr_status = 'needed' AND ${entitlements.hasOcrAccess ? 0 : 1} THEN 'scanned'
             END AS reason
         FROM attachment_processing_state
@@ -139,7 +144,7 @@ function hasAnyCode(error: string | null, codes: string[]): boolean {
  * With OCR entitlement a scan awaiting OCR is pending work, not an issue, so
  * `ocr_status = 'needed'` rows are only classified when the caller has no OCR
  * access; then they share the "scanned" group with extraction outcomes that
- * found no text, since OCR is the remedy for both. Returns `null` for rows that
+ * found no text in PDFs, since OCR is the remedy for both. Returns `null` for rows that
  * are not an issue from the user's point of view.
  */
 export function classifyProcessingIssue(
@@ -155,13 +160,15 @@ export function classifyProcessingIssue(
         if (hasAnyCode(error, TOO_LARGE_CODES)) return 'too_large';
         if (error && /(^|: )unsupported_/.test(error)) return 'unsupported';
         if (hasAnyCode(error, NO_TEXT_CODES)) {
-            return entitlements.hasOcrAccess ? 'no_text' : 'scanned';
+            return row.contentKind === 'pdf' && !entitlements.hasOcrAccess ? 'scanned' : 'no_text';
         }
         return 'extract_failed';
     }
 
     if (row.upsertStatus === 'failed' && entitlements.hasSearchIndexAccess) return 'index_failed';
-    if (row.ocrStatus === 'failed') return 'ocr_failed';
+    if (row.ocrStatus === 'failed') {
+        return hasAnyCode(row.lastError, FILE_UNAVAILABLE_CODES) ? 'file_unavailable' : 'ocr_failed';
+    }
     if (row.ocrStatus === 'needed' && !entitlements.hasOcrAccess) return 'scanned';
     return null;
 }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -2792,7 +2792,7 @@ export class BeaverDB {
         const rows: AttachmentProcessingIssueRow[] = [];
         await this.queryAsync(
             `SELECT library_id, zotero_key, extract_status, ocr_status,
-                    upsert_status, last_error, updated_at
+                    upsert_status, last_error, updated_at, content_kind
              FROM attachment_processing_state
              WHERE extract_status IN ('failed', 'skipped')
                 OR ocr_status IN ('failed', 'needed')
@@ -2807,6 +2807,7 @@ export class BeaverDB {
                 upsertStatus: row.getResultByIndex(4) ?? null,
                 lastError: row.getResultByIndex(5) ?? null,
                 updatedAt: row.getResultByIndex(6) ?? null,
+                contentKind: row.getResultByIndex(7) ?? null,
             }) },
         );
         return rows;

--- a/tests/unit/services/backgroundProcessingIssues.test.ts
+++ b/tests/unit/services/backgroundProcessingIssues.test.ts
@@ -8,6 +8,7 @@ import {
 function row(overrides: Partial<AttachmentProcessingIssueRow>): AttachmentProcessingIssueRow {
     return {
         libraryId: 1,
+        contentKind: 'pdf',
         zoteroKey: 'AAAAAAAA',
         extractStatus: null,
         ocrStatus: null,
@@ -29,6 +30,14 @@ describe('classifyProcessingIssue', () => {
         }
     });
 
+    it.each(['file_missing', 'download_failed: 404', 'ocr_remote_download_failed: download_failed',
+        'ocr_remote_download_failed: read_failed'])('classifies OCR file access failure %s as unavailable', (lastError) => {
+        for (const entitlements of [noOcr, withOcr]) {
+            expect(classifyProcessingIssue(row({ extractStatus: 'done', ocrStatus: 'failed', lastError }), entitlements))
+                .toBe('file_unavailable');
+        }
+    });
+
     it('recognises encrypted, oversized and unsupported files', () => {
         expect(classifyProcessingIssue(row({ extractStatus: 'skipped', lastError: 'encrypted' }), noOcr)).toBe('encrypted');
         expect(classifyProcessingIssue(row({ extractStatus: 'skipped', lastError: 'too_many_pages' }), noOcr)).toBe('too_large');
@@ -40,6 +49,13 @@ describe('classifyProcessingIssue', () => {
         const empty = row({ extractStatus: 'failed', lastError: 'empty_document' });
         expect(classifyProcessingIssue(empty, noOcr)).toBe('scanned');
         expect(classifyProcessingIssue(empty, withOcr)).toBe('no_text');
+    });
+
+    it.each(['epub', 'snapshot'])('does not recommend OCR for text-empty %s files', (contentKind) => {
+        for (const entitlements of [noOcr, withOcr]) {
+            expect(classifyProcessingIssue(row({ contentKind, extractStatus: 'failed', lastError: 'no_text_layer' }), entitlements))
+                .toBe('no_text');
+        }
     });
 
     it('treats a scan waiting for OCR as an issue only without OCR access', () => {

--- a/tests/unit/services/database.backgroundProcessing.test.ts
+++ b/tests/unit/services/database.backgroundProcessing.test.ts
@@ -491,6 +491,41 @@ describe('BeaverDB background processing state', () => {
         expect(await db.getProcessingIssuePage(entitlements, 'ocr_failed')).toEqual([]);
     });
 
+    it.each(['file_missing', 'download_failed: 404', 'ocr_remote_download_failed: download_failed',
+        'ocr_remote_download_failed: read_failed'])('groups OCR file access failure %s as unavailable in counts and pages', async (lastError) => {
+        await db.ensureAttachmentProcessingState({ libraryId: 1, zoteroKey: 'OCRFILE0', contentKind: 'pdf' });
+        await connection.queryAsync("UPDATE attachment_processing_state SET extract_status = 'done', ocr_status = 'failed', last_error = ?", [lastError]);
+        for (const hasOcrAccess of [true, false]) {
+            const entitlements = { hasOcrAccess, hasSearchIndexAccess: true };
+            expect(await db.getProcessingIssueCounts(entitlements)).toEqual([{ reason: 'file_unavailable', count: 1 }]);
+            expect((await db.getProcessingIssuePage(entitlements, 'file_unavailable')).map((item) => item.zoteroKey))
+                .toEqual(['OCRFILE0']);
+            expect(await db.getProcessingIssuePage(entitlements, 'ocr_failed')).toEqual([]);
+            expect(groupProcessingIssues(await db.getAttachmentProcessingIssueRows(), [], entitlements)
+                .map(({ reason, count }) => ({ reason, count })))
+                .toEqual(await db.getProcessingIssueCounts(entitlements));
+        }
+    });
+
+    it('keeps text-empty EPUBs and snapshots out of the PDF OCR group', async () => {
+        for (const contentKind of ['pdf', 'epub', 'snapshot'] as const) {
+            await db.ensureAttachmentProcessingState({ libraryId: 1, zoteroKey: contentKind, contentKind });
+            await db.markAttachmentExtractFailure({ libraryId: 1, zoteroKey: contentKind, status: 'failed', error: 'no_text_layer' });
+        }
+        for (const hasOcrAccess of [true, false]) {
+            const entitlements = { hasOcrAccess, hasSearchIndexAccess: true };
+            const expected = hasOcrAccess ? [{ reason: 'no_text', count: 3 }]
+                : [{ reason: 'scanned', count: 1 }, { reason: 'no_text', count: 2 }];
+            expect(await db.getProcessingIssueCounts(entitlements)).toEqual(expected);
+            expect(groupProcessingIssues(await db.getAttachmentProcessingIssueRows(), [], entitlements)
+                .map(({ reason, count }) => ({ reason, count }))).toEqual(expected);
+            expect((await db.getProcessingIssuePage(entitlements, 'scanned')).map((item) => item.zoteroKey))
+                .toEqual(hasOcrAccess ? [] : ['pdf']);
+            expect((await db.getProcessingIssuePage(entitlements, 'no_text')).map((item) => item.zoteroKey).sort())
+                .toEqual(hasOcrAccess ? ['epub', 'pdf', 'snapshot'] : ['epub', 'snapshot']);
+        }
+    });
+
     it('SQL grouping matches issue classification, with stable non-overlapping pages', async () => {
         const errors = ['file_missing', 'download_failed: 404', 'ocr load: read_failed', 'encrypted',
             'file_too_large: 120MB', 'too_many_pages', 'unsupported_type', 'wrapped: unsupported_type',

--- a/tests/unit/services/processingStatusSentence.test.ts
+++ b/tests/unit/services/processingStatusSentence.test.ts
@@ -11,6 +11,16 @@ function status(deferred: number, total = 1) {
 }
 
 describe('processing status sentence', () => {
+    it.each([false, true])('offers a manual recheck after unavailable files drain with continuous mode %s', (continuous) => {
+        const snapshot = status(0);
+        snapshot.ledger.readable = 0;
+        snapshot.ledger.unreadable = 1;
+        snapshot.issues = [{ reason: 'file_unavailable', count: 1 }];
+        expect(describeStatus(snapshot, continuous)).toMatchObject({ tone: 'error', processNow: true });
+        snapshot.worker.dispatchBlocker = 'sync_in_progress';
+        expect(describeStatus(snapshot, continuous).processNow).toBe(false);
+    });
+
     it('shows dispatcher-blocked work as waiting without offering an idle bypass', () => {
         const snapshot = status(0);
         snapshot.worker.available = 4;

--- a/tests/unit/ui/backgroundProcessingSection.test.ts
+++ b/tests/unit/ui/backgroundProcessingSection.test.ts
@@ -28,11 +28,13 @@ vi.mock('../../../src/utils/prefs', () => ({
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 afterEach(() => vi.clearAllMocks());
 
-it('waits for recovered files to be reconciled before draining Process now', async () => {
+it.each(['queued', 'unavailable'] as const)('reconciles before draining Process now with %s files', async (state) => {
     const store = createStore();
     store.set(backgroundProcessingStatusAtom, {
         ...store.get(backgroundProcessingStatusAtom),
-        worker: { available: 1, deferred: 0, inFlight: 0, dispatchBlocker: null, drainNow: false, backlogGateOpen: false },
+        ledger: { ...store.get(backgroundProcessingStatusAtom).ledger, total: 1, unreadable: state === 'unavailable' ? 1 : 0 },
+        issues: state === 'unavailable' ? [{ reason: 'file_unavailable', count: 1 }] : [],
+        worker: { available: state === 'queued' ? 1 : 0, deferred: 0, inFlight: 0, dispatchBlocker: null, drainNow: false, backlogGateOpen: false },
     });
     let finishReconcile!: () => void;
     const reconcileNow = vi.fn(() => new Promise<void>((resolve) => { finishReconcile = resolve; }));

--- a/tests/unit/ui/backgroundProcessingSection.test.ts
+++ b/tests/unit/ui/backgroundProcessingSection.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createStore, Provider } from 'jotai';
+import { afterEach, expect, it, vi } from 'vitest';
+import { backgroundProcessingStatusAtom } from '../../../react/atoms/backgroundProcessing';
+import BackgroundProcessingSection from '../../../react/components/preferences/BackgroundProcessingSection';
+
+const { refresh } = vi.hoisted(() => ({ refresh: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../../react/atoms/profile', async () => {
+    const { atom } = await import('jotai');
+    return {
+        hasOcrAccessAtom: atom(false),
+        hasSearchIndexAccessAtom: atom(false),
+        localZoteroLibrariesAtom: atom([]),
+        searchableLibraryIdsAtom: atom([]),
+    };
+});
+vi.mock('../../../react/hooks/useBackgroundProcessingStatus', () => ({
+    useBackgroundProcessingStatus: () => refresh,
+}));
+vi.mock('../../../react/components/preferences/ProcessingIssueList', () => ({ default: () => null }));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: (key: string) => key === 'backgroundProcessingEnabled',
+    setPref: vi.fn(),
+}));
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+afterEach(() => vi.clearAllMocks());
+
+it('waits for recovered files to be reconciled before draining Process now', async () => {
+    const store = createStore();
+    store.set(backgroundProcessingStatusAtom, {
+        ...store.get(backgroundProcessingStatusAtom),
+        worker: { available: 1, deferred: 0, inFlight: 0, dispatchBlocker: null, drainNow: false, backlogGateOpen: false },
+    });
+    let finishReconcile!: () => void;
+    const reconcileNow = vi.fn(() => new Promise<void>((resolve) => { finishReconcile = resolve; }));
+    const requestImmediateDrain = vi.fn();
+    const previousBeaver = Zotero.Beaver;
+    (Zotero as any).Beaver = {
+        processingReconciler: { reconcileNow },
+        backgroundExtractor: { requestImmediateDrain },
+    };
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    try {
+        await act(async () => root.render(React.createElement(Provider, { store }, React.createElement(BackgroundProcessingSection))));
+        const button = Array.from(container.querySelectorAll('button')).find((node) => node.textContent === 'Process now');
+        expect(button).toBeDefined();
+        await act(async () => button!.click());
+        expect(reconcileNow).toHaveBeenCalledOnce();
+        expect(requestImmediateDrain).not.toHaveBeenCalled();
+        expect(refresh).not.toHaveBeenCalled();
+        await act(async () => finishReconcile());
+        expect(requestImmediateDrain).toHaveBeenCalledOnce();
+        expect(refresh).toHaveBeenCalledOnce();
+    } finally {
+        act(() => root.unmount());
+        Zotero.Beaver = previousBeaver;
+    }
+});


### PR DESCRIPTION
## Summary

- Reconcile recovered files before triggering immediate background processing.
- Classify OCR file access failures as unavailable.
- Restrict scanned issue grouping to PDFs and simplify issue-list labels.
- Add database, classification, and UI coverage for reconciliation and issue grouping.

## Testing

- Not run