### PR TITLE
feat(mcp): add library and annotation tools

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -142,8 +142,9 @@ pref("threadsClaimKey", "");
 
 // MCP server
 pref("mcpServerEnabled", false);
+// Gates every mutating MCP tool. The key predates annotation writing and keeps
+// its original name so users who opted in do not have to opt in again.
 pref("mcpCreateNoteToolEnabled", false);
-pref("mcpAnnotationToolsEnabled", false);
 
 // Background extractor kill-switch (drains the background_jobs queue)
 pref("backgroundExtractorEnabled", true);

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -143,6 +143,7 @@ pref("threadsClaimKey", "");
 // MCP server
 pref("mcpServerEnabled", false);
 pref("mcpCreateNoteToolEnabled", false);
+pref("mcpAnnotationToolsEnabled", false);
 
 // Background extractor kill-switch (drains the background_jobs queue)
 pref("backgroundExtractorEnabled", true);

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -20,6 +20,7 @@ This is a **stateless POST-only subset** of Streamable HTTP. Each request gets a
 |------|--------|---------|
 | `src/services/mcpService.ts` | esbuild (imported by webpack) | MCP protocol engine: JSON-RPC 2.0 dispatch, tool registry, Zotero endpoint registration |
 | `react/hooks/useMcpServer.ts` | webpack | React hook: reads pref, registers tools with handlers, manages lifecycle |
+| `react/hooks/mcp/libraryAnnotationTools.ts` | webpack | Library and annotation tool schemas, validation, and adapters |
 | `react/index.tsx` | webpack | Mounts `useMcpServer()` in `GlobalContextInitializer` |
 | `addon/prefs.js` | N/A | `mcpServerEnabled` preference (default: `false`) |
 
@@ -167,7 +168,7 @@ curl -X POST http://localhost:PORT/beaver/mcp \
 
 ## Available Tools
 
-All tools that accept or return item/attachment IDs use the `<library_id>-<zotero_key>` format (e.g., `1-ABC12345`).
+Item and attachment IDs use portable library references (e.g. `u-ABC12345` or `g12345-ABC12345`). Legacy numeric IDs such as `1-ABC12345` are also accepted.
 
 ### `search_by_topic`
 
@@ -337,6 +338,63 @@ Browse items in the library, optionally filtered by collection or tag.
 **Response**: JSON with `total_count`, `has_more`, `next_offset`, and `items[]`. Item shape depends on `item_category`: regular items have `item_id`, `item_type`, `title`, `authors`, `year`, `date_added`, `date_modified` (no attachment IDs — use `get_item_details` to get those); notes have `parent_item_id`, `parent_title`, `date_modified`; attachments have `filename`, `content_type`, `parent_item_id`, `parent_title`, `annotations_count`, `date_modified`.
 
 **Underlying handler**: `handleListItemsRequest` from `src/services/agentDataProvider/`.
+
+---
+
+### `list_libraries`
+
+Lists only libraries available to Beaver. Returns `libraries` and `total_count`;
+rows include `library_ref` (`u` or `g<groupID>`), the local `library_id`, name,
+read-only status, and item/note/collection/tag counts. Takes no arguments.
+Use `library_ref` in the `library` argument of library-scoped tools.
+
+### `find_annotations`
+
+Searches annotation text and comments, with optional `tag`, `color`,
+`annotation_type` (`highlight`, `underline`, `note`), `author`, `attachment_id`,
+`collection`, `library`, and `modified_in_last` (e.g. `7 days`) filters.
+Supply at least one narrowing filter besides `library`. Filters combine with AND.
+The personal library is the default. Collection searches recurse by default.
+
+Results include annotation IDs, text, comments, source IDs, tags, and Zotero links.
+`limit` defaults to 25 (maximum 50); `offset` defaults to zero. Responses include
+`total_count`, `has_more`, `next_offset`, and any scan-limit note from the search.
+Sort with `sort_by` (`date_modified`, `date_added`, `reading_order`) and
+`sort_order` (`asc`, `desc`).
+
+### `create_highlight_annotations` and `create_note_annotations`
+
+Enable **Annotation Tools** in Beaver's advanced preferences
+(`extensions.zotero.beaver.mcpAnnotationToolsEnabled`, default `false`) and refresh
+the MCP client's tool list. This setting is independent of the Create Note tool.
+The tools create reader annotations on a single local PDF, EPUB, or HTML snapshot;
+`create_note_annotations` creates sticky notes on the attachment.
+
+Both accept `attachment_id`, an `items` array (1–50 entries), and optional `tags`
+applied to every annotation. Each item accepts an optional `color` (one of Zotero's
+eight palette names; default yellow). Highlights require `text`; notes require
+`comment`. Highlight comments are optional.
+
+For PDFs, call `read_attachment` with `include_annotation_locations: true` and a
+page range. Its structured `pages[].passages[]` output includes exact source
+`text`, `page_locations`, and `note_position`. Copy these locations into the
+creation request; do not invent coordinates. Page indices in locations are
+zero-based; the read tool's page range is one-based. Highlight boxes are PDF
+points in Beaver's extraction frame with an explicit `coord_origin` (`t` for
+top-left, `b` for bottom-left). Multi-page highlights produce one annotation per
+page. Note positions use `page_index`, `x`, `y`, `side`, and `coord_origin`.
+
+For EPUBs, provide `section_href` or a one-based `section_ordinal`, plus `text` or
+`anchor_id` to locate the passage. Snapshots use `text` or `anchor_id`. The same
+`read_attachment` option returns these as copyable `passages` for EPUBs and
+snapshots; section ordinals are separate from the read tool’s page window.
+
+The MCP client owns approval. Beaver validates library access, editability, and
+attachment availability, then executes directly. Responses include `created`
+(with `annotation_id` and `zotero_uri`), `failed`, `total_created`, and
+`total_failed`. Failed batches, including partial failures, set MCP `isError`;
+any successful writes are still returned. Retry only failed entries to avoid
+duplicates. Each result's zero-based `index` identifies the original input item.
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -22,13 +22,13 @@ This is a **stateless POST-only subset** of Streamable HTTP. Each request gets a
 | `react/hooks/useMcpServer.ts` | webpack | React hook: reads pref, registers tools with handlers, manages lifecycle |
 | `react/hooks/mcp/libraryAnnotationTools.ts` | webpack | Library and annotation tool schemas, validation, and adapters |
 | `react/index.tsx` | webpack | Mounts `useMcpServer()` in `GlobalContextInitializer` |
-| `addon/prefs.js` | N/A | `mcpServerEnabled` preference (default: `false`) |
+| `addon/prefs.js` | N/A | `mcpServerEnabled` and `mcpCreateNoteToolEnabled` preferences (both default: `false`) |
 
 ### How It Works
 
 1. `GlobalContextInitializer` calls `useMcpServer()` on mount.
 2. The hook reads the `mcpServerEnabled` preference. If `false`, it returns immediately.
-3. When enabled, it creates an `MCPService` instance, registers tools with their handlers, sets up auth checking, and calls `service.register()` to mount the `/beaver/mcp` endpoint.
+3. When enabled, it creates an `MCPService` instance, registers tools with their handlers, sets up auth checking, and calls `service.register()` to mount the `/beaver/mcp` endpoint. Mutating tools are registered only when `mcpCreateNoteToolEnabled` is `true`, so they are neither advertised nor callable otherwise. That key gates every write tool; it keeps its original name so users who already opted in stay opted in.
 4. MCP clients send JSON-RPC 2.0 requests. The service dispatches to `initialize`, `tools/list`, or `tools/call`.
 5. `tools/call` checks Beaver authentication first. If the user isn't logged in, it returns an `isError: true` response telling the model to ask the user to sign in.
 6. On unmount, the hook calls `service.unregister()` to remove the endpoint.
@@ -249,7 +249,7 @@ Read a Zotero note as simplified HTML. Citation, annotation, and image nodes are
 
 ### `create_note`
 
-Create a Zotero note from markdown. This is a mutating tool: MCP clients should apply their own approval policy before calling it.
+Create a Zotero note from markdown. This is a mutating tool: it is advertised only when **Write Tools** is enabled (`extensions.zotero.beaver.mcpCreateNoteToolEnabled`, default `false`), and MCP clients should apply their own approval policy before calling it.
 
 Citation tags use the unified format `<citation id="libraryID-zoteroKey"/>`. Add page locators with `loc`, for example `loc="page5"` or `loc="page5-page6"`. Use the 1-based page numbers from `read_attachment` `<pageN>` tags (physical page index, not printed labels). Use only IDs returned by tool results in the current session, copy page locators verbatim from `read_note` when editing existing notes, omit `loc` for metadata-only citations, and do not use legacy attributes such as `item_id`, `att_id`, `page`, or `sid`.
 
@@ -364,9 +364,9 @@ Sort with `sort_by` (`date_modified`, `date_added`, `reading_order`) and
 
 ### `create_highlight_annotations` and `create_note_annotations`
 
-Enable **Annotation Tools** in Beaver's advanced preferences
-(`extensions.zotero.beaver.mcpAnnotationToolsEnabled`, default `false`) and refresh
-the MCP client's tool list. This setting is independent of the Create Note tool.
+Enable **Write Tools** in Beaver's advanced preferences
+(`extensions.zotero.beaver.mcpCreateNoteToolEnabled`, default `false`) and refresh
+the MCP client's tool list. The same setting gates `create_note`.
 The tools create reader annotations on a single local PDF, EPUB, or HTML snapshot;
 `create_note_annotations` creates sticky notes on the attachment.
 

--- a/react/atoms/ui.ts
+++ b/react/atoms/ui.ts
@@ -101,8 +101,12 @@ export interface PendingActionEditRequest {
 }
 export const pendingActionEditRequestAtom = atom<PendingActionEditRequest | null>(null);
 export const mcpServerEnabledAtom = atom(getPref('mcpServerEnabled'));
-export const mcpCreateNoteToolEnabledAtom = atom(getPref('mcpCreateNoteToolEnabled'));
-export const mcpAnnotationToolsEnabledAtom = atom(getPref('mcpAnnotationToolsEnabled'));
+/**
+ * Gates every mutating MCP tool: note creation and annotation creation. The
+ * preference key predates annotation writing and is kept so users who already
+ * opted in do not have to opt in again.
+ */
+export const mcpWriteToolsEnabledAtom = atom(getPref('mcpCreateNoteToolEnabled'));
 export const dataProviderEnabledAtom = atom(getPref('dataProviderEnabled'));
 export const requestPlusToolsAtom = atom(getPref('requestPlusTools'));
 export const isWebSearchAllowedAtom = atom((get) => Boolean(get(isUsingBeaverCreditsAtom) || get(requestPlusToolsAtom)));

