### PR TITLE
feat(quick-prompt): add animated release note showcase

### DIFF
--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -627,6 +627,136 @@
     cursor: default;
 }
 
+/* Release-note showcases (react/components/ui/popup/showcases): the corner
+ * cards drawn right on the note, from their own classes, in a slot sized for
+ * the tallest of them so the note does not jump as the scene changes; a
+ * Decorative only. */
+.beaver-showcase {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    /* Closer to the text above than the note's own gap puts it. */
+    margin-top: -6px;
+    pointer-events: none;
+    user-select: none;
+}
+
+.beaver-showcase__stage {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* The composer card with its two-line prompt, the tallest scene. */
+    height: 120px;
+    /* Softened toward the bottom-right, like the feature tips' previews, so
+     * the visual reads as an illustration rather than a live card. */
+    mask-image: linear-gradient(to bottom right, black 45%, rgba(0, 0, 0, 0.45) 100%);
+}
+
+.beaver-showcase__chord {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.beaver-showcase__key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    min-width: 34px;
+    height: 36px;
+    padding: 0 10px;
+    border: 1px solid var(--beaver-border-strong);
+    border-radius: 8px;
+    background: var(--beaver-surface-overlay);
+    box-shadow: 0 2px 0 var(--fill-quarternary);
+    color: var(--fill-primary);
+    font-size: 15px;
+    font-weight: 500;
+    transition: transform 90ms ease, box-shadow 90ms ease, background-color 90ms ease;
+}
+
+.beaver-showcase__chord--pressed .beaver-showcase__key {
+    transform: translateY(2px);
+    box-shadow: 0 0 0 var(--fill-quarternary);
+    background: var(--fill-quinary);
+}
+
+/* The wrapper also carries the real cards' container classes (for the rules
+ * scoped under them), so their corner geometry is overridden here. */
+.beaver-showcase__card,
+.beaver-showcase__card.beaver-quick-prompt,
+.beaver-showcase__card.beaver-run-status-popup {
+    position: relative;
+    align-self: center;
+    width: 100%;
+    max-width: 324px;
+    margin: 0;
+    padding: 0;
+    animation: beaverShowcaseCardIn 240ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes beaverShowcaseCardIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.beaver-showcase__run-card {
+    cursor: default;
+}
+
+/* The editor line, with the composer's typography. */
+.beaver-showcase__editor {
+    min-height: calc(1.25em + 2px);
+    padding: 1px 0;
+    color: var(--fill-primary);
+    font-size: 13px;
+    line-height: 1.25;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.beaver-showcase__placeholder {
+    color: var(--fill-tertiary);
+}
+
+.beaver-showcase__caret {
+    display: inline-block;
+    width: 1px;
+    height: 1.1em;
+    margin: 0 1px;
+    vertical-align: text-bottom;
+    background: var(--fill-primary);
+    animation: beaverShowcaseCaret 1s steps(1, end) infinite;
+}
+
+@keyframes beaverShowcaseCaret {
+    50% {
+        opacity: 0;
+    }
+}
+
+.beaver-showcase__model {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.9rem;
+}
+
+.beaver-showcase__send--pressed {
+    transform: scale(0.85);
+    transition: transform 120ms ease;
+}
+
 /* A working run: a dot with a ring that keeps expanding out of it and fading. */
 .beaver-run-pulse {
     position: relative;
@@ -804,6 +934,12 @@
 [id^="beaver-pane-"] .source-preview.no-fade {
     animation: none;
     opacity: 1;
+}
+
+/* A release note is as tall as what it has to show — a showcase does not fit
+ * the cap above, and nothing in the card scrolls. */
+[id^="beaver-pane-"] .source-preview.beaver-popup-message--unbounded {
+    max-height: none;
 }
 
 @keyframes fadeIn {

--- a/react/atoms/featureTips.ts
+++ b/react/atoms/featureTips.ts
@@ -14,6 +14,7 @@ import {
 } from './floatingPopup';
 import {
     hasSeenFeatureTip,
+    isFeatureTipDeferred,
     isWithinFeatureTipGap,
     markFeatureTipShown,
     readFeatureTipState,
@@ -46,6 +47,7 @@ export const showFeatureTipAtom = atom(
         if (!options.force) {
             const state = readFeatureTipState();
             if (hasSeenFeatureTip(state, tipId)) return false;
+            if (isFeatureTipDeferred(state, tipId, Date.now())) return false;
             if (isWithinFeatureTipGap(state, Date.now(), [
                 getPref('versionUpdatePopupShownAt'),
                 getPref('onboardingWelcomeShownAt'),

--- a/react/components/ui/popup/FeatureTourContent.tsx
+++ b/react/components/ui/popup/FeatureTourContent.tsx
@@ -3,6 +3,7 @@ import { FeatureStep, ExamplePrompt } from '../../../constants/versionUpdateMess
 import Button from '@beaver/agent-ui/primitives/Button';
 import { ArrowRightIcon } from '../../icons/icons';
 import { parseTextWithLinksAndNewlines } from '../../../utils/parseTextWithLinksAndNewlines';
+import { getVersionShowcase } from '../../../constants/versionShowcases';
 
 interface FeatureTourContentProps {
     steps: FeatureStep[];
@@ -103,7 +104,9 @@ const FeatureTourContent: React.FC<FeatureTourContentProps> = ({ steps, onComple
     }, []);
     
     if (!step) return null;
-    
+
+    const Showcase = getVersionShowcase(step.showcase);
+
     return (
         <div className="feature-tour-content display-flex flex-col gap-3 w-full">
             {/* Step content - scrollable area */}
@@ -119,7 +122,9 @@ const FeatureTourContent: React.FC<FeatureTourContentProps> = ({ steps, onComple
                         {parseTextWithLinksAndNewlines(step.description)}
                     </div>
                 )}
-                
+
+                {Showcase && <Showcase />}
+
                 {/* Example prompts - compact */}
                 {step.examplePrompts && step.examplePrompts.length > 0 && (
                     <div className="display-flex flex-col gap-3 mt-2">

--- a/react/components/ui/popup/PopupMessageItem.tsx
+++ b/react/components/ui/popup/PopupMessageItem.tsx
@@ -104,7 +104,7 @@ const PopupMessageItem: React.FC<PopupMessageItemProps> = ({ message, onRemove, 
     return (
         <div
             ref={containerRef}
-            className="source-preview border-popup shadow-md mx-0 w-full"
+            className={`source-preview border-popup shadow-md mx-0 w-full ${message.type === 'version_update' ? 'beaver-popup-message--unbounded' : ''}`}
             style={{
                 background: backgroundColor,
                 backdropFilter: 'blur(6px)',

--- a/react/components/ui/popup/VersionUpdateMessageContent.tsx
+++ b/react/components/ui/popup/VersionUpdateMessageContent.tsx
@@ -8,6 +8,7 @@ import { parseTextWithLinksAndNewlines } from '../../../utils/parseTextWithLinks
 import FeatureTourContent from './FeatureTourContent';
 import { FeatureStep } from '../../../constants/versionUpdateMessages';
 import { eventManager } from '../../../events/eventManager';
+import { getVersionShowcase } from '../../../constants/versionShowcases';
 
 interface VersionUpdateMessageContentProps {
     message: PopupMessage;
@@ -24,7 +25,8 @@ const LegacyVersionContent: React.FC<{
     learnMoreUrl?: string;
     learnMoreLabel?: string;
     footer?: string;
-}> = ({ text, featureList, learnMoreUrl, learnMoreLabel, footer }) => {
+    Showcase?: React.ComponentType;
+}> = ({ text, featureList, learnMoreUrl, learnMoreLabel, footer, Showcase }) => {
     const handleLearnMore = () => {
         if (learnMoreUrl) {
             Zotero.launchURL(learnMoreUrl);
@@ -38,6 +40,8 @@ const LegacyVersionContent: React.FC<{
                     {parseTextWithLinksAndNewlines(text)}
                 </div>
             )}
+
+            {Showcase && <Showcase />}
 
             {featureList && featureList.length > 0 && (
                 <div className="display-flex flex-col gap-4">
@@ -91,8 +95,9 @@ const FloatingVersionCard: React.FC<{
     footer?: string;
     learnMoreUrl?: string;
     learnMoreLabel?: string;
+    Showcase?: React.ComponentType;
     onDismiss: () => void;
-}> = ({ version, title, text, subtitle, features, footer, learnMoreUrl, learnMoreLabel, onDismiss }) => {
+}> = ({ version, title, text, subtitle, features, footer, learnMoreUrl, learnMoreLabel, Showcase, onDismiss }) => {
     const handleOpenBeaver = () => {
         eventManager.dispatch('toggleChat', { forceOpen: true });
         onDismiss();
@@ -151,6 +156,9 @@ const FloatingVersionCard: React.FC<{
                     {parseTextWithLinksAndNewlines(subtitle || text || '')}
                 </div>
             )}
+
+            {/* The feature itself, where the note has one to show */}
+            {Showcase && <Showcase />}
 
             {/* Feature list */}
             {features.length > 0 && (
@@ -221,6 +229,7 @@ function buildFeatureList(message: PopupMessage): PopupMessageFeature[] {
 
 const VersionUpdateMessageContent: React.FC<VersionUpdateMessageContentProps> = ({ message, onDismiss, isFloating }) => {
     const { version, text, featureList, learnMoreUrl, learnMoreLabel, footer, steps, subtitle } = message;
+    const Showcase = getVersionShowcase(message.showcase);
 
     // Floating mode: render the card layout
     if (isFloating) {
@@ -234,6 +243,7 @@ const VersionUpdateMessageContent: React.FC<VersionUpdateMessageContentProps> = 
                 footer={footer}
                 learnMoreUrl={learnMoreUrl}
                 learnMoreLabel={learnMoreLabel}
+                Showcase={Showcase}
                 onDismiss={onDismiss || (() => {})}
             />
         );
@@ -250,6 +260,7 @@ const VersionUpdateMessageContent: React.FC<VersionUpdateMessageContentProps> = 
                         {parseTextWithLinksAndNewlines(subtitle)}
                     </p>
                 )}
+                {Showcase && <Showcase />}
                 <FeatureTourContent
                     steps={steps as FeatureStep[]}
                     onComplete={onDismiss || (() => {})}
@@ -260,7 +271,7 @@ const VersionUpdateMessageContent: React.FC<VersionUpdateMessageContentProps> = 
     }
 
     // Legacy format
-    if (!text && (!featureList || featureList.length === 0) && !learnMoreUrl) {
+    if (!text && (!featureList || featureList.length === 0) && !learnMoreUrl && !Showcase) {
         return null;
     }
 
@@ -271,6 +282,7 @@ const VersionUpdateMessageContent: React.FC<VersionUpdateMessageContentProps> = 
             learnMoreUrl={learnMoreUrl}
             learnMoreLabel={learnMoreLabel}
             footer={footer}
+            Showcase={Showcase}
         />
     );
 };

--- a/react/components/ui/popup/showcases/QuickPromptShowcase.tsx
+++ b/react/components/ui/popup/showcases/QuickPromptShowcase.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Button from '@beaver/agent-ui/primitives/Button';
+import {
+    ArrowDownIcon,
+    ArrowRightIcon,
+    ArrowUpLineIcon,
+    ArrowUpRightIcon,
+    BrainIcon,
+    CheckmarkCircleIcon,
+    GlobalSearchIcon,
+    Icon,
+    NoteIcon,
+    PdfIcon,
+    PlusSignIcon,
+} from '../../../icons/icons';
+import RunPulse from '../../../runStatusPopup/RunPulse';
+import { quickPromptShortcutKeys } from '../../../../utils/quickPromptShortcut';
+
+/** The prompt the showcase types, and what the run makes of it. */
+const PROMPT = 'Summarize the key findings and save them as a note';
+const THREAD_NAME = 'Key findings summary';
+const STATUS_LINES = ['Reading Sampson 2012, p. 31-48', 'Writing the note'];
+const NOTE_TITLE = 'Key findings: Sampson 2012';
+
+/** The compact control sizing the corner cards' footers share. */
+const FOOTER_BUTTON_STYLE: React.CSSProperties = { padding: '2px 10px', fontSize: '0.875rem', whiteSpace: 'nowrap' };
+
+type Scene = 'shortcut' | 'compose' | 'running' | 'completed';
+
+interface Frame {
+    scene: Scene;
+    /** Shortcut: the keys are down. */
+    pressed?: boolean;
+    /** Compose: how much of the prompt has been typed. */
+    typed?: number;
+    /** Compose: the send button is being pressed. */
+    sending?: boolean;
+    /** Running: which status line is up. */
+    status?: number;
+}
+
+interface Beat {
+    frame: Frame;
+    holdMs: number;
+}
+
+const TYPING_MS_PER_CHAR = 28;
+
+/**
+ * The story, beat by beat: the chord is pressed, the composer opens in the
+ * corner and the prompt is typed and sent, the run's card takes its place
+ * and works, and the result is there. Then it starts over.
+ */
+function buildTimeline(): Beat[] {
+    const beats: Beat[] = [
+        { frame: { scene: 'shortcut', pressed: false }, holdMs: 700 },
+        { frame: { scene: 'shortcut', pressed: true }, holdMs: 450 },
+        { frame: { scene: 'compose', typed: 0 }, holdMs: 600 },
+    ];
+    for (let typed = 1; typed <= PROMPT.length; typed++) {
+        beats.push({ frame: { scene: 'compose', typed }, holdMs: TYPING_MS_PER_CHAR });
+    }
+    beats.push(
+        { frame: { scene: 'compose', typed: PROMPT.length }, holdMs: 500 },
+        { frame: { scene: 'compose', typed: PROMPT.length, sending: true }, holdMs: 260 },
+        { frame: { scene: 'running', status: 0 }, holdMs: 1700 },
+        { frame: { scene: 'running', status: 1 }, holdMs: 1500 },
+        { frame: { scene: 'completed' }, holdMs: 3200 },
+    );
+    return beats;
+}
+
+const TIMELINE = buildTimeline();
+
+/** The same story as stills, for a user who asked for less motion. */
+const STILL_TIMELINE: Beat[] = [
+    { frame: { scene: 'shortcut', pressed: true }, holdMs: 2500 },
+    { frame: { scene: 'compose', typed: PROMPT.length }, holdMs: 3500 },
+    { frame: { scene: 'running', status: 0 }, holdMs: 3000 },
+    { frame: { scene: 'completed' }, holdMs: 4000 },
+];
+
+/**
+ * Plays the timeline on the window the showcase is drawn in, looping until
+ * the showcase goes away. The timers are the window's own: a popup can be
+ * drawn in either main window, and a timer scheduled elsewhere would outlive
+ * the one that closes.
+ */
+function useTimeline(rootRef: React.RefObject<HTMLElement>): Frame {
+    const [frame, setFrame] = useState<Frame>(TIMELINE[0].frame);
+    useEffect(() => {
+        const win = rootRef.current?.ownerDocument.defaultView;
+        if (!win) return;
+        const reducedMotion = win.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
+        const beats = reducedMotion ? STILL_TIMELINE : TIMELINE;
+        let index = 0;
+        let timer: number | null = null;
+        const play = () => {
+            setFrame(beats[index].frame);
+            timer = win.setTimeout(() => {
+                index = (index + 1) % beats.length;
+                play();
+            }, beats[index].holdMs);
+        };
+        play();
+        return () => {
+            if (timer !== null) win.clearTimeout(timer);
+        };
+    }, [rootRef]);
+    return frame;
+}
+
+const Chord: React.FC<{ keys: string[]; pressed: boolean }> = ({ keys, pressed }) => (
+    <div className={`beaver-showcase__chord ${pressed ? 'beaver-showcase__chord--pressed' : ''}`}>
+        {keys.map((key) => (
+            <span key={key} className="beaver-showcase__key">{key}</span>
+        ))}
+    </div>
+);
+
+/**
+ * The quick prompt's card, built from the real card's and composer's
+ * classes: the open file attached, the prompt being typed, and the control
+ * row with Send lighting up once there is something to send.
+ */
+const ComposerCard: React.FC<{ typed: string; sending: boolean }> = ({ typed, sending }) => (
+    <div className="beaver-quick-prompt__card">
+        <div className="beaver-quick-prompt__composer">
+            <div className="user-message-display">
+                <div className="composer-attachments">
+                    <span className="variant-outline source-button">
+                        <span className="chip-icon-slot">
+                            <Icon icon={PdfIcon} size={14} className="font-color-secondary" />
+                        </span>
+                        <span className="truncate">Current File</span>
+                    </span>
+                </div>
+                <div className="mb-2">
+                    <div className="beaver-showcase__editor">
+                        {typed ? (
+                            <>
+                                {typed}
+                                <span className="beaver-showcase__caret" />
+                            </>
+                        ) : (
+                            <span className="beaver-showcase__placeholder">
+                                <span className="beaver-showcase__caret" />
+                                Ask Beaver
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <div className="composer-controls">
+                    <button type="button" className="variant-ghost composer-add-sources" tabIndex={-1}>
+                        <Icon icon={PlusSignIcon} size={18} className="scale-13" />
+                    </button>
+                    <button type="button" className="variant-ghost-secondary beaver-showcase__model" tabIndex={-1}>
+                        <Icon icon={BrainIcon} />
+                        Auto
+                        <Icon icon={ArrowDownIcon} className="scale-11 -ml-1" />
+                    </button>
+                    <div className="flex-1" />
+                    <button type="button" className="variant-ghost-secondary icon-only composer-icons" tabIndex={-1}>
+                        <Icon icon={GlobalSearchIcon} />
+                    </button>
+                    <button
+                        type="button"
+                        className={`variant-solid icon-only composer-send ${sending ? 'beaver-showcase__send--pressed' : ''}`}
+                        disabled={typed.length === 0}
+                        tabIndex={-1}
+                    >
+                        <Icon icon={ArrowUpLineIcon} />
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+/** The run status card's frame, from the real card's classes. */
+const RunCard: React.FC<{ leading: React.ReactNode; detail?: React.ReactNode; children?: React.ReactNode }> = ({ leading, detail, children }) => (
+    <div className="beaver-run-status-popup__card beaver-showcase__run-card">
+        <div className="beaver-run-status-popup__content">
+            <div className="beaver-run-status-popup__header">
+                <div className="beaver-run-status-popup__leading">{leading}</div>
+                <div className="beaver-run-status-popup__text">
+                    <div className="beaver-run-status-popup__title font-color-primary">{THREAD_NAME}</div>
+                    {detail && <div className="beaver-run-status-popup__detail font-color-secondary">{detail}</div>}
+                </div>
+            </div>
+            {children}
+        </div>
+    </div>
+);
+
+const RunningCard: React.FC<{ status: number }> = ({ status }) => (
+    <RunCard leading={<RunPulse />} detail={<span className="shimmer-text">{STATUS_LINES[status] ?? STATUS_LINES[0]}</span>} />
+);
+
+const CompletedCard: React.FC = () => (
+    <RunCard leading={<Icon icon={CheckmarkCircleIcon} size={16} className="font-color-green" />}>
+        <div className="beaver-run-status-popup__rows">
+            <button type="button" className="beaver-run-status-popup__row" tabIndex={-1}>
+                <Icon icon={NoteIcon} className="font-color-secondary" />
+                <span className="beaver-run-status-popup__row-text">
+                    <span className="font-color-primary font-medium">Created Note</span>
+                    <span className="font-color-secondary"> {NOTE_TITLE}</span>
+                </span>
+                <Icon icon={ArrowUpRightIcon} className="font-color-tertiary beaver-run-status-popup__row-arrow" />
+            </button>
+        </div>
+        <div className="beaver-run-status-popup__footer">
+            <div className="flex-1" />
+            <Button variant="outline" style={FOOTER_BUTTON_STYLE} rightIcon={ArrowRightIcon} tabIndex={-1}>
+                Open Beaver
+            </Button>
+        </div>
+    </RunCard>
+);
+
+/**
+ * The release note's visual for the quick prompt: the feature played out in
+ * a slot on the note — the shortcut, the composer it opens, the run's card
+ * that takes over once the prompt is sent, and the result. The cards are
+ * drawn from the real cards' classes, so they look like what the user will
+ * see. Purely decorative: nothing in it takes the pointer or focus.
+ */
+const QuickPromptShowcase: React.FC = () => {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const frame = useTimeline(rootRef);
+    const keys = quickPromptShortcutKeys();
+
+    return (
+        <div ref={rootRef} className="beaver-showcase" data-scene={frame.scene} aria-hidden="true">
+            <div className="beaver-showcase__stage">
+                {frame.scene === 'shortcut' ? (
+                    <Chord keys={keys} pressed={!!frame.pressed} />
+                ) : (
+                    // Keyed on the scene so each card arrives with its own entrance.
+                    <div
+                        key={frame.scene}
+                        className={`beaver-showcase__card ${frame.scene === 'compose' ? 'beaver-quick-prompt' : 'beaver-run-status-popup'}`}
+                    >
+                        {frame.scene === 'compose' && (
+                            <ComposerCard typed={PROMPT.slice(0, frame.typed ?? 0)} sending={!!frame.sending} />
+                        )}
+                        {frame.scene === 'running' && <RunningCard status={frame.status ?? 0} />}
+                        {frame.scene === 'completed' && <CompletedCard />}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default QuickPromptShowcase;

--- a/react/constants/versionShowcases.ts
+++ b/react/constants/versionShowcases.ts
@@ -1,0 +1,18 @@
+/**
+ * The visuals a release note can carry: what each `showcase` id in
+ * `versionUpdateMessages.ts` draws.
+ *
+ * Kept apart from the version list because the plugin bundle reads that list
+ * at startup to queue the notifications, and must not pull React in with it.
+ */
+import type React from 'react';
+import type { VersionShowcaseId } from './versionUpdateMessages';
+import QuickPromptShowcase from '../components/ui/popup/showcases/QuickPromptShowcase';
+
+export const VERSION_SHOWCASES: Record<VersionShowcaseId, React.ComponentType> = {
+    'quick-prompt': QuickPromptShowcase,
+};
+
+export function getVersionShowcase(id: VersionShowcaseId | undefined): React.ComponentType | undefined {
+    return id ? VERSION_SHOWCASES[id] : undefined;
+}

--- a/react/constants/versionUpdateMessages.ts
+++ b/react/constants/versionUpdateMessages.ts
@@ -1,5 +1,6 @@
 import { PopupMessageFeature } from '../types/popupMessage';
 import { compareVersions } from '../../src/utils/compareVersions';
+import type { FeatureTipId } from './featureTips';
 
 /**
  * A visual a release note can carry — what `react/constants/versionShowcases.ts`
@@ -43,6 +44,8 @@ export interface FeatureStep {
  */
 export interface VersionUpdateMessageConfig {
     version: string;
+    /** Delay related tips from when this release notification is shown, in milliseconds. */
+    deferFeatureTips?: Partial<Record<FeatureTipId, number>>;
     title: string;
     /** Subtitle/intro text shown on the first screen */
     subtitle?: string;
@@ -584,6 +587,7 @@ const versionUpdateMessageList: VersionUpdateMessageConfig[] = [
     },
     {
         version: "0.25.0",
+        deferFeatureTips: { 'run-status-popup': 7 * 24 * 60 * 60 * 1000 },
         title: "Introducing Quick Prompt",
         text: "Press {{quickPromptShortcut}} to open a composer in the corner. Beaver works while you stay in Zotero: the card shows progress, asks for approvals, and reports the result.",
         showcase: 'quick-prompt',

--- a/react/constants/versionUpdateMessages.ts
+++ b/react/constants/versionUpdateMessages.ts
@@ -2,6 +2,13 @@ import { PopupMessageFeature } from '../types/popupMessage';
 import { compareVersions } from '../../src/utils/compareVersions';
 
 /**
+ * A visual a release note can carry — what `react/constants/versionShowcases.ts`
+ * draws for the id. An id rather than the component: this list is read by the
+ * plugin bundle at startup, which has no React.
+ */
+export type VersionShowcaseId = 'quick-prompt';
+
+/**
  * Example prompt shown as a chat bubble in the feature tour
  */
 export interface ExamplePrompt {
@@ -23,10 +30,17 @@ export interface FeatureStep {
     description?: string;
     /** Example prompts shown as chat bubbles */
     examplePrompts?: ExamplePrompt[];
+    /** A visual between the description and the prompts — the feature itself. */
+    showcase?: VersionShowcaseId;
     /** URL to learn more about this feature */
     learnMoreUrl?: string;
 }
 
+/**
+ * The copy fields (`text`, `subtitle`, descriptions) may use
+ * `{{quickPromptShortcut}}` for the quick prompt chord on the user's machine;
+ * it is filled when the note is built (`react/utils/versionUpdatePopup.ts`).
+ */
 export interface VersionUpdateMessageConfig {
     version: string;
     title: string;
@@ -38,6 +52,8 @@ export interface VersionUpdateMessageConfig {
     featureList?: PopupMessageFeature[];
     /** Feature steps for the guided tour (new format) */
     steps?: FeatureStep[];
+    /** A visual under the intro text — the feature itself, not a description of it. */
+    showcase?: VersionShowcaseId;
     learnMoreUrl?: string;
     learnMoreLabel?: string;
     footer?: string;
@@ -566,7 +582,14 @@ const versionUpdateMessageList: VersionUpdateMessageConfig[] = [
         ],
         footer: `<a href="https://github.com/jlegewie/beaver-zotero/releases/tag/v0.24.0" target='_blank'>Full changelog</a>`,
     },
-
+    {
+        version: "0.25.0",
+        title: "Introducing Quick Prompt",
+        text: "Press {{quickPromptShortcut}} to open a composer in the corner. Beaver works while you stay in Zotero: the card shows progress, asks for approvals, and reports the result.",
+        showcase: 'quick-prompt',
+        inPanel: false,
+        footer: `<a href="https://github.com/jlegewie/beaver-zotero/releases/tag/v0.25.0" target='_blank'>Full changelog</a>`,
+    },
 ];
 
 versionUpdateMessageList.sort((a, b) => compareVersions(a.version, b.version));

--- a/react/hooks/httpHandlers/testVersionPopupHandlers.ts
+++ b/react/hooks/httpHandlers/testVersionPopupHandlers.ts
@@ -1,0 +1,35 @@
+/**
+ * Dev-only HTTP handler for the release notes popup.
+ *
+ * `/beaver/test/version-popup` shows a version's release note without an
+ * upgrade: `{ version?: '0.25.0', inPanel?: boolean }` draws it (the newest
+ * configured version by default, where its config says unless overridden),
+ * and `{ clear: true }` takes it down. Wired to its path in
+ * `useHttpEndpoints.ts`.
+ */
+
+import { store } from '../../store';
+import { addPopupMessageAtom, removePopupMessageAtom } from '../../utils/popupMessageUtils';
+import { addFloatingPopupMessageAtom, removeFloatingPopupMessageAtom } from '../../atoms/floatingPopup';
+import { getAllVersionUpdateMessageVersions, getVersionUpdateMessageConfig } from '../../constants/versionUpdateMessages';
+import { versionUpdatePopupMessage } from '../../utils/versionUpdatePopup';
+
+const MESSAGE_ID = 'dev:version-popup';
+
+export async function handleTestVersionPopupHttpRequest(request: any): Promise<any> {
+    store.set(removePopupMessageAtom, MESSAGE_ID);
+    store.set(removeFloatingPopupMessageAtom, MESSAGE_ID);
+    if (request?.clear) return { shown: null };
+
+    const versions = getAllVersionUpdateMessageVersions();
+    const version = typeof request?.version === 'string' ? request.version : versions[versions.length - 1];
+    const config = getVersionUpdateMessageConfig(version);
+    if (!config) throw new Error(`No release note for version ${version} (known: ${versions.join(', ')})`);
+
+    const inPanel = typeof request?.inPanel === 'boolean' ? request.inPanel : !!config.inPanel;
+    store.set(inPanel ? addPopupMessageAtom : addFloatingPopupMessageAtom, {
+        ...versionUpdatePopupMessage(config),
+        id: MESSAGE_ID,
+    });
+    return { shown: { version, inPanel } };
+}

--- a/react/hooks/useHttpEndpoints.ts
+++ b/react/hooks/useHttpEndpoints.ts
@@ -54,6 +54,7 @@ import {
     handleReadNoteRequest,
 } from '../../src/services/agentDataProvider';
 import { handleTestVoiceHttpRequest } from './httpHandlers/testVoiceHandlers';
+import { handleTestVersionPopupHttpRequest } from './httpHandlers/testVersionPopupHandlers';
 import {
     handleTestPingHttpRequest,
     handleTestCacheMetadataHttpRequest,
@@ -1334,6 +1335,9 @@ function registerEndpoints(): (() => void) | undefined {
 
         endpoints['/beaver/test/quick-prompt'] =
             createEndpoint(handleTestQuickPromptHttpRequest);
+
+        endpoints['/beaver/test/version-popup'] =
+            createEndpoint(handleTestVersionPopupHttpRequest);
 
         endpoints['/beaver/test/saved-actions'] =
             createEndpoint(handleTestListSavedActionsHttpRequest);

--- a/react/hooks/useUpgradeHandler.ts
+++ b/react/hooks/useUpgradeHandler.ts
@@ -8,6 +8,7 @@ import { getPendingVersionNotifications, clearPendingVersionNotifications } from
 import { compareVersions } from '../../src/utils/compareVersions';
 import { getVersionUpdateMessageConfig } from '../constants/versionUpdateMessages';
 import { versionUpdatePopupMessage } from '../utils/versionUpdatePopup';
+import { deferFeatureTips } from '../utils/featureTipPrefs';
 
 /**
  * Hook to handle tasks that need to run after a plugin upgrade.
@@ -50,6 +51,7 @@ export const useUpgradeHandler = () => {
             setPref('versionUpdatePopupShownAt', new Date().toISOString());
 
             addFloatingPopupMessage(versionUpdatePopupMessage(latestFloating));
+            if (latestFloating.deferFeatureTips) deferFeatureTips(latestFloating.deferFeatureTips, Date.now());
         }
 
         if (latestInPanel) {
@@ -57,6 +59,7 @@ export const useUpgradeHandler = () => {
             logger(`useUpgradeHandler: Displaying in-panel release notes for version ${latestInPanel.version}.`, 3);
 
             addPopupMessage(versionUpdatePopupMessage(latestInPanel));
+            if (latestInPanel.deferFeatureTips) deferFeatureTips(latestInPanel.deferFeatureTips, Date.now());
         }
 
         if (!latestFloating && !latestInPanel && sorted.length > 0) {

--- a/react/hooks/useUpgradeHandler.ts
+++ b/react/hooks/useUpgradeHandler.ts
@@ -7,6 +7,7 @@ import { addPopupMessageAtom } from '../utils/popupMessageUtils';
 import { getPendingVersionNotifications, clearPendingVersionNotifications } from '../../src/utils/versionNotificationPrefs';
 import { compareVersions } from '../../src/utils/compareVersions';
 import { getVersionUpdateMessageConfig } from '../constants/versionUpdateMessages';
+import { versionUpdatePopupMessage } from '../utils/versionUpdatePopup';
 
 /**
  * Hook to handle tasks that need to run after a plugin upgrade.
@@ -48,38 +49,14 @@ export const useUpgradeHandler = () => {
             // Record when the version popup is shown so onboarding tips can enforce a gap after it
             setPref('versionUpdatePopupShownAt', new Date().toISOString());
 
-            addFloatingPopupMessage({
-                type: 'version_update',
-                version: latestFloating.version,
-                title: latestFloating.title,
-                text: latestFloating.text,
-                featureList: latestFloating.featureList,
-                learnMoreUrl: latestFloating.learnMoreUrl,
-                learnMoreLabel: latestFloating.learnMoreLabel,
-                footer: latestFloating.footer,
-                steps: latestFloating.steps,
-                subtitle: latestFloating.subtitle,
-                expire: false,
-            });
+            addFloatingPopupMessage(versionUpdatePopupMessage(latestFloating));
         }
 
         if (latestInPanel) {
             processedVersionsRef.current.add(latestInPanel.version);
             logger(`useUpgradeHandler: Displaying in-panel release notes for version ${latestInPanel.version}.`, 3);
 
-            addPopupMessage({
-                type: 'version_update',
-                version: latestInPanel.version,
-                title: latestInPanel.title,
-                text: latestInPanel.text,
-                featureList: latestInPanel.featureList,
-                learnMoreUrl: latestInPanel.learnMoreUrl,
-                learnMoreLabel: latestInPanel.learnMoreLabel,
-                footer: latestInPanel.footer,
-                steps: latestInPanel.steps,
-                subtitle: latestInPanel.subtitle,
-                expire: false,
-            });
+            addPopupMessage(versionUpdatePopupMessage(latestInPanel));
         }
 
         if (!latestFloating && !latestInPanel && sorted.length > 0) {

--- a/react/types/popupMessage.ts
+++ b/react/types/popupMessage.ts
@@ -1,5 +1,5 @@
 import { FileStatusSummary } from "./fileStatus";
-import { FeatureStep } from "../constants/versionUpdateMessages";
+import { FeatureStep, VersionShowcaseId } from "../constants/versionUpdateMessages";
 import { ButtonVariant } from "@beaver/agent-ui/primitives/Button";
 import type { FeatureTipId } from "../constants/featureTips";
 
@@ -53,4 +53,6 @@ export interface PopupMessage {
     steps?: FeatureStep[];
     /** Subtitle shown below the title in step-based tours */
     subtitle?: string;
+    /** The visual a version update message carries — see `react/constants/versionShowcases.ts`. */
+    showcase?: VersionShowcaseId;
 }

--- a/react/utils/featureTipPrefs.ts
+++ b/react/utils/featureTipPrefs.ts
@@ -14,6 +14,8 @@ export interface FeatureTipState {
     shown: Record<string, string>;
     /** When the newest tip of any kind was shown. */
     lastShownAt?: string;
+    /** Earliest eligible time for each postponed tip, as ISO timestamps. */
+    deferredUntil?: Record<string, string>;
 }
 
 /** The gap kept between two feature tips, whichever they are. */
@@ -32,6 +34,12 @@ export function parseFeatureTipState(raw: unknown): FeatureTipState {
             if (typeof at === 'string') state.shown[id] = at;
         }
         if (typeof parsed.lastShownAt === 'string') state.lastShownAt = parsed.lastShownAt;
+        if (parsed.deferredUntil && typeof parsed.deferredUntil === 'object') {
+            state.deferredUntil = {};
+            for (const [id, at] of Object.entries(parsed.deferredUntil)) {
+                if (typeof at === 'string' && Number.isFinite(Date.parse(at))) state.deferredUntil[id] = at;
+            }
+        }
         return state;
     } catch {
         return { shown: {} };
@@ -40,6 +48,23 @@ export function parseFeatureTipState(raw: unknown): FeatureTipState {
 
 export function hasSeenFeatureTip(state: FeatureTipState, tipId: string): boolean {
     return tipId in state.shown;
+}
+
+export function isFeatureTipDeferred(state: FeatureTipState, tipId: string, now: number): boolean {
+    const until = state.deferredUntil?.[tipId];
+    return !!until && Date.parse(until) > now;
+}
+
+/** Postpones selected tips without marking them seen or delaying unrelated tips. */
+export function deferFeatureTips(delays: Readonly<Record<string, number>>, now: number): void {
+    const state = readFeatureTipState();
+    const deferredUntil = { ...state.deferredUntil };
+    for (const [id, delayMs] of Object.entries(delays)) {
+        if (!Number.isFinite(delayMs) || delayMs <= 0) continue;
+        const previous = Date.parse(deferredUntil[id] ?? '');
+        deferredUntil[id] = new Date(Math.max(now + delayMs, Number.isFinite(previous) ? previous : 0)).toISOString();
+    }
+    writeFeatureTipState({ ...state, deferredUntil });
 }
 
 /**
@@ -66,7 +91,7 @@ export function isWithinFeatureTipGap(
 
 export function markFeatureTipShown(state: FeatureTipState, tipId: string, now: number): FeatureTipState {
     const at = new Date(now).toISOString();
-    return { shown: { ...state.shown, [tipId]: at }, lastShownAt: at };
+    return { ...state, shown: { ...state.shown, [tipId]: at }, lastShownAt: at };
 }
 
 export function readFeatureTipState(): FeatureTipState {

--- a/react/utils/quickPromptShortcut.ts
+++ b/react/utils/quickPromptShortcut.ts
@@ -1,0 +1,23 @@
+/**
+ * The quick prompt chord as the user should read it: Cmd+Option+<key> on
+ * macOS, Ctrl+Alt+<key> elsewhere, with the key the user configured for
+ * Beaver's shortcuts. The chord itself is matched in `src/utils/shortcuts.ts`;
+ * this is its display form, shared by everything that names it.
+ */
+import { getPref } from '../../src/utils/prefs';
+
+function shortcutKey(): string {
+    return (getPref('keyboardShortcut') || 'j').toUpperCase();
+}
+
+/** The chord key by key, for drawing keycaps. */
+export function quickPromptShortcutKeys(): string[] {
+    const key = shortcutKey();
+    return Zotero.isMac ? ['⌘', '⌥', key] : ['Ctrl', 'Alt', key];
+}
+
+/** The chord as one piece of text. */
+export function quickPromptShortcutLabel(): string {
+    const key = shortcutKey();
+    return Zotero.isMac ? `⌘⌥${key}` : `Ctrl+Alt+${key}`;
+}

--- a/react/utils/versionUpdatePopup.ts
+++ b/react/utils/versionUpdatePopup.ts
@@ -1,0 +1,38 @@
+import type { PopupMessage } from '../types/popupMessage';
+import type { VersionUpdateMessageConfig } from '../constants/versionUpdateMessages';
+import { quickPromptShortcutLabel } from './quickPromptShortcut';
+
+/**
+ * Placeholders a release note's copy may use for what differs per machine.
+ * Filled here, where the note is built, so the version list stays static text.
+ */
+const PLACEHOLDERS: Record<string, () => string> = {
+    '{{quickPromptShortcut}}': quickPromptShortcutLabel,
+};
+
+function fillPlaceholders<T extends string | undefined>(text: T): T {
+    if (!text) return text;
+    let filled: string = text;
+    for (const [token, value] of Object.entries(PLACEHOLDERS)) {
+        if (filled.includes(token)) filled = filled.split(token).join(value());
+    }
+    return filled as T;
+}
+
+/** The popup message for a release note, the same whether it floats or sits in the panel. */
+export function versionUpdatePopupMessage(config: VersionUpdateMessageConfig): Omit<PopupMessage, 'id'> {
+    return {
+        type: 'version_update',
+        version: config.version,
+        title: config.title,
+        text: fillPlaceholders(config.text),
+        featureList: config.featureList?.map((feature) => ({ ...feature, description: fillPlaceholders(feature.description) })),
+        learnMoreUrl: config.learnMoreUrl,
+        learnMoreLabel: config.learnMoreLabel,
+        footer: config.footer,
+        steps: config.steps?.map((step) => ({ ...step, description: fillPlaceholders(step.description) })),
+        subtitle: fillPlaceholders(config.subtitle),
+        showcase: config.showcase,
+        expire: false,
+    };
+}

--- a/tests/unit/components/popup/QuickPromptShowcase.test.ts
+++ b/tests/unit/components/popup/QuickPromptShowcase.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+/**
+ * The quick prompt showcase: the feature played through on a loop.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ prefs: {} as Record<string, unknown> }));
+
+vi.mock('../../../../src/utils/prefs', () => ({
+    getPref: (key: string) => mocks.prefs[key],
+    setPref: (key: string, value: unknown) => { mocks.prefs[key] = value; },
+}));
+
+import QuickPromptShowcase from '../../../../react/components/ui/popup/showcases/QuickPromptShowcase';
+
+let root: Root | null = null;
+let container: HTMLDivElement;
+
+function mount() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => { root!.render(React.createElement(QuickPromptShowcase)); });
+}
+
+const scene = () => container.querySelector('.beaver-showcase')?.getAttribute('data-scene');
+const editorText = () => container.querySelector('.beaver-showcase__editor')?.textContent ?? '';
+const keys = () => Array.from(container.querySelectorAll('.beaver-showcase__key')).map((key) => key.textContent);
+
+/** Plays until the showcase reaches the scene, or fails if it never does. */
+function playUntil(target: string, maxMs = 30_000) {
+    let elapsed = 0;
+    while (scene() !== target && elapsed < maxMs) {
+        act(() => { vi.advanceTimersByTime(50); });
+        elapsed += 50;
+    }
+    expect(scene()).toBe(target);
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    (globalThis as any).Zotero = { isMac: true };
+    mocks.prefs = { keyboardShortcut: 'j' };
+});
+
+afterEach(() => {
+    act(() => { root?.unmount(); });
+    root = null;
+    container.remove();
+    delete (globalThis as any).Zotero;
+    vi.useRealTimers();
+});
+
+describe('QuickPromptShowcase', () => {
+    it('plays the feature through — shortcut, composer, run, result — and starts over', () => {
+        mount();
+        expect(scene()).toBe('shortcut');
+        expect(keys()).toEqual(['⌘', '⌥', 'J']);
+
+        playUntil('compose');
+        expect(editorText()).toBe('Ask Beaver');
+        expect(container.querySelector<HTMLButtonElement>('.composer-send')?.disabled).toBe(true);
+
+        let elapsed = 0;
+        while (!editorText().endsWith('as a note') && elapsed < 10_000) {
+            act(() => { vi.advanceTimersByTime(50); });
+            elapsed += 50;
+        }
+        expect(editorText()).toBe('Summarize the key findings and save them as a note');
+        expect(container.querySelector<HTMLButtonElement>('.composer-send')?.disabled).toBe(false);
+
+        playUntil('running');
+        expect(container.querySelector('.shimmer-text')?.textContent).toBe('Reading Sampson 2012, p. 31-48');
+
+        playUntil('completed');
+        expect(container.textContent).toContain('Created Note');
+        expect(container.textContent).toContain('Open Beaver');
+
+        playUntil('shortcut');
+    });
+
+    it('draws the chord for the platform and the configured key', () => {
+        (globalThis as any).Zotero = { isMac: false };
+        mocks.prefs = { keyboardShortcut: 'k' };
+        mount();
+        expect(keys()).toEqual(['Ctrl', 'Alt', 'K']);
+    });
+
+    it('takes nothing with it: no pointer, no focus, no timers once gone', () => {
+        mount();
+        expect(container.querySelector('.beaver-showcase')?.getAttribute('aria-hidden')).toBe('true');
+        act(() => { vi.advanceTimersByTime(500); });
+        act(() => { root?.unmount(); });
+        root = null;
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/tests/unit/components/popup/VersionUpdateMessageContent.test.ts
+++ b/tests/unit/components/popup/VersionUpdateMessageContent.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+/**
+ * Where a release note's showcase is drawn, in each of the note's layouts.
+ */
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../react/events/eventManager', () => ({ eventManager: { dispatch: vi.fn() } }));
+vi.mock('../../../../react/constants/versionShowcases', async () => {
+    const React = await import('react');
+    const Stub: React.FC = () => React.createElement('div', { 'data-showcase': 'quick-prompt' }, 'showcase');
+    return { getVersionShowcase: (id?: string) => (id === 'quick-prompt' ? Stub : undefined) };
+});
+
+import VersionUpdateMessageContent from '../../../../react/components/ui/popup/VersionUpdateMessageContent';
+import type { PopupMessage } from '../../../../react/types/popupMessage';
+
+let root: Root | null = null;
+let container: HTMLDivElement;
+
+function render(message: Partial<PopupMessage>, isFloating = false) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+        root!.render(React.createElement(VersionUpdateMessageContent, {
+            message: { id: 'm', type: 'version_update', version: '0.25.0', ...message } as PopupMessage,
+            onDismiss: () => {},
+            isFloating,
+        }));
+    });
+}
+
+const showcases = () => container.querySelectorAll('[data-showcase]').length;
+/** What comes before and after the showcase, in document order. */
+const order = () => Array.from(container.querySelectorAll('[data-showcase], [data-order]')).map((el) => el.textContent);
+
+beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    (globalThis as any).Zotero = { launchURL: vi.fn() };
+});
+
+afterEach(() => {
+    act(() => { root?.unmount(); });
+    root = null;
+    container.remove();
+    delete (globalThis as any).Zotero;
+});
+
+describe('VersionUpdateMessageContent', () => {
+    it('draws the showcase under the intro of a floating note, above its feature list', () => {
+        render({ title: 'T', text: 'Intro', featureList: [{ title: 'Feature' }], showcase: 'quick-prompt' }, true);
+        expect(showcases()).toBe(1);
+        const text = container.textContent ?? '';
+        expect(text.indexOf('Intro')).toBeLessThan(text.indexOf('showcase'));
+        expect(text.indexOf('showcase')).toBeLessThan(text.indexOf('Feature'));
+    });
+
+    it('draws it in an in-panel note, with or without text beside it', () => {
+        render({ text: 'Intro', showcase: 'quick-prompt' });
+        expect(showcases()).toBe(1);
+        act(() => { root?.unmount(); });
+        container.remove();
+
+        render({ showcase: 'quick-prompt' });
+        expect(showcases()).toBe(1);
+    });
+
+    it('draws a step tour\'s showcases: the note\'s above the tour, a step\'s inside its step', () => {
+        render({
+            subtitle: 'Sub',
+            showcase: 'quick-prompt',
+            steps: [{ title: 'One', showcase: 'quick-prompt' }, { title: 'Two' }],
+        });
+        expect(showcases()).toBe(2);
+
+        act(() => { container.querySelector<HTMLButtonElement>('.step-indicator-dot:nth-child(2)')?.click(); });
+        expect(container.textContent).toContain('Two');
+        expect(showcases()).toBe(1);
+    });
+
+    it('draws nothing extra for a note without one', () => {
+        render({ title: 'T', text: 'Intro' }, true);
+        expect(showcases()).toBe(0);
+        expect(order()).toEqual([]);
+    });
+});

--- a/tests/unit/featureTips/featureTipPrefs.test.ts
+++ b/tests/unit/featureTips/featureTipPrefs.test.ts
@@ -21,6 +21,8 @@ describe('parseFeatureTipState', () => {
         expect(parseFeatureTipState('')).toEqual({ shown: {} });
         expect(parseFeatureTipState('not json')).toEqual({ shown: {} });
         expect(parseFeatureTipState(undefined)).toEqual({ shown: {} });
+        expect(parseFeatureTipState(JSON.stringify({ deferredUntil: { a: '2026-01-01T00:00:00.000Z', b: 5, c: 'bad' } })))
+            .toEqual({ shown: {}, deferredUntil: { a: '2026-01-01T00:00:00.000Z' } });
         expect(parseFeatureTipState('{"shown":{"a":"2026-01-01T00:00:00.000Z","b":5},"lastShownAt":"2026-01-01T00:00:00.000Z"}'))
             .toEqual({ shown: { a: '2026-01-01T00:00:00.000Z' }, lastShownAt: '2026-01-01T00:00:00.000Z' });
     });

--- a/tests/unit/featureTips/showFeatureTip.test.ts
+++ b/tests/unit/featureTips/showFeatureTip.test.ts
@@ -20,6 +20,8 @@ vi.mock('../../../react/constants/featureTips', () => ({
 import { dismissFeatureTipAtom, showFeatureTipAtom } from '../../../react/atoms/featureTips';
 import { popupMessagesAtom } from '../../../react/atoms/ui';
 import { floatingPopupMessagesAtom } from '../../../react/atoms/floatingPopup';
+import { getVersionUpdateMessageConfig } from '../../../react/constants/versionUpdateMessages';
+import { deferFeatureTips, isFeatureTipDeferred, markFeatureTipShown, readFeatureTipState, writeFeatureTipState } from '../../../react/utils/featureTipPrefs';
 
 let store = createStore();
 const inPanel = () => store.get(popupMessagesAtom).map((m) => m.id);
@@ -32,6 +34,37 @@ beforeEach(() => {
 });
 
 describe('showFeatureTipAtom', () => {
+    it('postpones the quick prompt release tip for seven days without marking it seen', () => {
+        vi.useFakeTimers();
+        const now = Date.UTC(2026, 8, 9);
+        vi.setSystemTime(now);
+        const delays = getVersionUpdateMessageConfig('0.25.0')!.deferFeatureTips!;
+        deferFeatureTips(delays, now);
+        expect(readFeatureTipState().shown).toEqual({});
+        expect(readFeatureTipState().lastShownAt).toBeUndefined();
+        expect(isFeatureTipDeferred(readFeatureTipState(), 'other', now)).toBe(false);
+
+        // Showing another tip must preserve the pending deferral.
+        writeFeatureTipState(markFeatureTipShown(readFeatureTipState(), 'other', now));
+        const until = now + 7 * 24 * 60 * 60 * 1000;
+        vi.setSystemTime(until - 1);
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(false);
+        expect(inPanel()).toEqual([]);
+        expect(readFeatureTipState().shown['run-status-popup']).toBeUndefined();
+
+        vi.setSystemTime(until);
+        expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(true);
+    });
+
+    it('preserves longer deferrals and allows previews without consuming them', () => {
+        const now = Date.now();
+        deferFeatureTips({ 'run-status-popup': 100_000 }, now);
+        deferFeatureTips({ 'run-status-popup': 1_000 }, now);
+        expect(isFeatureTipDeferred(readFeatureTipState(), 'run-status-popup', now + 50_000)).toBe(true);
+        expect(store.set(showFeatureTipAtom, 'run-status-popup', { force: true })).toBe(true);
+        expect(readFeatureTipState().shown).toEqual({});
+    });
+
     it('shows the tip where its definition says, once, and records it', () => {
         expect(store.set(showFeatureTipAtom, 'run-status-popup')).toBe(true);
         expect(inPanel()).toEqual(['feature-tip:run-status-popup']);

--- a/tests/unit/versionUpdate/versionUpdatePopup.test.ts
+++ b/tests/unit/versionUpdate/versionUpdatePopup.test.ts
@@ -1,0 +1,77 @@
+/**
+ * A release note as a popup message, and the visual it can carry.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ prefs: {} as Record<string, unknown> }));
+vi.mock('../../../src/utils/prefs', () => ({
+    getPref: (key: string) => mocks.prefs[key],
+    setPref: vi.fn(),
+}));
+
+beforeEach(() => {
+    mocks.prefs = {};
+    (globalThis as any).Zotero = { isMac: true };
+});
+afterEach(() => {
+    delete (globalThis as any).Zotero;
+});
+
+import { versionUpdatePopupMessage } from '../../../react/utils/versionUpdatePopup';
+import { getVersionUpdateMessageConfig, type VersionUpdateMessageConfig } from '../../../react/constants/versionUpdateMessages';
+import { getVersionShowcase } from '../../../react/constants/versionShowcases';
+
+describe('versionUpdatePopupMessage', () => {
+    it('carries every part of the note, including its showcase, and never expires', () => {
+        const config: VersionUpdateMessageConfig = {
+            version: '9.9.9',
+            title: 'T',
+            text: 't',
+            subtitle: 's',
+            footer: 'f',
+            learnMoreUrl: 'https://example.test',
+            learnMoreLabel: 'More',
+            steps: [{ title: 'Step', showcase: 'quick-prompt' }],
+            showcase: 'quick-prompt',
+        };
+        expect(versionUpdatePopupMessage(config)).toEqual({
+            type: 'version_update',
+            version: '9.9.9',
+            title: 'T',
+            text: 't',
+            subtitle: 's',
+            footer: 'f',
+            learnMoreUrl: 'https://example.test',
+            learnMoreLabel: 'More',
+            featureList: undefined,
+            steps: config.steps,
+            showcase: 'quick-prompt',
+            expire: false,
+        });
+    });
+
+    it('names the quick prompt chord for this machine wherever the copy asks for it', () => {
+        const config: VersionUpdateMessageConfig = {
+            version: '9.9.9',
+            title: 'T',
+            text: 'Press {{quickPromptShortcut}} to start.',
+            steps: [{ title: 'S', description: 'Also {{quickPromptShortcut}}.' }],
+        };
+        expect(versionUpdatePopupMessage(config).text).toBe('Press ⌘⌥J to start.');
+        expect(versionUpdatePopupMessage(config).steps?.[0].description).toBe('Also ⌘⌥J.');
+
+        (globalThis as any).Zotero = { isMac: false };
+        mocks.prefs = { keyboardShortcut: 'k' };
+        expect(versionUpdatePopupMessage(config).text).toBe('Press Ctrl+Alt+K to start.');
+    });
+});
+
+describe('the quick prompt release note', () => {
+    it('floats in the corner the feature lives in, with its showcase', () => {
+        const config = getVersionUpdateMessageConfig('0.25.0');
+        expect(config?.inPanel).toBe(false);
+        expect(config?.showcase).toBe('quick-prompt');
+        expect(getVersionShowcase(config?.showcase)).toEqual(expect.any(Function));
+        expect(getVersionShowcase(undefined)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- Add an animated Quick Prompt feature showcase to version update messages.
- Render shortcut, composer, run status, and completion states with reduced-motion support.
- Add version showcase configuration, shortcut placeholder substitution, and a dev-only popup test endpoint.
- Support library/reader toggle locations and unbounded release-note popup sizing.

## Testing

- Added unit coverage for the Quick Prompt showcase, version update content, popup utilities, and version popup handlers.
- Not run locally.