--- a/react/atoms/ui.ts
+++ b/react/atoms/ui.ts
@@ -102,6 +102,7 @@ export interface PendingActionEditRequest {
 export const pendingActionEditRequestAtom = atom<PendingActionEditRequest | null>(null);
 export const mcpServerEnabledAtom = atom(getPref('mcpServerEnabled'));
 export const mcpCreateNoteToolEnabledAtom = atom(getPref('mcpCreateNoteToolEnabled'));
+export const mcpAnnotationToolsEnabledAtom = atom(getPref('mcpAnnotationToolsEnabled'));
 export const dataProviderEnabledAtom = atom(getPref('dataProviderEnabled'));
 export const requestPlusToolsAtom = atom(getPref('requestPlusTools'));
 export const isWebSearchAllowedAtom = atom((get) => Boolean(get(isUsingBeaverCreditsAtom) || get(requestPlusToolsAtom)));

--- a/react/components/preferences/AdvancedSection.tsx
+++ b/react/components/preferences/AdvancedSection.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Button from "@beaver/agent-ui/primitives/Button";
 import {SettingsGroup, SettingsRow, DocLink} from "./components/SettingsElements";
-import { dataProviderEnabledAtom, mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from "../../atoms/ui";
+import { dataProviderEnabledAtom, mcpAnnotationToolsEnabledAtom, mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from "../../atoms/ui";
 import { isMcpServerSupportedAtom } from "../../atoms/profile";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { currentMessageExternalFilesAtom } from "../../atoms/messageComposition";
@@ -101,6 +101,7 @@ const AdvancedSection: React.FC = () => {
 
     // --- Atoms: MCP Server enabled ---
     const [mcpServerEnabled, setMcpServerEnabled] = useAtom(mcpServerEnabledAtom);
+    const [mcpAnnotationToolsEnabled, setMcpAnnotationToolsEnabled] = useAtom(mcpAnnotationToolsEnabledAtom);
     const [mcpCreateNoteToolEnabled, setMcpCreateNoteToolEnabled] = useAtom(mcpCreateNoteToolEnabledAtom);
     const [mcpCopied, setMcpCopied] = useState(false);
     const [mcpHttpCopied, setMcpHttpCopied] = useState(false);
@@ -170,6 +171,13 @@ const AdvancedSection: React.FC = () => {
         setPref('mcpCreateNoteToolEnabled', newValue);
         setMcpCreateNoteToolEnabled(newValue);
     }, [mcpCreateNoteToolEnabled, isMcpServerSupported, setMcpCreateNoteToolEnabled]);
+
+    const handleMcpAnnotationToolsToggle = useCallback(() => {
+        if (!isMcpServerSupported) return;
+        const value = !mcpAnnotationToolsEnabled;
+        setPref('mcpAnnotationToolsEnabled', value);
+        setMcpAnnotationToolsEnabled(value);
+    }, [mcpAnnotationToolsEnabled, isMcpServerSupported, setMcpAnnotationToolsEnabled]);
 
     // --- Data provider (library access for other Beaver clients) ---
     const [dataProviderEnabled, setDataProviderEnabled] = useAtom(dataProviderEnabledAtom);
@@ -336,6 +344,29 @@ const AdvancedSection: React.FC = () => {
                                 aria-label="Enable Create Note Tool"
                                 checked={mcpCreateNoteToolEnabled}
                                 onChange={handleMcpCreateNoteToolToggle}
+                                onClick={(e) => e.stopPropagation()}
+                                disabled={!isMcpServerSupported}
+                                style={{ cursor: isMcpServerSupported ? 'pointer' : 'not-allowed', margin: 0 }}
+                            />
+                        </div>
+                    }
+                />
+                <SettingsRow
+                    title="Enable Annotation Tools"
+                    description="Allow MCP clients to create highlights and sticky-note annotations. Changing setting requires reloading of the MCP server."
+                    onClick={handleMcpAnnotationToolsToggle}
+                    hasBorder
+                    disabled={!isMcpServerSupported}
+                    tooltip={isMcpServerSupported
+                        ? 'Advertise and allow the annotation creation MCP tools'
+                        : 'Only available with Beaver Pro'}
+                    control={
+                        <div className="display-flex flex-row items-center gap-2">
+                            <input
+                                type="checkbox"
+                                aria-label="Enable Annotation Tools"
+                                checked={mcpAnnotationToolsEnabled}
+                                onChange={handleMcpAnnotationToolsToggle}
                                 onClick={(e) => e.stopPropagation()}
                                 disabled={!isMcpServerSupported}
                                 style={{ cursor: isMcpServerSupported ? 'pointer' : 'not-allowed', margin: 0 }}

--- a/react/components/preferences/AdvancedSection.tsx
+++ b/react/components/preferences/AdvancedSection.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Button from "@beaver/agent-ui/primitives/Button";
 import {SettingsGroup, SettingsRow, DocLink} from "./components/SettingsElements";
-import { dataProviderEnabledAtom, mcpAnnotationToolsEnabledAtom, mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from "../../atoms/ui";
+import { dataProviderEnabledAtom, mcpServerEnabledAtom, mcpWriteToolsEnabledAtom } from "../../atoms/ui";
 import { isMcpServerSupportedAtom } from "../../atoms/profile";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { currentMessageExternalFilesAtom } from "../../atoms/messageComposition";
@@ -101,8 +101,7 @@ const AdvancedSection: React.FC = () => {
 
     // --- Atoms: MCP Server enabled ---
     const [mcpServerEnabled, setMcpServerEnabled] = useAtom(mcpServerEnabledAtom);
-    const [mcpAnnotationToolsEnabled, setMcpAnnotationToolsEnabled] = useAtom(mcpAnnotationToolsEnabledAtom);
-    const [mcpCreateNoteToolEnabled, setMcpCreateNoteToolEnabled] = useAtom(mcpCreateNoteToolEnabledAtom);
+    const [mcpWriteToolsEnabled, setMcpWriteToolsEnabled] = useAtom(mcpWriteToolsEnabledAtom);
     const [mcpCopied, setMcpCopied] = useState(false);
     const [mcpHttpCopied, setMcpHttpCopied] = useState(false);
     const isMcpServerSupported = useAtomValue(isMcpServerSupportedAtom);
@@ -165,19 +164,12 @@ const AdvancedSection: React.FC = () => {
         setMcpServerEnabled(newValue);
     }, [mcpServerEnabled, isMcpServerSupported, setMcpServerEnabled]);
 
-    const handleMcpCreateNoteToolToggle = useCallback(() => {
+    const handleMcpWriteToolsToggle = useCallback(() => {
         if (!isMcpServerSupported) return;
-        const newValue = !mcpCreateNoteToolEnabled;
+        const newValue = !mcpWriteToolsEnabled;
         setPref('mcpCreateNoteToolEnabled', newValue);
-        setMcpCreateNoteToolEnabled(newValue);
-    }, [mcpCreateNoteToolEnabled, isMcpServerSupported, setMcpCreateNoteToolEnabled]);
-
-    const handleMcpAnnotationToolsToggle = useCallback(() => {
-        if (!isMcpServerSupported) return;
-        const value = !mcpAnnotationToolsEnabled;
-        setPref('mcpAnnotationToolsEnabled', value);
-        setMcpAnnotationToolsEnabled(value);
-    }, [mcpAnnotationToolsEnabled, isMcpServerSupported, setMcpAnnotationToolsEnabled]);
+        setMcpWriteToolsEnabled(newValue);
+    }, [mcpWriteToolsEnabled, isMcpServerSupported, setMcpWriteToolsEnabled]);
 
     // --- Data provider (library access for other Beaver clients) ---
     const [dataProviderEnabled, setDataProviderEnabled] = useAtom(dataProviderEnabledAtom);
@@ -329,44 +321,21 @@ const AdvancedSection: React.FC = () => {
                     }
                 />
                 <SettingsRow
-                    title="Enable Create Note Tool"
-                    description="Allow MCP clients to create Zotero notes. Changing setting requires reloading of the MCP server."
-                    onClick={handleMcpCreateNoteToolToggle}
+                    title="Enable Write Tools"
+                    description="Allow MCP clients to create Zotero notes, highlights, and sticky-note annotations. Changing setting requires reloading of the MCP server."
+                    onClick={handleMcpWriteToolsToggle}
                     hasBorder
                     disabled={!isMcpServerSupported}
                     tooltip={isMcpServerSupported
-                        ? 'Advertise and allow the create_note MCP tool'
+                        ? 'Advertise and allow the MCP tools that write to your library'
                         : 'Only available with Beaver Pro'}
                     control={
                         <div className="display-flex flex-row items-center gap-2">
                             <input
                                 type="checkbox"
-                                aria-label="Enable Create Note Tool"
-                                checked={mcpCreateNoteToolEnabled}
-                                onChange={handleMcpCreateNoteToolToggle}
-                                onClick={(e) => e.stopPropagation()}
-                                disabled={!isMcpServerSupported}
-                                style={{ cursor: isMcpServerSupported ? 'pointer' : 'not-allowed', margin: 0 }}
-                            />
-                        </div>
-                    }
-                />
-                <SettingsRow
-                    title="Enable Annotation Tools"
-                    description="Allow MCP clients to create highlights and sticky-note annotations. Changing setting requires reloading of the MCP server."
-                    onClick={handleMcpAnnotationToolsToggle}
-                    hasBorder
-                    disabled={!isMcpServerSupported}
-                    tooltip={isMcpServerSupported
-                        ? 'Advertise and allow the annotation creation MCP tools'
-                        : 'Only available with Beaver Pro'}
-                    control={
-                        <div className="display-flex flex-row items-center gap-2">
-                            <input
-                                type="checkbox"
-                                aria-label="Enable Annotation Tools"
-                                checked={mcpAnnotationToolsEnabled}
-                                onChange={handleMcpAnnotationToolsToggle}
+                                aria-label="Enable Write Tools"
+                                checked={mcpWriteToolsEnabled}
+                                onChange={handleMcpWriteToolsToggle}
                                 onClick={(e) => e.stopPropagation()}
                                 disabled={!isMcpServerSupported}
                                 style={{ cursor: isMcpServerSupported ? 'pointer' : 'not-allowed', margin: 0 }}

--- a/react/hooks/mcp/libraryAnnotationTools.ts
+++ b/react/hooks/mcp/libraryAnnotationTools.ts
@@ -1,0 +1,233 @@
+import {
+    handleListLibrariesRequest,
+    handleFindAnnotationsRequest,
+    validateCreateHighlightAnnotationsAction,
+    executeCreateHighlightAnnotationsAction,
+    validateCreateNoteAnnotationsAction,
+    executeCreateNoteAnnotationsAction,
+} from '../../../src/services/agentDataProvider';
+import type { WSFindAnnotationsRequest } from '@beaver/agent-core/protocol/agentProtocol';
+import { resolveObjectId, modelObjectIdFromReference, UNRESOLVED_LIBRARY_ID } from '../../../src/utils/libraryIdentity';
+import { getZoteroSelectURI } from '../../../src/utils/zoteroUtils';
+
+const readHints = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+const colors = ['yellow', 'red', 'green', 'blue', 'purple', 'magenta', 'orange', 'gray'];
+const string = { type: 'string', minLength: 1 };
+const pageIndex = { type: 'integer', minimum: 0 };
+const origin = { type: 'string', enum: ['t', 'b'], description: 't = top-left, b = bottom-left.' };
+const boxSchema = {
+    type: 'object', additionalProperties: false, required: ['l', 't', 'r', 'b', 'coord_origin'],
+    properties: { l: { type: 'number' }, t: { type: 'number' }, r: { type: 'number' }, b: { type: 'number' }, coord_origin: origin },
+};
+const locationSchema = {
+    type: 'object', additionalProperties: false, required: ['page_idx', 'boxes'],
+    properties: {
+        page_idx: pageIndex,
+        boxes: { type: 'array', minItems: 1, maxItems: 1000, items: boxSchema },
+        page_label: string,
+        reading_order_offset: pageIndex,
+    },
+};
+const notePositionSchema = {
+    type: 'object', additionalProperties: false, required: ['page_index', 'x', 'y', 'side', 'coord_origin'],
+    properties: {
+        page_index: pageIndex, x: { type: 'number' }, y: { type: 'number' },
+        side: { type: 'string', enum: ['left', 'right'] }, coord_origin: origin,
+    },
+};
+
+export const LIST_LIBRARIES_TOOL = {
+    name: 'list_libraries', annotations: { title: 'List Libraries', ...readHints },
+    description: 'List Zotero libraries available to Beaver, with portable library_ref, name, read-only status, and item, note, collection, and tag counts. Excluded libraries are omitted. Use library_ref as the library argument of other tools.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+};
+
+export const FIND_ANNOTATIONS_TOOL = {
+    name: 'find_annotations', annotations: { title: 'Find Annotations', ...readHints },
+    description: 'Find highlights, underlines, and note annotations in a Zotero library. Filters are combined with AND; supply at least one filter besides library. Returns annotation text, comments, tags, source IDs, and pagination. Defaults to the personal library; use list_libraries for other libraries.',
+    inputSchema: {
+        type: 'object', additionalProperties: false,
+        properties: {
+            text_contains: { ...string, description: 'Substring in highlighted text.' },
+            comment_contains: { ...string, description: 'Substring in annotation comments.' },
+            tag: string, color: { ...string, description: 'Zotero color name or hex color (matched to nearest palette color).' },
+            annotation_type: { type: 'string', enum: ['highlight', 'underline', 'note'] },
+            author: string,
+            attachment_id: { ...string, description: 'Attachment or parent item ID from another tool.' },
+            collection: { ...string, description: 'Collection ID or name.' },
+            library: { type: ['string', 'integer'], description: 'Library ref (u or g<groupID>), numeric ID, or name.' },
+            recursive: { type: 'boolean', default: true },
+            modified_in_last: { ...string, description: 'Relative duration, e.g. "7 days" or "2 months".' },
+            sort_by: { type: 'string', enum: ['date_modified', 'date_added', 'reading_order'], default: 'date_modified' },
+            sort_order: { type: 'string', enum: ['asc', 'desc'], default: 'desc' },
+            limit: { type: 'integer', minimum: 1, maximum: 50, default: 25 },
+            offset: { type: 'integer', minimum: 0, default: 0 },
+        },
+    },
+};
+
+function creationTool(highlight: boolean) {
+    return {
+        name: highlight ? 'create_highlight_annotations' : 'create_note_annotations',
+        annotations: { title: highlight ? 'Create Highlight Annotations' : 'Create Note Annotations', ...readHints, readOnlyHint: false, idempotentHint: false },
+        description: `Create a batch of ${highlight ? 'highlights' : 'sticky-note annotations (not standalone Zotero notes)'} on one local PDF, EPUB, or HTML snapshot attachment. ` +
+            'For PDFs, copy exact page_locations or note_position from read_attachment with include_annotation_locations=true; never guess coordinates. ' +
+            'The same read option returns EPUB section and text/anchor locators; snapshots use text or anchor_id. ' +
+            'Writes immediately after validation; the MCP client handles approval. Returns created annotation IDs and per-item failures. ' +
+            'A multi-page highlight creates one annotation per page. Retrying successful items creates duplicates; retry only failed items.',
+        inputSchema: {
+            type: 'object', additionalProperties: false, required: ['attachment_id', 'items'],
+            properties: {
+                attachment_id: { ...string, description: 'Attachment ID from search or get_item_details, e.g. u-ABC12345.' },
+                tags: { type: 'array', maxItems: 100, items: string },
+                items: {
+                    type: 'array', minItems: 1, maxItems: 50,
+                    items: {
+                        type: 'object', additionalProperties: false, required: [highlight ? 'text' : 'comment'],
+                        properties: {
+                            text: { ...string, description: 'Exact source passage. Required for highlights; optional anchor for notes.' },
+                            comment: { type: 'string', ...(highlight ? {} : { minLength: 1 }) },
+                            color: { type: 'string', enum: colors, default: 'yellow' },
+                            page_label: string,
+                            ...(highlight ? { page_locations: { type: 'array', minItems: 1, maxItems: 30, items: locationSchema } }
+                                : { note_position: notePositionSchema, reading_order_offset: pageIndex }),
+                            section_href: string,
+                            section_ordinal: { type: 'integer', minimum: 1 },
+                            anchor_id: string,
+                        },
+                    },
+                },
+            },
+        },
+    };
+}
+export const CREATE_HIGHLIGHT_ANNOTATIONS_TOOL = creationTool(true);
+export const CREATE_NOTE_ANNOTATIONS_TOOL = creationTool(false);
+
+/** Validate the JSON Schema subset used by these tools, including direct HTTP calls. */
+function validateInput(value: any, schema: any, path = 'arguments'): void {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const matches = types.some((type: string) => type === 'integer' ? Number.isSafeInteger(value)
+        : type === 'number' ? typeof value === 'number' && Number.isFinite(value)
+            : type === 'array' ? Array.isArray(value)
+                : type === 'object' ? value !== null && typeof value === 'object' && !Array.isArray(value)
+                    : typeof value === type);
+    if (!matches) throw new Error(`${path} must be ${types.join(' or ')}.`);
+    if (schema.enum && !schema.enum.includes(value)) throw new Error(`${path} must be one of: ${schema.enum.join(', ')}.`);
+    if (typeof value === 'number' && (value < (schema.minimum ?? -Infinity) || value > (schema.maximum ?? Infinity))) {
+        throw new Error(`${path} is outside the allowed range (${schema.minimum ?? '-infinity'}–${schema.maximum ?? 'infinity'}).`);
+    }
+    if (typeof value === 'string' && schema.minLength && value.trim().length < schema.minLength) throw new Error(`${path} cannot be empty.`);
+    if (Array.isArray(value)) {
+        if (value.length < (schema.minItems ?? 0) || value.length > (schema.maxItems ?? Infinity)) throw new Error(`${path} has an invalid number of items.`);
+        value.forEach((item, index) => validateInput(item, schema.items, `${path}[${index}]`));
+    } else if (value !== null && typeof value === 'object') {
+        for (const key of schema.required ?? []) if (!(key in value)) throw new Error(`${path}.${key} is required.`);
+        for (const [key, item] of Object.entries(value)) {
+            if (!Object.prototype.hasOwnProperty.call(schema.properties, key)) throw new Error(`Unknown argument: ${path}.${key}.`);
+            validateInput(item, schema.properties[key], `${path}.${key}`);
+        }
+    }
+}
+
+function errorResult(error: unknown) {
+    return { isError: true, content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }] };
+}
+function requestId(): string { return Zotero.Utilities.randomString(16); }
+
+export async function handleListLibraries(args: unknown = {}): Promise<any> {
+    try {
+        validateInput(args, LIST_LIBRARIES_TOOL.inputSchema);
+        const response = await handleListLibrariesRequest({ event: 'list_libraries_request', request_id: requestId() });
+        if (response.error) return errorResult(response.error);
+        return { libraries: response.libraries, total_count: response.total_count };
+    } catch (error) { return errorResult(error); }
+}
+
+export async function handleFindAnnotations(args: any = {}): Promise<any> {
+    try {
+        validateInput(args, FIND_ANNOTATIONS_TOOL.inputSchema);
+        const { library, ...filters } = args;
+        const request: WSFindAnnotationsRequest = {
+            ...filters, event: 'find_annotations_request', request_id: requestId(), library_id: library,
+            recursive: args.recursive ?? true, sort_by: args.sort_by ?? 'date_modified', sort_order: args.sort_order ?? 'desc',
+            limit: args.limit ?? 25, offset: args.offset ?? 0,
+        };
+        const response = await handleFindAnnotationsRequest(request);
+        if (response.error) return errorResult(response.error);
+        const next = request.offset + response.annotations.length;
+        const hasMore = response.annotations.length > 0 && next < response.total_count;
+        return {
+            annotations: response.annotations.map(annotation => {
+                const ref = resolveObjectId(annotation.annotation_id);
+                return { ...annotation, zotero_uri: ref && ref.library_id !== UNRESOLVED_LIBRARY_ID ? getZoteroSelectURI(ref.library_id, ref.zotero_key) : null };
+            }),
+            total_count: response.total_count, has_more: hasMore, next_offset: hasMore ? next : null,
+            ...(response.note ? { note: response.note } : {}),
+        };
+    } catch (error) { return errorResult(error); }
+}
+
+async function createAnnotations(args: any, highlight: boolean): Promise<any> {
+    try {
+        const tool = highlight ? CREATE_HIGHLIGHT_ANNOTATIONS_TOOL : CREATE_NOTE_ANNOTATIONS_TOOL;
+        validateInput(args, tool.inputSchema);
+        const ref = resolveObjectId(args.attachment_id);
+        if (!ref) throw new Error('Invalid attachment_id. Use an ID returned by search or get_item_details.');
+        if (ref.library_id === UNRESOLVED_LIBRARY_ID) throw new Error('The attachment library is not available on this computer.');
+        for (const [index, item] of args.items.entries()) {
+            const hasPdf = highlight ? !!item.page_locations : !!item.note_position;
+            const hasDom = !!(item.section_href || item.section_ordinal || item.anchor_id || (!highlight && item.text));
+            if (!hasPdf && !hasDom && !highlight) throw new Error(`items[${index}] requires note_position or a DOM text/section/anchor locator.`);
+            // Snapshot highlights can be located by their required text alone.
+            for (const location of item.page_locations ?? []) {
+                for (const box of location.boxes) {
+                    if (box.r <= box.l || (box.coord_origin === 't' ? box.b <= box.t : box.t <= box.b)) {
+                        throw new Error(`items[${index}] contains an empty or inverted bounding box.`);
+                    }
+                }
+            }
+        }
+        const actionType = highlight ? 'create_highlight_annotations' : 'create_note_annotations';
+        const data = {
+            requested_ref: ref, resolved_ref: ref, tags: args.tags,
+            items: args.items.map((item: any, index: number) => ({
+                ...item, index, client_item_id: String(index), title: '', loc_raw: '',
+                loc: { kind: 'unknown', value: '', raw: '' }, color: item.color ?? 'yellow',
+            })),
+        };
+        const validate = highlight ? validateCreateHighlightAnnotationsAction : validateCreateNoteAnnotationsAction;
+        const execute = highlight ? executeCreateHighlightAnnotationsAction : executeCreateNoteAnnotationsAction;
+        const validation = await validate({ event: 'agent_action_validate', request_id: requestId(), action_type: actionType, action_data: data });
+        if (!validation.valid) return errorResult(validation.error ?? 'Annotation validation failed.');
+        const kind = validation.current_value?.content_kind;
+        for (const [index, item] of args.items.entries()) {
+            if (kind === 'pdf' && !(highlight ? item.page_locations : item.note_position)) {
+                throw new Error(`items[${index}] requires ${highlight ? 'page_locations' : 'note_position'} for a PDF. Read with include_annotation_locations=true first.`);
+            }
+            if (kind === 'epub' && !item.section_href && !item.section_ordinal) {
+                throw new Error(`items[${index}] requires section_href or section_ordinal for an EPUB.`);
+            }
+            if (kind === 'snapshot' && !item.text && !item.anchor_id) {
+                throw new Error(`items[${index}] requires text or anchor_id for a snapshot.`);
+            }
+        }
+        const response = await execute({
+            event: 'agent_action_execute', request_id: requestId(), action_type: actionType,
+            action_data: { ...data, ...validation.normalized_action_data },
+        }, { signal: new AbortController().signal, timeoutSeconds: 120, startTime: Date.now() });
+        if (!response.success) return errorResult(response.error ?? 'Annotation creation failed.');
+        const result = response.result_data ?? {};
+        const output = {
+            attachment_id: modelObjectIdFromReference(ref),
+            created: (result.created ?? []).map((annotation: any) => ({
+                ...annotation, annotation_id: modelObjectIdFromReference(annotation),
+                zotero_uri: getZoteroSelectURI(annotation.library_id, annotation.zotero_key),
+            })),
+            failed: result.failed ?? [], total_created: result.total_created ?? 0, total_failed: result.total_failed ?? 0,
+        };
+        return { content: [{ type: 'text', text: JSON.stringify(output) }], ...(output.total_failed > 0 ? { isError: true } : {}) };
+    } catch (error) { return errorResult(error); }
+}
+export const handleCreateHighlightAnnotations = (args: any) => createAnnotations(args, true);
+export const handleCreateNoteAnnotations = (args: any) => createAnnotations(args, false);

--- a/react/hooks/mcp/libraryAnnotationTools.ts
+++ b/react/hooks/mcp/libraryAnnotationTools.ts
@@ -1,3 +1,4 @@
+import { mcpError, generateRequestId, buildNoopTimeoutContext } from './utils';
 import {
     handleListLibrariesRequest,
     handleFindAnnotationsRequest,
@@ -11,6 +12,7 @@ import { resolveObjectId, modelObjectIdFromReference, UNRESOLVED_LIBRARY_ID } fr
 import { getZoteroSelectURI } from '../../../src/utils/zoteroUtils';
 
 const readHints = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+const writeHints = { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false };
 const colors = ['yellow', 'red', 'green', 'blue', 'purple', 'magenta', 'orange', 'gray'];
 const string = { type: 'string', minLength: 1 };
 const pageIndex = { type: 'integer', minimum: 0 };
@@ -69,7 +71,7 @@ export const FIND_ANNOTATIONS_TOOL = {
 function creationTool(highlight: boolean) {
     return {
         name: highlight ? 'create_highlight_annotations' : 'create_note_annotations',
-        annotations: { title: highlight ? 'Create Highlight Annotations' : 'Create Note Annotations', ...readHints, readOnlyHint: false, idempotentHint: false },
+        annotations: { title: highlight ? 'Create Highlight Annotations' : 'Create Note Annotations', ...writeHints },
         description: `Create a batch of ${highlight ? 'highlights' : 'sticky-note annotations (not standalone Zotero notes)'} on one local PDF, EPUB, or HTML snapshot attachment. ` +
             'For PDFs, copy exact page_locations or note_position from read_attachment with include_annotation_locations=true; never guess coordinates. ' +
             'The same read option returns EPUB section and text/anchor locators; snapshots use text or anchor_id. ' +
@@ -130,18 +132,13 @@ function validateInput(value: any, schema: any, path = 'arguments'): void {
     }
 }
 
-function errorResult(error: unknown) {
-    return { isError: true, content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }] };
-}
-function requestId(): string { return Zotero.Utilities.randomString(16); }
-
 export async function handleListLibraries(args: unknown = {}): Promise<any> {
     try {
         validateInput(args, LIST_LIBRARIES_TOOL.inputSchema);
-        const response = await handleListLibrariesRequest({ event: 'list_libraries_request', request_id: requestId() });
-        if (response.error) return errorResult(response.error);
+        const response = await handleListLibrariesRequest({ event: 'list_libraries_request', request_id: generateRequestId() });
+        if (response.error) return mcpError(response.error);
         return { libraries: response.libraries, total_count: response.total_count };
-    } catch (error) { return errorResult(error); }
+    } catch (error) { return mcpError(error); }
 }
 
 export async function handleFindAnnotations(args: any = {}): Promise<any> {
@@ -149,12 +146,12 @@ export async function handleFindAnnotations(args: any = {}): Promise<any> {
         validateInput(args, FIND_ANNOTATIONS_TOOL.inputSchema);
         const { library, ...filters } = args;
         const request: WSFindAnnotationsRequest = {
-            ...filters, event: 'find_annotations_request', request_id: requestId(), library_id: library,
+            ...filters, event: 'find_annotations_request', request_id: generateRequestId(), library_id: library,
             recursive: args.recursive ?? true, sort_by: args.sort_by ?? 'date_modified', sort_order: args.sort_order ?? 'desc',
             limit: args.limit ?? 25, offset: args.offset ?? 0,
         };
         const response = await handleFindAnnotationsRequest(request);
-        if (response.error) return errorResult(response.error);
+        if (response.error) return mcpError(response.error);
         const next = request.offset + response.annotations.length;
         const hasMore = response.annotations.length > 0 && next < response.total_count;
         return {
@@ -165,7 +162,7 @@ export async function handleFindAnnotations(args: any = {}): Promise<any> {
             total_count: response.total_count, has_more: hasMore, next_offset: hasMore ? next : null,
             ...(response.note ? { note: response.note } : {}),
         };
-    } catch (error) { return errorResult(error); }
+    } catch (error) { return mcpError(error); }
 }
 
 async function createAnnotations(args: any, highlight: boolean): Promise<any> {
@@ -176,10 +173,6 @@ async function createAnnotations(args: any, highlight: boolean): Promise<any> {
         if (!ref) throw new Error('Invalid attachment_id. Use an ID returned by search or get_item_details.');
         if (ref.library_id === UNRESOLVED_LIBRARY_ID) throw new Error('The attachment library is not available on this computer.');
         for (const [index, item] of args.items.entries()) {
-            const hasPdf = highlight ? !!item.page_locations : !!item.note_position;
-            const hasDom = !!(item.section_href || item.section_ordinal || item.anchor_id || (!highlight && item.text));
-            if (!hasPdf && !hasDom && !highlight) throw new Error(`items[${index}] requires note_position or a DOM text/section/anchor locator.`);
-            // Snapshot highlights can be located by their required text alone.
             for (const location of item.page_locations ?? []) {
                 for (const box of location.boxes) {
                     if (box.r <= box.l || (box.coord_origin === 't' ? box.b <= box.t : box.t <= box.b)) {
@@ -198,8 +191,8 @@ async function createAnnotations(args: any, highlight: boolean): Promise<any> {
         };
         const validate = highlight ? validateCreateHighlightAnnotationsAction : validateCreateNoteAnnotationsAction;
         const execute = highlight ? executeCreateHighlightAnnotationsAction : executeCreateNoteAnnotationsAction;
-        const validation = await validate({ event: 'agent_action_validate', request_id: requestId(), action_type: actionType, action_data: data });
-        if (!validation.valid) return errorResult(validation.error ?? 'Annotation validation failed.');
+        const validation = await validate({ event: 'agent_action_validate', request_id: generateRequestId(), action_type: actionType, action_data: data });
+        if (!validation.valid) return mcpError(validation.error ?? 'Annotation validation failed.');
         const kind = validation.current_value?.content_kind;
         for (const [index, item] of args.items.entries()) {
             if (kind === 'pdf' && !(highlight ? item.page_locations : item.note_position)) {
@@ -213,10 +206,10 @@ async function createAnnotations(args: any, highlight: boolean): Promise<any> {
             }
         }
         const response = await execute({
-            event: 'agent_action_execute', request_id: requestId(), action_type: actionType,
+            event: 'agent_action_execute', request_id: generateRequestId(), action_type: actionType,
             action_data: { ...data, ...validation.normalized_action_data },
-        }, { signal: new AbortController().signal, timeoutSeconds: 120, startTime: Date.now() });
-        if (!response.success) return errorResult(response.error ?? 'Annotation creation failed.');
+        }, buildNoopTimeoutContext());
+        if (!response.success) return mcpError(response.error ?? 'Annotation creation failed.');
         const result = response.result_data ?? {};
         const output = {
             attachment_id: modelObjectIdFromReference(ref),
@@ -227,7 +220,7 @@ async function createAnnotations(args: any, highlight: boolean): Promise<any> {
             failed: result.failed ?? [], total_created: result.total_created ?? 0, total_failed: result.total_failed ?? 0,
         };
         return { content: [{ type: 'text', text: JSON.stringify(output) }], ...(output.total_failed > 0 ? { isError: true } : {}) };
-    } catch (error) { return errorResult(error); }
+    } catch (error) { return mcpError(error); }
 }
 export const handleCreateHighlightAnnotations = (args: any) => createAnnotations(args, true);
 export const handleCreateNoteAnnotations = (args: any) => createAnnotations(args, false);

--- a/react/hooks/mcp/utils.ts
+++ b/react/hooks/mcp/utils.ts
@@ -1,0 +1,23 @@
+import type { TimeoutContext } from '../../../src/services/agentDataProvider/timeout';
+
+export function generateRequestId(): string {
+    if (typeof Zotero !== 'undefined' && Zotero.Utilities?.randomString) {
+        return Zotero.Utilities.randomString(16);
+    }
+    return `${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+}
+
+export function mcpError(error: unknown) {
+    return {
+        content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+        isError: true,
+    };
+}
+
+export function buildNoopTimeoutContext(): TimeoutContext {
+    return {
+        signal: new AbortController().signal,
+        timeoutSeconds: 120,
+        startTime: Date.now(),
+    };
+}

--- a/react/hooks/useMcpServer.ts
+++ b/react/hooks/useMcpServer.ts
@@ -43,7 +43,7 @@ import {
 } from '../../src/utils/libraryIdentity';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { isAuthenticatedAtom } from '../atoms/auth';
-import { mcpAnnotationToolsEnabledAtom, mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from '../atoms/ui';
+import { mcpServerEnabledAtom, mcpWriteToolsEnabledAtom } from '../atoms/ui';
 import { store } from '../store';
 import type {
     WSItemSearchByTopicRequest,
@@ -1529,8 +1529,7 @@ async function handleListItems(args: any): Promise<any> {
 
 export function useMcpServer() {
     const enabled = useAtomValue(mcpServerEnabledAtom);
-    const createNoteToolEnabled = useAtomValue(mcpCreateNoteToolEnabledAtom);
-    const annotationToolsEnabled = useAtomValue(mcpAnnotationToolsEnabledAtom);
+    const writeToolsEnabled = useAtomValue(mcpWriteToolsEnabledAtom);
 
     useEffect(() => {
         if (!enabled) {
@@ -1559,12 +1558,11 @@ export function useMcpServer() {
             { def: LIST_LIBRARIES_TOOL, handler: handleListLibraries },
             { def: FIND_ANNOTATIONS_TOOL, handler: handleFindAnnotations },
         ];
-        if (createNoteToolEnabled) {
-            tools.push({ def: CREATE_NOTE_TOOL, handler: handleCreateNote });
-        }
-
-        if (annotationToolsEnabled) {
+        // Mutating tools are advertised only when the user opts in. An unregistered
+        // name is rejected by the dispatcher, so the gate also blocks direct calls.
+        if (writeToolsEnabled) {
             tools.push(
+                { def: CREATE_NOTE_TOOL, handler: handleCreateNote },
                 { def: CREATE_HIGHLIGHT_ANNOTATIONS_TOOL, handler: handleCreateHighlightAnnotations },
                 { def: CREATE_NOTE_ANNOTATIONS_TOOL, handler: handleCreateNoteAnnotations },
             );
@@ -1582,5 +1580,5 @@ export function useMcpServer() {
                 service.unregister();
             }
         };
-    }, [enabled, createNoteToolEnabled, annotationToolsEnabled]);
+    }, [enabled, writeToolsEnabled]);
 }

--- a/react/hooks/useMcpServer.ts
+++ b/react/hooks/useMcpServer.ts
@@ -9,10 +9,15 @@ import { tryGetWindowRuntime } from '../runtime/windowRuntime';
  *
  * Tools: search_by_topic, search_by_metadata, read_attachment, read_note,
  *        get_item_details, list_collections, list_tags, list_items
- * Optional tool: create_note
+ *        list_libraries, find_annotations
+ * Optional tools: create_note, create_highlight_annotations, create_note_annotations
  */
 
 import { useEffect } from 'react';
+import {
+    LIST_LIBRARIES_TOOL, FIND_ANNOTATIONS_TOOL, CREATE_HIGHLIGHT_ANNOTATIONS_TOOL, CREATE_NOTE_ANNOTATIONS_TOOL,
+    handleListLibraries, handleFindAnnotations, handleCreateHighlightAnnotations, handleCreateNoteAnnotations,
+} from './mcp/libraryAnnotationTools';
 import { useAtomValue } from 'jotai';
 import { MCPService } from '../../src/services/mcpService';
 import {
@@ -38,7 +43,7 @@ import {
 } from '../../src/utils/libraryIdentity';
 import { logger } from '@beaver/agent-core/platform/logger';
 import { isAuthenticatedAtom } from '../atoms/auth';
-import { mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from '../atoms/ui';
+import { mcpAnnotationToolsEnabledAtom, mcpCreateNoteToolEnabledAtom, mcpServerEnabledAtom } from '../atoms/ui';
 import { store } from '../store';
 import type {
     WSItemSearchByTopicRequest,
@@ -331,6 +336,10 @@ const READ_ATTACHMENT_TOOL = {
                 type: 'string',
                 description:
                     'The attachment ID as returned by other tools, in the form `<library>-<zotero_key>` (e.g., "u-ABC12345"; legacy numeric ids like "1-ABC12345" are also accepted). Obtain this from search results.',
+            },
+            include_annotation_locations: {
+                type: 'boolean', default: false,
+                description: 'Return structured passages with exact annotation locators: PDF page_locations and note_position, or EPUB/snapshot text and section/anchor identifiers.',
             },
             start_page: {
                 type: 'integer',
@@ -885,6 +894,9 @@ async function handleSearchByMetadata(args: any): Promise<any> {
  */
 export async function handleReadAttachment(args: any): Promise<any> {
     const MAX_PAGES = 30;
+    if (args.include_annotation_locations !== undefined && typeof args.include_annotation_locations !== 'boolean') {
+        return mcpError('include_annotation_locations must be a boolean.');
+    }
 
     const parsed = parseItemId(args.attachment_id);
     if (!parsed) {
@@ -923,7 +935,7 @@ export async function handleReadAttachment(args: any): Promise<any> {
             zotero_key: parsed.key,
             library_ref: parsed.libraryRef ?? libraryRefForLibraryID(parsed.libraryId) ?? undefined,
         },
-        mode: 'markdown',
+        mode: args.include_annotation_locations ? 'structured' : 'markdown',
     };
 
     const response: WSZoteroDocumentResponse = await handleZoteroDocumentRequest(wsRequest);
@@ -932,6 +944,54 @@ export async function handleReadAttachment(args: any): Promise<any> {
         return mcpError(response.error ?? 'Failed to read attachment');
     }
     const result = response.result;
+    if (args.include_annotation_locations && (result.content_kind === 'epub' || result.content_kind === 'snapshot')) {
+        const document = domDocumentToMarkdownPages(result);
+        if (startPage > document.pageCount) return mcpError('start_page is out of range.');
+        return {
+            attachment_id: response.resolved_attachment ? modelObjectIdFromReference(response.resolved_attachment) : args.attachment_id,
+            content_kind: result.content_kind,
+            total_pages: document.pageCount,
+            passages: result.sections.flatMap(section => section.items
+                .filter(item => item.kind !== 'picture')
+                .filter(item => (item.pageNumber ?? section.index + 1) >= startPage && (item.pageNumber ?? section.index + 1) <= endPage)
+                .flatMap(item => {
+                    const texts = item.sentences?.length ? item.sentences.map(sentence => sentence.text) : [item.text ?? ''];
+                    return texts.filter(text => text.trim()).map(text => ({
+                        text,
+                        ...(result.content_kind === 'epub' ? { section_href: section.rawHref, section_ordinal: section.index + 1 } : {}),
+                        ...(item.anchorId ? { anchor_id: item.anchorId } : {}),
+                    }));
+                })),
+        };
+    }
+    if (result.content_kind !== 'epub' && result.content_kind !== 'snapshot' && result.content_kind !== 'text'
+        && result.mode === 'structured' && args.include_annotation_locations) {
+        if (startPage > result.document.pageCount) return mcpError('start_page is out of range.');
+        return {
+            attachment_id: response.resolved_attachment ? modelObjectIdFromReference(response.resolved_attachment) : args.attachment_id,
+            total_pages: result.document.pageCount,
+            pages: result.document.pages.filter(page => page.index + 1 >= startPage && page.index + 1 <= endPage).map(page => ({
+                page: page.index + 1,
+                passages: page.items.flatMap(item => {
+                    const parts = 'sentences' in item && item.sentences?.length
+                        ? item.sentences.map(sentence => ({ text: sentence.text, boxes: sentence.bboxes }))
+                        : 'text' in item ? [{ text: item.text, boxes: [item.bbox] }] : [];
+                    return parts.filter(part => part.boxes.length > 0).map(part => ({
+                        text: part.text,
+                        page_locations: [{
+                            page_idx: page.index,
+                            ...(page.label ? { page_label: page.label } : {}),
+                            boxes: part.boxes.map(([l, t, r, b]) => ({ l, t, r, b, coord_origin: 't' })),
+                        }],
+                        note_position: {
+                            page_index: page.index, side: 'right', coord_origin: 't',
+                            x: part.boxes[0][2], y: (part.boxes[0][1] + part.boxes[0][3]) / 2,
+                        },
+                    }));
+                }),
+            })),
+        };
+    }
     const markdownDocument = result.content_kind === 'epub' || result.content_kind === 'snapshot'
         ? domDocumentToMarkdownPages(result)
         : result.content_kind === 'text'
@@ -1489,6 +1549,7 @@ async function handleListItems(args: any): Promise<any> {
 export function useMcpServer() {
     const enabled = useAtomValue(mcpServerEnabledAtom);
     const createNoteToolEnabled = useAtomValue(mcpCreateNoteToolEnabledAtom);
+    const annotationToolsEnabled = useAtomValue(mcpAnnotationToolsEnabledAtom);
 
     useEffect(() => {
         if (!enabled) {
@@ -1514,9 +1575,18 @@ export function useMcpServer() {
             { def: LIST_COLLECTIONS_TOOL, handler: handleListCollections },
             { def: LIST_TAGS_TOOL, handler: handleListTags },
             { def: LIST_ITEMS_TOOL, handler: handleListItems },
+            { def: LIST_LIBRARIES_TOOL, handler: handleListLibraries },
+            { def: FIND_ANNOTATIONS_TOOL, handler: handleFindAnnotations },
         ];
         if (createNoteToolEnabled) {
             tools.push({ def: CREATE_NOTE_TOOL, handler: handleCreateNote });
+        }
+
+        if (annotationToolsEnabled) {
+            tools.push(
+                { def: CREATE_HIGHLIGHT_ANNOTATIONS_TOOL, handler: handleCreateHighlightAnnotations },
+                { def: CREATE_NOTE_ANNOTATIONS_TOOL, handler: handleCreateNoteAnnotations },
+            );
         }
 
         for (const { def, handler } of tools) {
@@ -1531,5 +1601,5 @@ export function useMcpServer() {
                 service.unregister();
             }
         };
-    }, [enabled, createNoteToolEnabled]);
+    }, [enabled, createNoteToolEnabled, annotationToolsEnabled]);
 }

--- a/react/hooks/useMcpServer.ts
+++ b/react/hooks/useMcpServer.ts
@@ -32,7 +32,7 @@ import {
     validateCreateNoteAction,
     executeCreateNoteAction,
 } from '../../src/services/agentDataProvider';
-import type { TimeoutContext } from '../../src/services/agentDataProvider/timeout';
+import { mcpError, generateRequestId, buildNoopTimeoutContext } from './mcp/utils';
 import { getCitationKeyFromItem, getZoteroSelectURI } from '../../src/utils/zoteroUtils';
 import {
     libraryRefForLibraryID,
@@ -670,13 +670,6 @@ const LIST_ITEMS_TOOL = {
 // Utilities
 // =============================================================================
 
-function generateRequestId(): string {
-    if (typeof Zotero !== 'undefined' && Zotero.Utilities?.randomString) {
-        return Zotero.Utilities.randomString(16);
-    }
-    return `${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
-}
-
 /**
  * Parses an MCP item/attachment id in the portable ("u-KEY" / "g<groupID>-KEY")
  * or legacy numeric ("<libraryID>-KEY") form. `libraryId` is resolved to this
@@ -704,13 +697,6 @@ function getMcpAttachmentStatus(attachment: any): string {
     if (status === 'unreadable') return 'unavailable';
     if (status) return status;
     return attachment.path ? 'available' : 'unavailable';
-}
-
-function mcpError(message: string) {
-    return {
-        content: [{ type: 'text', text: message }],
-        isError: true,
-    };
 }
 
 type McpToolRegistration = {
@@ -944,88 +930,77 @@ export async function handleReadAttachment(args: any): Promise<any> {
         return mcpError(response.error ?? 'Failed to read attachment');
     }
     const result = response.result;
-    if (args.include_annotation_locations && (result.content_kind === 'epub' || result.content_kind === 'snapshot')) {
-        const document = domDocumentToMarkdownPages(result);
-        if (startPage > document.pageCount) return mcpError('start_page is out of range.');
-        return {
-            attachment_id: response.resolved_attachment ? modelObjectIdFromReference(response.resolved_attachment) : args.attachment_id,
-            content_kind: result.content_kind,
-            total_pages: document.pageCount,
-            passages: result.sections.flatMap(section => section.items
-                .filter(item => item.kind !== 'picture')
-                .filter(item => (item.pageNumber ?? section.index + 1) >= startPage && (item.pageNumber ?? section.index + 1) <= endPage)
-                .flatMap(item => {
-                    const texts = item.sentences?.length ? item.sentences.map(sentence => sentence.text) : [item.text ?? ''];
-                    return texts.filter(text => text.trim()).map(text => ({
-                        text,
-                        ...(result.content_kind === 'epub' ? { section_href: section.rawHref, section_ordinal: section.index + 1 } : {}),
-                        ...(item.anchorId ? { anchor_id: item.anchorId } : {}),
-                    }));
+    const includeLocations = args.include_annotation_locations === true;
+    const isDom = result.content_kind === 'epub' || result.content_kind === 'snapshot';
+    const attachmentId = response.resolved_attachment
+        ? modelObjectIdFromReference(response.resolved_attachment)
+        : args.attachment_id;
+    let document: { pageCount: number; pages: AttachmentReadPage[] } | null = null;
+    if (result.content_kind === 'epub' || result.content_kind === 'snapshot') {
+        document = domDocumentToPages(result, includeLocations);
+    } else if (result.content_kind !== 'text') {
+        if (result.mode === 'markdown' && !includeLocations) {
+            document = {
+                pageCount: result.document.pageCount,
+                pages: result.document.pages.map(page => ({ pageNumber: page.index + 1, markdown: page.markdown ?? '' })),
+            };
+        } else if (result.mode === 'structured' && includeLocations) {
+            document = {
+                pageCount: result.document.pageCount,
+                pages: result.document.pages.map(page => ({
+                    pageNumber: page.index + 1,
+                    passages: page.items.flatMap(item => {
+                        const parts = 'sentences' in item && item.sentences?.length
+                            ? item.sentences.map(sentence => ({ text: sentence.text, boxes: sentence.bboxes }))
+                            : 'text' in item ? [{ text: item.text, boxes: [item.bbox] }] : [];
+                        return parts.filter(part => part.boxes.length > 0).map(part => ({
+                            text: part.text,
+                            page_locations: [{
+                                page_idx: page.index,
+                                ...(page.label ? { page_label: page.label } : {}),
+                                boxes: part.boxes.map(([l, t, r, b]) => ({ l, t, r, b, coord_origin: 't' })),
+                            }],
+                            note_position: {
+                                page_index: page.index, side: 'right', coord_origin: 't',
+                                x: part.boxes[0][2], y: (part.boxes[0][1] + part.boxes[0][3]) / 2,
+                            },
+                        }));
+                    }),
                 })),
-        };
+            };
+        }
     }
-    if (result.content_kind !== 'epub' && result.content_kind !== 'snapshot' && result.content_kind !== 'text'
-        && result.mode === 'structured' && args.include_annotation_locations) {
-        if (startPage > result.document.pageCount) return mcpError('start_page is out of range.');
-        return {
-            attachment_id: response.resolved_attachment ? modelObjectIdFromReference(response.resolved_attachment) : args.attachment_id,
-            total_pages: result.document.pageCount,
-            pages: result.document.pages.filter(page => page.index + 1 >= startPage && page.index + 1 <= endPage).map(page => ({
-                page: page.index + 1,
-                passages: page.items.flatMap(item => {
-                    const parts = 'sentences' in item && item.sentences?.length
-                        ? item.sentences.map(sentence => ({ text: sentence.text, boxes: sentence.bboxes }))
-                        : 'text' in item ? [{ text: item.text, boxes: [item.bbox] }] : [];
-                    return parts.filter(part => part.boxes.length > 0).map(part => ({
-                        text: part.text,
-                        page_locations: [{
-                            page_idx: page.index,
-                            ...(page.label ? { page_label: page.label } : {}),
-                            boxes: part.boxes.map(([l, t, r, b]) => ({ l, t, r, b, coord_origin: 't' })),
-                        }],
-                        note_position: {
-                            page_index: page.index, side: 'right', coord_origin: 't',
-                            x: part.boxes[0][2], y: (part.boxes[0][1] + part.boxes[0][3]) / 2,
-                        },
-                    }));
-                }),
-            })),
-        };
-    }
-    const markdownDocument = result.content_kind === 'epub' || result.content_kind === 'snapshot'
-        ? domDocumentToMarkdownPages(result)
-        : result.content_kind === 'text'
-            ? null
-            : result.mode === 'markdown'
-                ? {
-                    pageCount: result.document.pageCount,
-                    pages: result.document.pages.map((page) => ({
-                        pageNumber: page.index + 1,
-                        markdown: page.markdown ?? '',
-                    })),
-                }
-                : null;
-    if (!markdownDocument) {
+    if (!document) {
         return mcpError('Attachment read returned an unsupported document format.');
     }
 
-    const totalPages = markdownDocument.pageCount;
+    const totalPages = document.pageCount;
     if (Number.isInteger(totalPages) && totalPages >= 0 && startPage > totalPages) {
         return mcpError(`Requested start_page ${startPage} is out of range; attachment has ${totalPages} pages.`);
     }
 
-    const requestedPages = markdownDocument.pages.filter(
+    const requestedPages = document.pages.filter(
         (page) => page.pageNumber >= startPage && page.pageNumber <= endPage,
     );
     if (requestedPages.length === 0) {
         return mcpError(`Requested page window ${startPage}-${endPage} is out of range or contains no extractable pages.`);
     }
 
+    if (includeLocations) {
+        return {
+            attachment_id: attachmentId,
+            total_pages: totalPages,
+            ...(isDom
+                ? { content_kind: result.content_kind, passages: requestedPages.flatMap(page => page.passages ?? []) }
+                : { pages: requestedPages.map(page => ({ page: page.pageNumber, passages: page.passages ?? [] })) }),
+        };
+    }
+
     // Build plain text response with <pageN> tags
     const actualEnd = requestedPages.length > 0
         ? requestedPages[requestedPages.length - 1].pageNumber
         : startPage;
-    const header = `Attachment: ${args.attachment_id} | Total pages: ${markdownDocument.pageCount ?? 'unknown'} | Showing pages ${startPage}-${actualEnd}`;
+    const header = `Attachment: ${attachmentId} | Total pages: ${document.pageCount ?? 'unknown'} | Showing pages ${startPage}-${actualEnd}`;
     const pageTexts = requestedPages.map(
         (p) => `<page${p.pageNumber}>\n${p.markdown}\n</page${p.pageNumber}>`,
     );
@@ -1033,9 +1008,10 @@ export async function handleReadAttachment(args: any): Promise<any> {
     return [header, '', ...pageTexts].join('\n');
 }
 
-interface AttachmentMarkdownPage {
+interface AttachmentReadPage {
     pageNumber: number;
-    markdown: string;
+    markdown?: string;
+    passages?: Record<string, unknown>[];
 }
 
 type DomReadItem = {
@@ -1046,13 +1022,16 @@ type DomReadItem = {
     level?: number;
     sentences?: Array<{ text: string }>;
     pageNumber?: number;
+    sectionHref?: string;
+    anchorId?: string;
 };
 
 // EPUB and snapshot both carry stamped per-item page numbers. Grouping items by
 // that coordinate keeps MCP reads aligned with backend read pagination.
-function domDocumentToMarkdownPages(
+function domDocumentToPages(
     document: Extract<NonNullable<WSZoteroDocumentResponse['result']>, { content_kind: 'epub' | 'snapshot' }>,
-): { pageCount: number; pages: AttachmentMarkdownPage[] } {
+    includeLocations: boolean,
+): { pageCount: number; pages: AttachmentReadPage[] } {
     const pagesByNumber = new Map<number, DomReadItem[]>();
     const orderedItems = document.sections
         .slice()
@@ -1062,6 +1041,8 @@ function domDocumentToMarkdownPages(
             .sort((a, b) => a.order - b.order)
             .map((item) => ({
                 ...item,
+                sectionHref: section.rawHref,
+                sectionIndex: section.index,
                 pageNumber: item.pageNumber ?? section.index + 1,
             })));
 
@@ -1080,15 +1061,23 @@ function domDocumentToMarkdownPages(
     // table) spans interior pages that no item is stamped to.
     const observedPageCount = Math.max(0, ...Array.from(pagesByNumber.keys()));
     const pageCount = Math.max(document.pageCount ?? observedPageCount, observedPageCount);
-    const pages: AttachmentMarkdownPage[] = [];
+    const pages: AttachmentReadPage[] = [];
     for (let pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
         const items = pagesByNumber.get(pageNumber) ?? [];
         pages.push({
             pageNumber,
-            markdown: items
-                .map(domItemToMarkdown)
-                .filter((text) => text.length > 0)
-                .join('\n\n'),
+            ...(includeLocations ? {
+                passages: items.filter(item => item.kind !== 'picture').flatMap(item => {
+                    const texts = item.sentences?.length ? item.sentences.map(sentence => sentence.text) : [item.text ?? ''];
+                    return texts.filter(text => text.trim()).map(text => ({
+                        text,
+                        ...(document.content_kind === 'epub' ? { section_href: item.sectionHref, section_ordinal: item.sectionIndex + 1 } : {}),
+                        ...(item.anchorId ? { anchor_id: item.anchorId } : {}),
+                    }));
+                }),
+            } : {
+                markdown: items.map(domItemToMarkdown).filter(text => text.length > 0).join('\n\n'),
+            }),
         });
     }
     return { pageCount, pages };
@@ -1161,14 +1150,6 @@ export async function handleReadNote(args: any): Promise<any> {
             item_type: item.item_type,
             title: item.title ?? null,
         })),
-    };
-}
-
-function buildNoopTimeoutContext(): TimeoutContext {
-    return {
-        signal: new AbortController().signal,
-        timeoutSeconds: 120,
-        startTime: Date.now(),
     };
 }
 

--- a/src/services/agentDataProvider.ts
+++ b/src/services/agentDataProvider.ts
@@ -33,3 +33,5 @@ export { handleAgentActionExecuteRequest } from './agentDataProvider/handleAgent
 export { handleDeleteItemsRequest } from './agentDataProvider/handleDeleteItemsRequest';
 export { handleReadNoteRequest } from './agentDataProvider/handleReadNoteRequest';
 export { validateCreateNoteAction, executeCreateNoteAction } from './agentDataProvider/actions/createNote';
+export { validateCreateHighlightAnnotationsAction, executeCreateHighlightAnnotationsAction } from './agentDataProvider/actions/createHighlightAnnotations';
+export { validateCreateNoteAnnotationsAction, executeCreateNoteAnnotationsAction } from './agentDataProvider/actions/createNoteAnnotations';

--- a/src/services/agentDataProvider/actions/createHighlightAnnotations.ts
+++ b/src/services/agentDataProvider/actions/createHighlightAnnotations.ts
@@ -241,6 +241,7 @@ export async function validateCreateHighlightAnnotationsAction(
         request_id: request.request_id,
         valid: true,
         current_value: {
+            content_kind: contentKind,
             library_name: library.name,
             attachment_title: await getAttachmentTitle(attachment),
             item_count: items.length,

--- a/src/services/agentDataProvider/actions/createNoteAnnotations.ts
+++ b/src/services/agentDataProvider/actions/createNoteAnnotations.ts
@@ -250,6 +250,7 @@ export async function validateCreateNoteAnnotationsAction(
         request_id: request.request_id,
         valid: true,
         current_value: {
+            content_kind: contentKind,
             library_name: library.name,
             attachment_title: await getAttachmentTitle(attachment),
             item_count: items.length,

--- a/tests/live/mcpAnnotationTools.live.test.ts
+++ b/tests/live/mcpAnnotationTools.live.test.ts
@@ -1,0 +1,149 @@
+/** Exercise the actual JSON-RPC endpoint with MCP and annotation tools enabled. */
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
+import { SMALL_PDF, NON_PDF } from '../helpers/fixtures';
+import { post } from '../helpers/zoteroHttpClient';
+import { getExcludedLibraries, setExcludedLibraries, restoreExcludedLibraries } from '../helpers/cacheInspector';
+
+let available = false;
+let createdIds: string[] = [];
+let fixtureIds: string[] = [];
+const attachmentId = `${SMALL_PDF.library_id}-${SMALL_PDF.zotero_key}`;
+const tag = `mcp-annotation-test-${Date.now()}`;
+
+async function rpc(method: string, params?: any): Promise<any> {
+    const response = await post<any>('/beaver/mcp', { jsonrpc: '2.0', id: 1, method, params }, { timeout: 120000 });
+    expect(response.error).toBeUndefined();
+    return response.result;
+}
+async function call(name: string, args: any = {}, allowError = false): Promise<any> {
+    const result = await rpc('tools/call', { name, arguments: args });
+    let data: any;
+    try { data = JSON.parse(result.content[0].text); } catch { data = null; }
+    for (const annotation of data?.created ?? []) createdIds.push(annotation.annotation_id);
+    if (!allowError) expect(result.isError, result.content?.[0]?.text).not.toBe(true);
+    return allowError ? { result, data } : data;
+}
+
+beforeAll(async () => { available = await isZoteroAvailable(); });
+beforeEach(ctx => { skipIfNoZotero(ctx, available); createdIds = []; fixtureIds = []; });
+afterEach(async () => {
+    try {
+        if (createdIds.length) await post('/beaver/delete-items', { item_ids: createdIds });
+    } finally {
+        if (fixtureIds.length) await post('/beaver/delete-items', { item_ids: fixtureIds });
+    }
+});
+
+describe('MCP library and annotation tools', () => {
+    it('discovers all four tools with correct read/write hints', async () => {
+        const { tools } = await rpc('tools/list');
+        for (const name of ['list_libraries', 'find_annotations', 'create_highlight_annotations', 'create_note_annotations']) {
+            const tool = tools.find((entry: any) => entry.name === name);
+            expect(tool, `${name} must be enabled in this Zotero instance`).toBeDefined();
+            expect(tool.annotations.readOnlyHint).toBe(!name.startsWith('create_'));
+        }
+    });
+
+    it('lists usable library identities and permissions', async () => {
+        const result = await call('list_libraries');
+        expect(result.total_count).toBe(result.libraries.length);
+        expect(result.libraries.find((library: any) => library.library_ref === 'u')).toMatchObject({ read_only: false, is_group: false });
+        expect(result.libraries.every((library: any) => Number.isInteger(library.item_count))).toBe(true);
+    });
+
+    it('finds no annotations for a unique unused tag', async () => {
+        const result = await call('find_annotations', { tag });
+        expect(result).toMatchObject({ annotations: [], total_count: 0, has_more: false, next_offset: null });
+    });
+
+    for (const type of ['highlight', 'note']) {
+        it(`creates a ${type} using extracted PDF geometry and finds its persisted content`, async () => {
+            const document = await call('read_attachment', { attachment_id: attachmentId, start_page: 1, end_page: 1, include_annotation_locations: true });
+            const passage = document.pages[0].passages.find((item: any) => item.text?.trim());
+            expect(passage).toBeDefined();
+            const item = type === 'highlight'
+                ? { text: passage.text, page_locations: passage.page_locations, comment: 'MCP live highlight', color: 'blue' }
+                : { note_position: passage.note_position, comment: 'MCP live sticky note', color: 'green' };
+            const result = await call(`create_${type}_annotations`, { attachment_id: attachmentId, items: [item], tags: [tag] });
+            expect(result).toMatchObject({ total_created: 1, total_failed: 0 });
+            expect(result.created[0].annotation_id).toMatch(/^u-/);
+            const found = await call('find_annotations', { attachment_id: attachmentId, tag, annotation_type: type });
+            expect(found.total_count).toBe(1);
+            expect(found.annotations[0]).toMatchObject({ annotation_id: result.created[0].annotation_id, comment: item.comment, annotation_type: type, tags: [tag] });
+            if (type === 'highlight') expect(found.annotations[0].text).toBe(passage.text);
+            expect(found.annotations[0].page).toBe(1);
+        }, 120000);
+    }
+
+    it('returns successful writes alongside out-of-range page failures', async () => {
+        const position = { page_index: 0, x: 100, y: 100, side: 'right', coord_origin: 't' };
+        const { result, data } = await call('create_note_annotations', { attachment_id: attachmentId, tags: [tag], items: [
+            { comment: 'Valid page', note_position: position },
+            { comment: 'Invalid page', note_position: { ...position, page_index: 999999 } },
+        ] }, true);
+        expect(result.isError).toBe(true);
+        expect(data).toMatchObject({ total_created: 1, total_failed: 1 });
+        expect(data.failed[0].index).toBe(1);
+        expect((await call('find_annotations', { tag })).total_count).toBe(1);
+    }, 120000);
+
+    it('rejects PDF notes without a PDF position instead of silently placing them on page one', async () => {
+        const { result } = await call('create_note_annotations', { attachment_id: attachmentId, items: [{ comment: 'Invalid locator', anchor_id: 'p1' }] }, true);
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('note_position');
+    });
+});
+
+
+describe('MCP excluded-library boundary', () => {
+    it('hides excluded libraries and rejects annotation reads and both writes', async () => {
+        const original = await getExcludedLibraries();
+        try {
+            expect((await setExcludedLibraries([SMALL_PDF.library_id])).ok).toBe(true);
+            const libraries = await call('list_libraries');
+            expect(libraries.libraries.some((library: any) => library.library_id === SMALL_PDF.library_id)).toBe(false);
+            const search = await call('find_annotations', { library: SMALL_PDF.library_id, tag }, true);
+            expect(search.result.isError).toBe(true);
+            for (const name of ['create_highlight_annotations', 'create_note_annotations']) {
+                const item = name === 'create_highlight_annotations'
+                    ? { text: 'Excluded source', page_locations: [{ page_idx: 0, boxes: [{ l: 10, t: 20, r: 80, b: 30, coord_origin: 't' }] }] }
+                    : { comment: 'Excluded note', note_position: { page_index: 0, x: 100, y: 100, side: 'right', coord_origin: 't' } };
+                const response = await call(name, { attachment_id: attachmentId, items: [item], tags: [tag] }, true);
+                expect(response.result.isError).toBe(true);
+                expect(response.result.content[0].text).toMatch(/excluded|not searchable/i);
+            }
+        } finally {
+            expect((await restoreExcludedLibraries(original.excluded_libraries)).ok).toBe(true);
+        }
+        expect((await call('find_annotations', { tag })).total_count).toBe(0);
+    });
+});
+
+
+describe('MCP EPUB and snapshot annotations', () => {
+    for (const kind of ['epub', 'snapshot'] as const) {
+        for (const type of ['highlight', 'note']) {
+            it(`creates and reads back a ${kind} ${type} using returned locators`, async () => {
+                let attachment_id = `${NON_PDF.library_id}-${NON_PDF.zotero_key}`;
+                if (kind === 'snapshot') {
+                    const fixture = await post<any>('/beaver/test/create-report', { libraryID: SMALL_PDF.library_id, spec: {
+                        title: 'MCP annotation test', sections: [{ heading: 'Passage', blocks: [{ type: 'paragraph', text: 'This temporary local HTML snapshot contains a source passage for verifying that MCP annotations can be created and read back.' }] }],
+                    } });
+                    expect(fixture.ok, fixture.error).toBe(true);
+                    attachment_id = `${fixture.report.libraryID}-${fixture.report.key}`;
+                    fixtureIds.push(attachment_id);
+                }
+                const document = await call('read_attachment', { attachment_id, include_annotation_locations: true });
+                expect(document.content_kind).toBe(kind);
+                const passage = document.passages.find((entry: any) => entry.text.length > 60);
+                expect(passage).toBeDefined();
+                const created = await call(`create_${type}_annotations`, { attachment_id, tags: [tag], items: [{ ...passage, comment: 'MCP DOM annotation' }] });
+                expect(created).toMatchObject({ total_created: 1, total_failed: 0 });
+                const found = await call('find_annotations', { attachment_id, tag, annotation_type: type });
+                expect(found.total_count).toBe(1);
+                expect(found.annotations[0]).toMatchObject({ annotation_id: created.created[0].annotation_id, comment: 'MCP DOM annotation' });
+            }, 120000);
+        }
+    }
+});

--- a/tests/live/mcpAnnotationTools.live.test.ts
+++ b/tests/live/mcpAnnotationTools.live.test.ts
@@ -1,4 +1,4 @@
-/** Exercise the actual JSON-RPC endpoint with MCP and annotation tools enabled. */
+/** Exercise the actual JSON-RPC endpoint with the MCP server and write tools enabled. */
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { isZoteroAvailable, skipIfNoZotero } from '../helpers/zoteroAvailability';
 import { SMALL_PDF, NON_PDF } from '../helpers/fixtures';

--- a/tests/unit/handlers/mcpToolHandlers.test.ts
+++ b/tests/unit/handlers/mcpToolHandlers.test.ts
@@ -2877,6 +2877,35 @@ describe('MCP libraries and annotations', () => {
         expect(result.passages).toEqual([{ text: 'Source passage.', anchor_id: 'intro', ...(content_kind === 'epub' ? { section_href: 'chapter.xhtml', section_ordinal: 1 } : {}) }]);
     });
 
+    it.each(['pdf', 'epub', 'snapshot'])('uses the same range error for %s annotation locations', async content_kind => {
+        const result = content_kind === 'pdf'
+            ? { content_kind, mode: 'structured', document: { pageCount: 1, pages: [{ index: 0, items: [] }] } }
+            : { content_kind, pageCount: 1, sections: [{ index: 0, rawHref: 'chapter.xhtml', items: [] }] };
+        mockHandleZoteroDocumentRequest.mockResolvedValue({ result });
+        const response = await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', start_page: 2, include_annotation_locations: true });
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain('Requested start_page 2 is out of range; attachment has 1 pages.');
+    });
+
+    it('rejects an empty structured PDF page window', async () => {
+        mockHandleZoteroDocumentRequest.mockResolvedValue({ result: { content_kind: 'pdf', mode: 'structured', document: { pageCount: 2, pages: [{ index: 0, items: [] }] } } });
+        const response = await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', start_page: 2, include_annotation_locations: true });
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain('contains no extractable pages');
+    });
+
+    it('does not silently return empty locations when extraction returns markdown', async () => {
+        mockHandleZoteroDocumentRequest.mockResolvedValue({ result: { content_kind: 'pdf', mode: 'markdown', document: { pageCount: 1, pages: [{ index: 0, markdown: 'Source' }] } } });
+        expect((await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', include_annotation_locations: true })).isError).toBe(true);
+    });
+
+    it('rejects a mixed PDF note batch before any write when one item lacks a position', async () => {
+        const response = await callTool(endpoint, 'create_note_annotations', { attachment_id: 'u-ATT00001', items: [note, { comment: 'Missing position' }] });
+        expect(response.isError).toBe(true);
+        expect(mockValidateAnnotationNotes).toHaveBeenCalledOnce();
+        expect(mockExecuteAnnotationNotes).not.toHaveBeenCalled();
+    });
+
     it('returns copyable PDF geometry from read_attachment', async () => {
         mockHandleZoteroDocumentRequest.mockResolvedValue({ result: { content_kind: 'pdf', mode: 'structured', document: { pageCount: 2, pages: [
             { index: 0, items: [] },

--- a/tests/unit/handlers/mcpToolHandlers.test.ts
+++ b/tests/unit/handlers/mcpToolHandlers.test.ts
@@ -28,10 +28,9 @@ const mockValidateHighlights = vi.fn();
 const mockExecuteHighlights = vi.fn();
 const mockValidateAnnotationNotes = vi.fn();
 const mockExecuteAnnotationNotes = vi.fn();
-const mockMcpAnnotationToolsEnabled = vi.hoisted(() => ({ value: false }));
 const mockValidateCreateNoteAction = vi.fn();
 const mockExecuteCreateNoteAction = vi.fn();
-const mockMcpCreateNoteToolEnabled = vi.hoisted(() => ({ value: false }));
+const mockMcpWriteToolsEnabled = vi.hoisted(() => ({ value: false }));
 
 vi.mock('../../../src/services/agentDataProvider', () => ({
     handleItemSearchByTopicRequest: (...args: any[]) => mockHandleItemSearchByTopicRequest(...args),
@@ -66,9 +65,8 @@ vi.mock('../../../react/atoms/auth', () => ({
 }));
 
 vi.mock('../../../react/atoms/ui', () => ({
-    mcpAnnotationToolsEnabledAtom: { toString: () => 'mcpAnnotationToolsEnabledAtom' },
     mcpServerEnabledAtom: { toString: () => 'mcpServerEnabledAtom' },
-    mcpCreateNoteToolEnabledAtom: { toString: () => 'mcpCreateNoteToolEnabledAtom' },
+    mcpWriteToolsEnabledAtom: { toString: () => 'mcpWriteToolsEnabledAtom' },
 }));
 
 vi.mock('../../../react/store', () => ({
@@ -85,10 +83,7 @@ vi.mock('react', () => ({
 
 vi.mock('jotai', () => ({
     useAtomValue: vi.fn((atom: any) => {
-        if (atom?.toString?.() === 'mcpAnnotationToolsEnabledAtom') return mockMcpAnnotationToolsEnabled.value;
-        if (atom?.toString?.() === 'mcpCreateNoteToolEnabledAtom') {
-            return mockMcpCreateNoteToolEnabled.value;
-        }
+        if (atom?.toString?.() === 'mcpWriteToolsEnabledAtom') return mockMcpWriteToolsEnabled.value;
         return true; // MCP server enabled and authenticated by default
     }),
 }));
@@ -100,8 +95,7 @@ vi.mock('jotai', () => ({
 const zotero = (globalThis as any).Zotero;
 
 beforeEach(() => {
-    mockMcpCreateNoteToolEnabled.value = false;
-    mockMcpAnnotationToolsEnabled.value = false;
+    mockMcpWriteToolsEnabled.value = false;
     zotero.Utilities = { randomString: vi.fn(() => 'test-request-id') };
     zotero.DataDirectory = { dir: '/mock/data' };
     zotero.Server = { Endpoints: {} };
@@ -246,15 +240,19 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
             expect(result.tools).toHaveLength(10);
         });
 
-        it('registers create_note when enabled by preference', async () => {
-            mockMcpCreateNoteToolEnabled.value = true;
+        it('registers every write tool when enabled by preference', async () => {
+            mockMcpWriteToolsEnabled.value = true;
             endpoint = setupMcpEndpoint();
 
             const result = await listTools(endpoint);
             const names = result.tools.map((t: any) => t.name);
 
-            expect(names).toContain('create_note');
-            expect(result.tools).toHaveLength(11);
+            expect(names).toEqual(expect.arrayContaining([
+                'create_note',
+                'create_highlight_annotations',
+                'create_note_annotations',
+            ]));
+            expect(result.tools).toHaveLength(13);
         });
 
         it('each tool has name, description, and inputSchema', async () => {
@@ -281,7 +279,7 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
         });
 
         it('advertises MCP tool annotations', async () => {
-            mockMcpCreateNoteToolEnabled.value = true;
+            mockMcpWriteToolsEnabled.value = true;
             endpoint = setupMcpEndpoint();
 
             const result = await listTools(endpoint);
@@ -1314,7 +1312,7 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
 
     describe('create_note', () => {
         beforeEach(() => {
-            mockMcpCreateNoteToolEnabled.value = true;
+            mockMcpWriteToolsEnabled.value = true;
             endpoint = setupMcpEndpoint();
         });
 
@@ -2702,7 +2700,7 @@ describe('MCP portable ids', () => {
     });
 
     it('create_note returns portable note ids', async () => {
-        mockMcpCreateNoteToolEnabled.value = true;
+        mockMcpWriteToolsEnabled.value = true;
         endpoint = setupMcpEndpoint();
         mockValidateCreateNoteAction.mockResolvedValue({ valid: true });
         mockExecuteCreateNoteAction.mockResolvedValue({
@@ -2733,7 +2731,7 @@ describe('MCP libraries and annotations', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         zotero.Libraries.userLibraryID = 1;
-        mockMcpAnnotationToolsEnabled.value = true;
+        mockMcpWriteToolsEnabled.value = true;
         endpoint = setupMcpEndpoint();
         for (const validate of [mockValidateHighlights, mockValidateAnnotationNotes]) {
             validate.mockResolvedValue({ valid: true, current_value: { content_kind: 'pdf' } });
@@ -2743,7 +2741,7 @@ describe('MCP libraries and annotations', () => {
         }
     });
 
-    it('advertises reads by default and writes only with their separate preference', async () => {
+    it('advertises reads by default and writes only with the write tools preference', async () => {
         let tools = (await listTools(endpoint)).tools;
         for (const name of ['list_libraries', 'find_annotations']) {
             expect(tools.find((tool: any) => tool.name === name).annotations.readOnlyHint).toBe(true);
@@ -2751,7 +2749,7 @@ describe('MCP libraries and annotations', () => {
         for (const name of ['create_highlight_annotations', 'create_note_annotations']) {
             expect(tools.find((tool: any) => tool.name === name).annotations).toMatchObject({ readOnlyHint: false, idempotentHint: false, destructiveHint: false });
         }
-        mockMcpAnnotationToolsEnabled.value = false;
+        mockMcpWriteToolsEnabled.value = false;
         endpoint = setupMcpEndpoint();
         tools = (await listTools(endpoint)).tools;
         expect(tools.map((tool: any) => tool.name)).not.toContain('create_highlight_annotations');

--- a/tests/unit/handlers/mcpToolHandlers.test.ts
+++ b/tests/unit/handlers/mcpToolHandlers.test.ts
@@ -22,6 +22,13 @@ const mockHandleListCollectionsRequest = vi.fn();
 const mockHandleListTagsRequest = vi.fn();
 const mockHandleListItemsRequest = vi.fn();
 const mockHandleReadNoteRequest = vi.fn();
+const mockHandleListLibrariesRequest = vi.fn();
+const mockHandleFindAnnotationsRequest = vi.fn();
+const mockValidateHighlights = vi.fn();
+const mockExecuteHighlights = vi.fn();
+const mockValidateAnnotationNotes = vi.fn();
+const mockExecuteAnnotationNotes = vi.fn();
+const mockMcpAnnotationToolsEnabled = vi.hoisted(() => ({ value: false }));
 const mockValidateCreateNoteAction = vi.fn();
 const mockExecuteCreateNoteAction = vi.fn();
 const mockMcpCreateNoteToolEnabled = vi.hoisted(() => ({ value: false }));
@@ -35,6 +42,12 @@ vi.mock('../../../src/services/agentDataProvider', () => ({
     handleListTagsRequest: (...args: any[]) => mockHandleListTagsRequest(...args),
     handleListItemsRequest: (...args: any[]) => mockHandleListItemsRequest(...args),
     handleReadNoteRequest: (...args: any[]) => mockHandleReadNoteRequest(...args),
+    handleListLibrariesRequest: (...args: any[]) => mockHandleListLibrariesRequest(...args),
+    handleFindAnnotationsRequest: (...args: any[]) => mockHandleFindAnnotationsRequest(...args),
+    validateCreateHighlightAnnotationsAction: (...args: any[]) => mockValidateHighlights(...args),
+    executeCreateHighlightAnnotationsAction: (...args: any[]) => mockExecuteHighlights(...args),
+    validateCreateNoteAnnotationsAction: (...args: any[]) => mockValidateAnnotationNotes(...args),
+    executeCreateNoteAnnotationsAction: (...args: any[]) => mockExecuteAnnotationNotes(...args),
     validateCreateNoteAction: (...args: any[]) => mockValidateCreateNoteAction(...args),
     executeCreateNoteAction: (...args: any[]) => mockExecuteCreateNoteAction(...args),
 }));
@@ -53,6 +66,7 @@ vi.mock('../../../react/atoms/auth', () => ({
 }));
 
 vi.mock('../../../react/atoms/ui', () => ({
+    mcpAnnotationToolsEnabledAtom: { toString: () => 'mcpAnnotationToolsEnabledAtom' },
     mcpServerEnabledAtom: { toString: () => 'mcpServerEnabledAtom' },
     mcpCreateNoteToolEnabledAtom: { toString: () => 'mcpCreateNoteToolEnabledAtom' },
 }));
@@ -71,6 +85,7 @@ vi.mock('react', () => ({
 
 vi.mock('jotai', () => ({
     useAtomValue: vi.fn((atom: any) => {
+        if (atom?.toString?.() === 'mcpAnnotationToolsEnabledAtom') return mockMcpAnnotationToolsEnabled.value;
         if (atom?.toString?.() === 'mcpCreateNoteToolEnabledAtom') {
             return mockMcpCreateNoteToolEnabled.value;
         }
@@ -86,6 +101,7 @@ const zotero = (globalThis as any).Zotero;
 
 beforeEach(() => {
     mockMcpCreateNoteToolEnabled.value = false;
+    mockMcpAnnotationToolsEnabled.value = false;
     zotero.Utilities = { randomString: vi.fn(() => 'test-request-id') };
     zotero.DataDirectory = { dir: '/mock/data' };
     zotero.Server = { Endpoints: {} };
@@ -227,7 +243,7 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
             expect(names).toContain('list_collections');
             expect(names).toContain('list_tags');
             expect(names).toContain('list_items');
-            expect(result.tools).toHaveLength(8);
+            expect(result.tools).toHaveLength(10);
         });
 
         it('registers create_note when enabled by preference', async () => {
@@ -238,7 +254,7 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
             const names = result.tools.map((t: any) => t.name);
 
             expect(names).toContain('create_note');
-            expect(result.tools).toHaveLength(9);
+            expect(result.tools).toHaveLength(11);
         });
 
         it('each tool has name, description, and inputSchema', async () => {
@@ -2704,5 +2720,171 @@ describe('MCP portable ids', () => {
 
         expect(data.note_id).toBe('u-NOTE0001');
         expect(data.parent_item_id).toBe('u-PARENT01');
+    });
+});
+
+describe('MCP libraries and annotations', () => {
+    let endpoint: Endpoint;
+    const box = { l: 10, t: 20, r: 80, b: 30, coord_origin: 't' };
+    const highlight = { text: 'A source sentence.', page_locations: [{ page_idx: 0, boxes: [box] }] };
+    const note = { comment: 'A reading note.', note_position: { page_index: 0, x: 80, y: 25, side: 'right', coord_origin: 't' } };
+    const created = { library_id: 1, library_ref: 'u', zotero_key: 'ANNOT001', index: 0, client_item_id: '0' };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        zotero.Libraries.userLibraryID = 1;
+        mockMcpAnnotationToolsEnabled.value = true;
+        endpoint = setupMcpEndpoint();
+        for (const validate of [mockValidateHighlights, mockValidateAnnotationNotes]) {
+            validate.mockResolvedValue({ valid: true, current_value: { content_kind: 'pdf' } });
+        }
+        for (const execute of [mockExecuteHighlights, mockExecuteAnnotationNotes]) {
+            execute.mockResolvedValue({ success: true, result_data: { created: [created], failed: [], total_created: 1, total_failed: 0 } });
+        }
+    });
+
+    it('advertises reads by default and writes only with their separate preference', async () => {
+        let tools = (await listTools(endpoint)).tools;
+        for (const name of ['list_libraries', 'find_annotations']) {
+            expect(tools.find((tool: any) => tool.name === name).annotations.readOnlyHint).toBe(true);
+        }
+        for (const name of ['create_highlight_annotations', 'create_note_annotations']) {
+            expect(tools.find((tool: any) => tool.name === name).annotations).toMatchObject({ readOnlyHint: false, idempotentHint: false, destructiveHint: false });
+        }
+        mockMcpAnnotationToolsEnabled.value = false;
+        endpoint = setupMcpEndpoint();
+        tools = (await listTools(endpoint)).tools;
+        expect(tools.map((tool: any) => tool.name)).not.toContain('create_highlight_annotations');
+        expect(tools.map((tool: any) => tool.name)).not.toContain('create_note_annotations');
+        expect((await callTool(endpoint, 'create_note_annotations', { attachment_id: 'u-ATT00001', items: [note] }))._error).toBeDefined();
+        expect(mockExecuteAnnotationNotes).not.toHaveBeenCalled();
+    });
+
+    it('lists available library identities, permissions, and counts', async () => {
+        const libraries = [{ library_ref: 'u', library_id: 1, name: 'My Library', read_only: false, item_count: 12 }];
+        mockHandleListLibrariesRequest.mockResolvedValue({ libraries, total_count: 1 });
+        const result = JSON.parse((await callTool(endpoint, 'list_libraries')).content[0].text);
+        expect(result).toEqual({ libraries, total_count: 1 });
+        expect(mockHandleListLibrariesRequest).toHaveBeenCalledWith(expect.objectContaining({ event: 'list_libraries_request' }));
+    });
+
+    it('returns an empty library set without fabricating a default library', async () => {
+        mockHandleListLibrariesRequest.mockResolvedValue({ libraries: [], total_count: 0 });
+        expect(JSON.parse((await callTool(endpoint, 'list_libraries')).content[0].text)).toEqual({ libraries: [], total_count: 0 });
+    });
+
+    it('reports library listing failures as MCP tool errors', async () => {
+        mockHandleListLibrariesRequest.mockRejectedValue(new Error('Database unavailable'));
+        expect(await callTool(endpoint, 'list_libraries')).toMatchObject({ isError: true });
+    });
+
+    it('forwards annotation filters and formats pagination and links', async () => {
+        const args = { library: 'u', text_contains: 'source', comment_contains: 'note', tag: 'review', color: 'yellow',
+            annotation_type: 'highlight', author: 'Beaver', attachment_id: 'u-ATT00001', collection: 'Reading',
+            recursive: false, modified_in_last: '7 days', sort_by: 'reading_order', sort_order: 'asc', offset: 1, limit: 1 };
+        mockHandleFindAnnotationsRequest.mockResolvedValue({ annotations: [{ annotation_id: 'u-ANNOT001', text: 'source', attachment_id: 'u-ATT00001' }], total_count: 3, note: 'Scan capped' });
+        const result = JSON.parse((await callTool(endpoint, 'find_annotations', args)).content[0].text);
+        const { library, ...filters } = args;
+        expect(mockHandleFindAnnotationsRequest).toHaveBeenCalledWith(expect.objectContaining({ ...filters, library_id: library }));
+        expect(result).toMatchObject({ total_count: 3, has_more: true, next_offset: 2, note: 'Scan capped' });
+        expect(result.annotations[0].zotero_uri).toContain('ANNOT001');
+    });
+
+    it('supplies search defaults and terminates pagination on an empty page', async () => {
+        mockHandleFindAnnotationsRequest.mockResolvedValue({ annotations: [], total_count: 0 });
+        const result = JSON.parse((await callTool(endpoint, 'find_annotations', { tag: 'missing' })).content[0].text);
+        expect(mockHandleFindAnnotationsRequest).toHaveBeenCalledWith(expect.objectContaining({ limit: 25, offset: 0, recursive: true, sort_by: 'date_modified', sort_order: 'desc' }));
+        expect(result).toMatchObject({ has_more: false, next_offset: null });
+    });
+
+    it.each([{ limit: 0 }, { limit: 51 }, { offset: -1 }, { offset: 1.5 }, { recursive: 'yes' }, { tag: [] }, { annotation_type: 'ink' }, { sort_by: 'bogus' }])('rejects invalid search inputs %j', async args => {
+        expect((await callTool(endpoint, 'find_annotations', args)).isError).toBe(true);
+        expect(mockHandleFindAnnotationsRequest).not.toHaveBeenCalled();
+    });
+
+    it('preserves exclusion failures from the annotation search handler', async () => {
+        mockHandleFindAnnotationsRequest.mockResolvedValue({ error: 'Library is excluded', error_code: 'library_not_searchable' });
+        const result = await callTool(endpoint, 'find_annotations', { library: 'u', tag: 'review' });
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('excluded');
+    });
+
+    for (const [name, item, validate, execute] of [
+        ['create_highlight_annotations', highlight, mockValidateHighlights, mockExecuteHighlights],
+        ['create_note_annotations', note, mockValidateAnnotationNotes, mockExecuteAnnotationNotes],
+    ] as const) {
+        describe(name, () => {
+            it('validates then executes with portable references and returns created IDs', async () => {
+                validate.mockResolvedValue({ valid: true, current_value: { content_kind: 'pdf' }, normalized_action_data: { tags: ['normalized'] } });
+                const result = await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items: [item], tags: ['review'] });
+                expect(result.isError).not.toBe(true);
+                expect(validate).toHaveBeenCalledWith(expect.objectContaining({ action_type: name, action_data: expect.objectContaining({ resolved_ref: { library_id: 1, library_ref: 'u', zotero_key: 'ATT00001' } }) }));
+                expect(execute).toHaveBeenCalledWith(expect.objectContaining({ action_data: expect.objectContaining({ tags: ['normalized'], items: [expect.objectContaining({ ...item, index: 0, color: 'yellow' })] }) }), expect.objectContaining({ timeoutSeconds: 120 }));
+                expect(JSON.parse(result.content[0].text).created[0]).toMatchObject({ annotation_id: 'u-ANNOT001', zotero_uri: expect.stringContaining('ANNOT001') });
+            });
+
+            it.each(['Library is excluded', 'Library is read-only', 'Attachment file is not available locally'])('does not execute when validation fails: %s', async error => {
+                validate.mockResolvedValue({ valid: false, error });
+                const result = await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items: [item] });
+                expect(result).toMatchObject({ isError: true });
+                expect(result.content[0].text).toContain(error);
+                expect(execute).not.toHaveBeenCalled();
+            });
+
+            it.each([[], [null], Array(51).fill(item), [{ ...item, color: 'invisible' }]])('rejects invalid batches before validation', async items => {
+                expect((await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items })).isError).toBe(true);
+                expect(validate).not.toHaveBeenCalled();
+                expect(execute).not.toHaveBeenCalled();
+            });
+
+            it('returns partial successes together with failures and sets isError', async () => {
+                execute.mockResolvedValue({ success: true, result_data: { created: [created], failed: [{ index: 1, error: 'Missing geometry' }], total_created: 1, total_failed: 1 } });
+                const result = await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items: [item, item] });
+                expect(result.isError).toBe(true);
+                expect(JSON.parse(result.content[0].text)).toMatchObject({ total_created: 1, total_failed: 1, failed: [{ index: 1, error: 'Missing geometry' }] });
+            });
+
+            it('reports execution errors without pretending annotations were created', async () => {
+                execute.mockResolvedValue({ success: false, error: 'Library became excluded' });
+                expect((await callTool(endpoint, name, { attachment_id: '1-ATT00001', items: [item] })).isError).toBe(true);
+            });
+
+            it('requires PDF geometry instead of accepting a DOM locator', async () => {
+                const domItem = name === 'create_highlight_annotations' ? { text: 'Source', section_ordinal: 1 } : { comment: 'Note', anchor_id: 'p1' };
+                expect((await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items: [domItem] })).isError).toBe(true);
+                expect(execute).not.toHaveBeenCalled();
+            });
+
+            it('accepts EPUB section and text locators without PDF geometry', async () => {
+                validate.mockResolvedValue({ valid: true, current_value: { content_kind: 'epub' } });
+                const result = await callTool(endpoint, name, { attachment_id: 'u-ATT00001', items: [{ text: 'Source passage', comment: 'Note', section_ordinal: 2 }] });
+                expect(result.isError).not.toBe(true);
+                expect(execute).toHaveBeenCalledOnce();
+            });
+        });
+    }
+
+    it('rejects inverted highlight boxes', async () => {
+        expect((await callTool(endpoint, 'create_highlight_annotations', { attachment_id: 'u-ATT00001', items: [{ ...highlight, page_locations: [{ page_idx: 0, boxes: [{ ...box, r: 1 }] }] }] })).isError).toBe(true);
+        expect(mockExecuteHighlights).not.toHaveBeenCalled();
+    });
+
+    it.each(['epub', 'snapshot'])('returns copyable %s locators using section identities rather than synthetic page numbers', async content_kind => {
+        mockHandleZoteroDocumentRequest.mockResolvedValue({ result: { content_kind, pageCount: 3, sections: [
+            { index: 0, rawHref: 'chapter.xhtml', items: [{ kind: 'picture', order: 0, sectionIndex: 0, anchorId: 'cover', pageNumber: 3, text: 'Image alt text' }, { kind: 'text', order: 1, sectionIndex: 0, anchorId: 'intro', pageNumber: 3, text: 'Source passage.' }] },
+        ] } });
+        const result = JSON.parse((await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', start_page: 3, include_annotation_locations: true })).content[0].text);
+        expect(result.passages).toEqual([{ text: 'Source passage.', anchor_id: 'intro', ...(content_kind === 'epub' ? { section_href: 'chapter.xhtml', section_ordinal: 1 } : {}) }]);
+    });
+
+    it('returns copyable PDF geometry from read_attachment', async () => {
+        mockHandleZoteroDocumentRequest.mockResolvedValue({ result: { content_kind: 'pdf', mode: 'structured', document: { pageCount: 2, pages: [
+            { index: 0, items: [] },
+            { index: 1, label: 'iii', items: [{ kind: 'text', text: 'Source.', bbox: [10, 20, 80, 30], sentences: [{ text: 'Source.', bboxes: [[10, 20, 80, 30]] }] }] },
+        ] } } });
+        const result = JSON.parse((await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', start_page: 2, include_annotation_locations: true })).content[0].text);
+        expect(mockHandleZoteroDocumentRequest).toHaveBeenCalledWith(expect.objectContaining({ mode: 'structured' }));
+        expect(result.pages).toHaveLength(1);
+        expect(result.pages[0].passages[0]).toEqual({ text: 'Source.', page_locations: [{ page_idx: 1, page_label: 'iii', boxes: [box] }], note_position: { ...note.note_position, page_index: 1 } });
     });
 });

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -77,7 +77,6 @@ declare namespace _ZoteroTypes {
       "threadsClaimKey": string;
       "mcpServerEnabled": boolean;
       "mcpCreateNoteToolEnabled": boolean;
-      "mcpAnnotationToolsEnabled": boolean;
       "backgroundExtractorEnabled": boolean;
       "backgroundProcessingEnabled": boolean;
       "backgroundProcessingContinuous": boolean;

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -77,6 +77,7 @@ declare namespace _ZoteroTypes {
       "threadsClaimKey": string;
       "mcpServerEnabled": boolean;
       "mcpCreateNoteToolEnabled": boolean;
+      "mcpAnnotationToolsEnabled": boolean;
       "backgroundExtractorEnabled": boolean;
       "backgroundProcessingEnabled": boolean;
       "backgroundProcessingContinuous": boolean;


### PR DESCRIPTION
## Summary

- Add MCP tools for listing libraries, searching annotations, and creating highlights or sticky notes.
- Add annotation-tool preference gating and portable library reference support.
- Document the new MCP tools, inputs, validation, and response formats.
- Remove obsolete release-note showcase and quick-prompt shortcut code.

## Testing

- Added live MCP annotation tool coverage.
- Expanded MCP handler unit tests.
- Updated table-store unit tests and related popup/feature-tip test coverage.