### PR TITLE
fix(mcp): resolve filter schema, identity, and search edge cases

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -177,7 +177,7 @@ Semantic (meaning-based) search across the user's Zotero library. The most impor
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `topic_query` | `string` | Yes | Concise topic phrase (2-8 words). Use canonical academic terms. |
-| `author_filter` | `string[]` | No | Author last names (OR logic). |
+| `author_filter` | `string[]` | No | Creator names (first, last, full, or institutional) (OR logic). |
 | `min_year` | `integer` | No | Earliest publication year (inclusive). |
 | `max_year` | `integer` | No | Latest publication year (inclusive). |
 | `libraries_filter` | `string[]` | No | Library names or IDs. |
@@ -198,7 +198,7 @@ Find specific papers when you know bibliographic details (author name, title key
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `author_query` | `string` | No* | Author's last name to search for. |
+| `author_query` | `string` | No* | Creator name tokens (first, last, full, or institutional); case-insensitive within one creator. |
 | `title_query` | `string` | No* | Keyword or phrase from the title. |
 | `publication_query` | `string` | No* | Journal or publication name. |
 | `min_year` | `integer` | No | Earliest publication year (inclusive). |
@@ -217,15 +217,16 @@ Find specific papers when you know bibliographic details (author name, title key
 
 ### `read_attachment`
 
-Read the text content of a PDF attachment from the user's Zotero library. Maximum 30 pages per request.
+Read supported attachment text from the user's Zotero library. Maximum 30 pages per request; EPUB page windows use extraction pages, not section ordinals.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `attachment_id` | `string` | Yes | Attachment ID in `<library_id>-<zotero_key>` format. |
 | `start_page` | `integer` | No | Starting page number (1-indexed). Default: 1. |
 | `end_page` | `integer` | No | Ending page number (inclusive). Default: last page (up to 30). |
+| `include_annotation_locations` | `boolean` | No | Return structured source passages and copyable annotation locators. Default: false. |
 
-**Response**: Plain text with page content wrapped in `<pageN>...</pageN>` XML tags. Includes a header with attachment ID, total page count, and the page range shown.
+**Response**: With `include_annotation_locations=true`, JSON discriminated by `content_kind`: PDF uses `pages[].passages[]`, while EPUB and snapshots use `passages[]`. Otherwise, plain text with page content wrapped in `<pageN>...</pageN>` XML tags. Includes a header with attachment ID, total page count, and the page range shown.
 
 **Underlying handler**: `handleZoteroDocumentRequest` from `src/services/agentDataProvider/`, sliced to the requested page window.
 
@@ -291,7 +292,8 @@ List collections (folders) in the user's Zotero library.
 |-----------|------|----------|-------------|
 | `library` | `string` | No | Library name or ID. Default: user's library. |
 | `parent_collection` | `string` | No | Collection key to list subcollections within. |
-| `include_item_counts` | `boolean` | No | Include item counts. Default: true. |
+| `recursive` | `boolean` | No | Include every descendant instead of direct children only. Default: false. |
+| `include_item_counts` | `boolean` | No | Include item counts. Default: true. Counts are omitted when false. |
 | `limit` | `integer` | No | Max results per page (default 50, max 100). |
 | `offset` | `integer` | No | Results to skip for pagination (default 0). |
 
@@ -309,11 +311,13 @@ List tags in the user's Zotero library.
 |-----------|------|----------|-------------|
 | `library` | `string` | No | Library name or ID. Default: user's library. |
 | `collection` | `string` | No | Collection key to list tags within. |
-| `min_item_count` | `integer` | No | Minimum items a tag must have. Default: 1. |
+| `name_query` | `string` | No | Case-insensitive tag-name substring. |
+| `tag_type` | `string` | No | `manual` (default), `automatic`, or `all`. Mixed tags count as manual. |
+| `min_item_count` | `integer` | No | Minimum tagged objects (regular items, attachments, notes, and annotations). Default: 1. |
 | `limit` | `integer` | No | Max results per page (default 50, max 100). |
 | `offset` | `integer` | No | Results to skip for pagination (default 0). |
 
-**Response**: JSON with `total_count`, `has_more`, `next_offset`, and `tags[]`. Each tag has `name`, `item_count`, and optionally `color`.
+**Response**: JSON with `total_count`, `has_more`, `next_offset`, and `tags[]`. Each tag has `name`, `tag_type`, per-object-type counts, and optionally `color`. `manual_count` and `automatic_count` apply after `name_query` and `min_item_count`, before `tag_type` and pagination.
 
 **Underlying handler**: `handleListTagsRequest` from `src/services/agentDataProvider/`.
 
@@ -328,7 +332,7 @@ Browse items in the library, optionally filtered by collection or tag.
 | `library` | `string` | No | Library name or ID. Default: user's library. |
 | `collection` | `string` | No | Collection name or key. |
 | `tag` | `string` | No | Tag to filter by. |
-| `item_category` | `string` | No | Item type to return: "regular", "note", "attachment", "annotation", or "all". Default: "regular". |
+| `item_category` | `string` | No | Item type to return: "regular", "note", "attachment", or "all"; use `find_annotations` for annotations. Default: "regular". |
 | `recursive` | `boolean` | No | Include subcollection items. Default: true. |
 | `sort_by` | `string` | No | Sort field: "dateAdded", "dateModified", "title", "creator", "year". Default: "dateModified". |
 | `sort_order` | `string` | No | "asc" or "desc". Default: "desc". |
@@ -353,7 +357,7 @@ Use `library_ref` in the `library` argument of library-scoped tools.
 Searches annotation text and comments, with optional `tag`, `color`,
 `annotation_type` (`highlight`, `underline`, `note`), `author`, `attachment_id`,
 `collection`, `library`, and `modified_in_last` (e.g. `7 days`) filters.
-Supply at least one narrowing filter besides `library`. Filters combine with AND.
+Omit filters to browse all annotations with pagination. Filters combine with AND. `author` matches the annotation creator (for example, `Beaver`), not the paper author. `attachment_id` requires an actual file attachment ID; resolve parent items with `get_item_details(include_attachments=true)` first.
 The personal library is the default. Collection searches recurse by default.
 
 Results include annotation IDs, text, comments, source IDs, tags, and Zotero links.
@@ -382,7 +386,7 @@ creation request; do not invent coordinates. Page indices in locations are
 zero-based; the read tool's page range is one-based. Highlight boxes are PDF
 points in Beaver's extraction frame with an explicit `coord_origin` (`t` for
 top-left, `b` for bottom-left). Multi-page highlights produce one annotation per
-page. Note positions use `page_index`, `x`, `y`, `side`, and `coord_origin`.
+page. Note positions use `page_index`, `x`, `y`, `side`, and `coord_origin`. Copy the passage's `page_label` too; when omitted, PDF note creation resolves it from document metadata. Physical `page` is one-based and distinct from the printed `page_label`.
 
 For EPUBs, provide `section_href` or a one-based `section_ordinal`, plus `text` or
 `anchor_id` to locate the passage. Snapshots use `text` or `anchor_id`. The same
@@ -515,3 +519,13 @@ Add the new tool to the [Available Tools](#available-tools) section above.
 - [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
 - [ ] Tested with `curl` against the endpoint
 - [ ] This document updated with the new tool
+
+### Argument and identity rules
+
+All MCP calls validate types, enums, required fields, and unknown properties before executing. For example, `list_items(tags_filter=[...])` is rejected; its filter is `tag`. Omitted parameters receive documented defaults; invalid categories never fall back to regular items.
+
+Publication-year bounds are inclusive and exclude undated items. Collection names must be unambiguous within the requested scope; ambiguity errors list accessible collection IDs and paths for retrying. Successful metadata results emit portable IDs even when requested with legacy numeric IDs.
+
+`read_note.cited_items` describes resolved citations in the returned line slice, including directly cited attachments. Deleted, excluded, and unresolved targets are omitted.
+
+`list_libraries.tag_count` counts distinct tag names on non-deleted objects, merging manual/automatic uses of the same name. It matches an unfiltered `list_tags(tag_type="all", min_item_count=0)` scope.

--- a/packages/agent-core/src/extract/document/shared/contentKinds.ts
+++ b/packages/agent-core/src/extract/document/shared/contentKinds.ts
@@ -30,6 +30,8 @@ export interface AttachmentStub {
 }
 
 export interface AttachmentInfo extends AttachmentStub {
+    /** MIME type reported by the attachment host. */
+    mime_type?: string | null;
     status: ContentInfoStatus;
     status_code?: string | null;
     status_reason?: string | null;

--- a/packages/agent-core/src/protocol/agentProtocol.ts
+++ b/packages/agent-core/src/protocol/agentProtocol.ts
@@ -626,6 +626,7 @@ export interface WSItemSearchByMetadataRequest extends WSBaseEvent {
 
 /** Error codes for item search failures */
 export type ItemSearchErrorCode =
+    | 'ambiguous_collection'
     | 'internal_error'         // General internal error
     | 'database_error'         // Database/indexing error
     | 'invalid_request'        // Invalid request parameters
@@ -1822,7 +1823,7 @@ export interface CollectionInfo {
      * Top-level regular items directly in this collection, excluding
      * attachments, notes and annotations.
      */
-    item_count: number;
+    item_count?: number;
     /**
      * Attachments sitting directly in this collection rather than under a
      * parent item.

--- a/react/hooks/mcp/libraryAnnotationTools.ts
+++ b/react/hooks/mcp/libraryAnnotationTools.ts
@@ -1,3 +1,4 @@
+import { validateInput } from '../../../src/services/mcpInputValidation';
 import { mcpError, generateRequestId, buildNoopTimeoutContext } from './utils';
 import {
     handleListLibrariesRequest,
@@ -46,7 +47,7 @@ export const LIST_LIBRARIES_TOOL = {
 
 export const FIND_ANNOTATIONS_TOOL = {
     name: 'find_annotations', annotations: { title: 'Find Annotations', ...readHints },
-    description: 'Find highlights, underlines, and note annotations in a Zotero library. Filters are combined with AND; supply at least one filter besides library. Returns annotation text, comments, tags, source IDs, and pagination. Defaults to the personal library; use list_libraries for other libraries.',
+    description: 'Find highlights, underlines, and note annotations in a Zotero library. Filters are combined with AND. Omit filters to browse all annotations with pagination. Returns annotation text, comments, tags, source IDs, and pagination. Defaults to the personal library; use list_libraries for other libraries.',
     inputSchema: {
         type: 'object', additionalProperties: false,
         properties: {
@@ -54,8 +55,8 @@ export const FIND_ANNOTATIONS_TOOL = {
             comment_contains: { ...string, description: 'Substring in annotation comments.' },
             tag: string, color: { ...string, description: 'Zotero color name or hex color (matched to nearest palette color).' },
             annotation_type: { type: 'string', enum: ['highlight', 'underline', 'note'] },
-            author: string,
-            attachment_id: { ...string, description: 'Attachment or parent item ID from another tool.' },
+            author: { ...string, description: 'Annotation creator name substring, not the paper author. Beaver-created annotations have creator "Beaver".' },
+            attachment_id: { ...string, description: 'File attachment ID from another tool. Parent item IDs are not supported; use get_item_details with include_attachments=true to find attachment IDs.' },
             collection: { ...string, description: 'Collection ID or name.' },
             library: { type: ['string', 'integer'], description: 'Library ref (u or g<groupID>), numeric ID, or name.' },
             recursive: { type: 'boolean', default: true },
@@ -105,32 +106,6 @@ function creationTool(highlight: boolean) {
 }
 export const CREATE_HIGHLIGHT_ANNOTATIONS_TOOL = creationTool(true);
 export const CREATE_NOTE_ANNOTATIONS_TOOL = creationTool(false);
-
-/** Validate the JSON Schema subset used by these tools, including direct HTTP calls. */
-function validateInput(value: any, schema: any, path = 'arguments'): void {
-    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
-    const matches = types.some((type: string) => type === 'integer' ? Number.isSafeInteger(value)
-        : type === 'number' ? typeof value === 'number' && Number.isFinite(value)
-            : type === 'array' ? Array.isArray(value)
-                : type === 'object' ? value !== null && typeof value === 'object' && !Array.isArray(value)
-                    : typeof value === type);
-    if (!matches) throw new Error(`${path} must be ${types.join(' or ')}.`);
-    if (schema.enum && !schema.enum.includes(value)) throw new Error(`${path} must be one of: ${schema.enum.join(', ')}.`);
-    if (typeof value === 'number' && (value < (schema.minimum ?? -Infinity) || value > (schema.maximum ?? Infinity))) {
-        throw new Error(`${path} is outside the allowed range (${schema.minimum ?? '-infinity'}–${schema.maximum ?? 'infinity'}).`);
-    }
-    if (typeof value === 'string' && schema.minLength && value.trim().length < schema.minLength) throw new Error(`${path} cannot be empty.`);
-    if (Array.isArray(value)) {
-        if (value.length < (schema.minItems ?? 0) || value.length > (schema.maxItems ?? Infinity)) throw new Error(`${path} has an invalid number of items.`);
-        value.forEach((item, index) => validateInput(item, schema.items, `${path}[${index}]`));
-    } else if (value !== null && typeof value === 'object') {
-        for (const key of schema.required ?? []) if (!(key in value)) throw new Error(`${path}.${key} is required.`);
-        for (const [key, item] of Object.entries(value)) {
-            if (!Object.prototype.hasOwnProperty.call(schema.properties, key)) throw new Error(`Unknown argument: ${path}.${key}.`);
-            validateInput(item, schema.properties[key], `${path}.${key}`);
-        }
-    }
-}
 
 export async function handleListLibraries(args: unknown = {}): Promise<any> {
     try {
@@ -214,10 +189,10 @@ async function createAnnotations(args: any, highlight: boolean): Promise<any> {
         const output = {
             attachment_id: modelObjectIdFromReference(ref),
             created: (result.created ?? []).map((annotation: any) => ({
-                ...annotation, annotation_id: modelObjectIdFromReference(annotation),
+                ...Object.fromEntries(Object.entries(annotation).filter(([key, value]) => key !== 'loc_raw' || value !== '')), annotation_id: modelObjectIdFromReference(annotation),
                 zotero_uri: getZoteroSelectURI(annotation.library_id, annotation.zotero_key),
             })),
-            failed: result.failed ?? [], total_created: result.total_created ?? 0, total_failed: result.total_failed ?? 0,
+            failed: (result.failed ?? []).map((failure: any) => Object.fromEntries(Object.entries(failure).filter(([key, value]) => key !== 'loc_raw' || value !== ''))), total_created: result.total_created ?? 0, total_failed: result.total_failed ?? 0,
         };
         return { content: [{ type: 'text', text: JSON.stringify(output) }], ...(output.total_failed > 0 ? { isError: true } : {}) };
     } catch (error) { return mcpError(error); }

--- a/react/hooks/useMcpServer.ts
+++ b/react/hooks/useMcpServer.ts
@@ -194,7 +194,7 @@ const SEARCH_BY_TOPIC_TOOL = {
             author_filter: {
                 type: 'array',
                 items: { type: 'string' },
-                description: 'Author last names to filter results (OR logic). Example: ["Acemoglu", "Robinson"].',
+                description: 'Creator name tokens (first, last, full, or institutional), matched case-insensitively within one creator (OR across filters). Example: ["Acemoglu", "Robinson"].',
             },
             min_year: {
                 type: 'integer',
@@ -260,7 +260,7 @@ const SEARCH_BY_METADATA_TOOL = {
         properties: {
             author_query: {
                 type: 'string',
-                description: 'Author\'s last name to search for (e.g., "Acemoglu").',
+                description: 'Creator name tokens (first, last, full, or institutional), matched case-insensitively within one creator.',
             },
             title_query: {
                 type: 'string',
@@ -550,7 +550,7 @@ const LIST_TAGS_TOOL = {
         'Each tag reports a `tag_type`: "manual" when the user added it, "automatic" when it was imported ' +
         'with an item\'s metadata (publisher keywords, MeSH terms). `tag_type` selects which kind to list: ' +
         '"manual" (default, the user\'s own vocabulary), "automatic" (imported keywords only) or "all". ' +
-        'The response always reports `manual_count` and `automatic_count` for the whole scope.',
+        'The response always reports `manual_count` and `automatic_count` after name_query and min_item_count, before tag_type and pagination.',
     inputSchema: {
         type: 'object' as const,
         properties: {
@@ -960,6 +960,7 @@ export async function handleReadAttachment(args: any): Promise<any> {
                                 ...(page.label ? { page_label: page.label } : {}),
                                 boxes: part.boxes.map(([l, t, r, b]) => ({ l, t, r, b, coord_origin: 't' })),
                             }],
+                            ...(page.label ? { page_label: page.label } : {}),
                             note_position: {
                                 page_index: page.index, side: 'right', coord_origin: 't',
                                 x: part.boxes[0][2], y: (part.boxes[0][1] + part.boxes[0][3]) / 2,
@@ -992,7 +993,7 @@ export async function handleReadAttachment(args: any): Promise<any> {
             total_pages: totalPages,
             ...(isDom
                 ? { content_kind: result.content_kind, passages: requestedPages.flatMap(page => page.passages ?? []) }
-                : { pages: requestedPages.map(page => ({ page: page.pageNumber, passages: page.passages ?? [] })) }),
+                : { content_kind: 'pdf', pages: requestedPages.map(page => ({ page: page.pageNumber, passages: page.passages ?? [] })) }),
         };
     }
 
@@ -1284,7 +1285,7 @@ async function handleGetItemDetails(args: any): Promise<any> {
                 return {
                     attachment_id: getMcpAttachmentId(a),
                     filename: a.filename || null,
-                    content_type: a.content_type ?? a.contentType ?? null,
+                    content_type: a.mime_type ?? a.content_type ?? a.contentType ?? null,
                     content_kind: a.content_kind ?? null,
                     page_count: a.page_count ?? null,
                     annotations_count: a.annotations_count,
@@ -1432,9 +1433,8 @@ async function handleListItems(args: any): Promise<any> {
     const sortOrder = args.sort_order === 'asc' ? 'asc' : 'desc';
 
     const validCategories: ZoteroItemCategory[] = ['regular', 'note', 'attachment', 'all'];
-    const itemCategory: ZoteroItemCategory = validCategories.includes(args.item_category)
-        ? args.item_category
-        : 'regular';
+    if (args.item_category !== undefined && !validCategories.includes(args.item_category)) return mcpError('Invalid item_category. Use regular, note, attachment, or all; use find_annotations for annotations.');
+    const itemCategory: ZoteroItemCategory = args.item_category ?? 'regular';
 
     const wsRequest: WSListItemsRequest = {
         event: 'list_items_request',
@@ -1497,7 +1497,7 @@ async function handleListItems(args: any): Promise<any> {
                     title: attachment.title ?? null,
                     filename: attachment.filename ?? null,
                     content_kind: attachment.content_kind,
-                    content_type: (attachment as any).content_type ?? null,
+                    content_type: (attachment as any).mime_type ?? (attachment as any).content_type ?? null,
                     status: getMcpAttachmentStatus(attachment),
                     status_reason: attachment.status_reason ?? null,
                     parent_item_id: attachment.parent_item_id ?? null,

--- a/react/utils/searchTools.ts
+++ b/react/utils/searchTools.ts
@@ -1,3 +1,4 @@
+import { matchesPublicationYear, matchesCreatorName } from '../../src/utils/searchFilters';
 /**
  * Search tools for AI agent to query Zotero library using native search capabilities
  */
@@ -92,7 +93,9 @@ export const searchItemsByMetadata = async (
 
         // Author/Creator search
         if (author_query) {
-            search.addCondition('creator', 'contains', author_query);
+            for (const token of author_query.trim().split(/[\s,]+/).filter(Boolean)) {
+                search.addCondition('creator', 'contains', token);
+            }
         }
 
         // Publication search
@@ -108,7 +111,7 @@ export const searchItemsByMetadata = async (
                 search.addCondition('date', 'isAfter', `${year_min - 1}-12-31`);
             }
             if (year_max && year_max > 0) {
-                search.addCondition('date', 'isBefore', `${year_max + 1}-01-01`);
+                search.addCondition('date', 'isBefore', `${year_max + 1}`);
             }
         }
 
@@ -175,7 +178,8 @@ export const searchItemsByMetadata = async (
     const itemIDs = Array.from(itemIDSet).sort((a, b) => a - b);
 
     // Apply limit
-    const limitedIDs = limit > 0 ? itemIDs.slice(0, limit) : itemIDs;
+    const needsFiltering = year_min != null || year_max != null || year_exact != null || !!author_query;
+    const limitedIDs = limit > 0 && !needsFiltering ? itemIDs.slice(0, limit) : itemIDs;
 
     if (limitedIDs.length === 0) {
         return [];
@@ -190,7 +194,11 @@ export const searchItemsByMetadata = async (
         await Zotero.Items.loadDataTypes(items, ["itemData", "creators"]);
     }
 
-    return items;
+    const filtered = needsFiltering ? items.filter(item =>
+        matchesPublicationYear(item.getField('date', false, true), year_exact ?? year_min, year_exact ?? year_max)
+        && (!author_query || matchesCreatorName(item.getCreators(), author_query))
+    ) : items;
+    return limit > 0 ? filtered.slice(0, limit) : filtered;
 };
 
 
@@ -320,7 +328,7 @@ export const resolveItemsByFilters = async (
                     search.addCondition('date', 'isAfter', `${year!.min - 1}-12-31`);
                 }
                 if (year!.max && year!.max > 0) {
-                    search.addCondition('date', 'isBefore', `${year!.max + 1}-01-01`);
+                    search.addCondition('date', 'isBefore', `${year!.max + 1}`);
                 }
             }
         });

--- a/src/services/agentDataProvider/handleGetMetadataRequest.ts
+++ b/src/services/agentDataProvider/handleGetMetadataRequest.ts
@@ -1,3 +1,4 @@
+import { cleanMetadataUrl } from '../../utils/metadataUrl';
 /**
  * Agent Data Provider
  * 
@@ -99,7 +100,7 @@ export async function handleGetMetadataRequest(
                 // it serves notes and child items as well as regular ones.
                 await loadQuickSearchHitData([item]);
                 items.push({
-                    item_id: itemId,
+                    item_id: modelObjectId(item.libraryID, item.key),
                     ...toQuickSearchHit(item),
                 });
                 continue;
@@ -151,7 +152,7 @@ export async function handleGetMetadataRequest(
                 }
                 items.push({
                     ...info,
-                    item_id: itemId,
+                    item_id: modelObjectId(item.libraryID, item.key),
                     itemType: 'attachment',
                     parent_item: parentSummary,
                     collections: enrichItemCollections(item),
@@ -231,7 +232,8 @@ export async function handleGetMetadataRequest(
 
             // Get full item data via toJSON({ mode: 'full' }) - includes all fields
             const itemData: Record<string, any> = item.toJSON({ mode: 'full' });
-            itemData.item_id = itemId;
+            itemData.item_id = modelObjectId(item.libraryID, item.key);
+            if ('url' in itemData) itemData.url = cleanMetadataUrl(itemData.url);
             itemData.library_ref = libraryRefForLibraryID(libraryId) ?? undefined;
             
             // Return all fields (including tags and collections)
@@ -302,14 +304,14 @@ export async function handleGetMetadataRequest(
                         
                         try {
                             const attachmentInfo = await getAttachmentInfoForItem(attachment, {
-                                parentItemId: itemId,
+                                parentItemId: modelObjectId(item.libraryID, item.key),
                                 isPrimary: bestAttachment ? attachment.id === bestAttachment.id : false,
                                 includeAnnotationsCount: true,
                                 skipWorkerFallback: true,
                             });
                             attachments.push({
                                 ...attachmentInfo,
-                                url: attachment.getField('url') || null,
+                                url: cleanMetadataUrl(attachment.getField('url')),
                             });
                         } catch (error) {
                             logger(`handleGetMetadataRequest: Error processing attachment ${attachment.key}: ${error}`, 2);

--- a/src/services/agentDataProvider/handleItemSearchByTopicRequest.ts
+++ b/src/services/agentDataProvider/handleItemSearchByTopicRequest.ts
@@ -1,3 +1,4 @@
+import { matchesPublicationYear, matchesCreatorName } from '../../utils/searchFilters';
 /**
  * Agent Data Provider
  * 
@@ -313,27 +314,9 @@ export async function handleItemSearchByTopicRequest(
         if (!item) continue;
 
         // Apply filters
-        // Year filter
-        if (request.year_min || request.year_max) {
-            const yearStr = item.getField('date', false, true);
-            const yearMatch = yearStr ? String(yearStr).match(/\d{4}/) : null;
-            const year = yearMatch ? parseInt(yearMatch[0], 10) : null;
-
-            if (year) {
-                if (request.year_min && year < request.year_min) continue;
-                if (request.year_max && year > request.year_max) continue;
-            }
-        }
-
-        // Author filter
-        if (request.author_filter && request.author_filter.length > 0) {
-            const creators = item.getCreators();
-            const creatorLastNames = creators.map(c => (c.lastName || '').toLowerCase());
-            const matchesAuthor = request.author_filter.some(authorName =>
-                creatorLastNames.some(lastName => lastName.includes(authorName.toLowerCase()))
-            );
-            if (!matchesAuthor) continue;
-        }
+        if ((request.year_min != null || request.year_max != null)
+            && !matchesPublicationYear(item.getField('date', false, true), request.year_min, request.year_max)) continue;
+        if (request.author_filter?.length && !request.author_filter.some(name => matchesCreatorName(item.getCreators(), name))) continue;
 
         // Tags filter, applied to the resolved tag names rather than the request's
         // own spelling so it matches what the library actually stores.

--- a/src/services/agentDataProvider/handleListCollectionsRequest.ts
+++ b/src/services/agentDataProvider/handleListCollectionsRequest.ts
@@ -164,7 +164,7 @@ export async function handleListCollectionsRequest(
             name: collection.name,
             parent_key: collection.parentKey || null,
             parent_name: collection.parentID ? collectionIdToName.get(collection.parentID) || null : null,
-            item_count: request.include_item_counts ? (itemCountById.get(collection.id) || 0) : 0,
+            item_count: request.include_item_counts ? (itemCountById.get(collection.id) || 0) : undefined,
             // Left off entirely when counts were not requested: absent means
             // "not reported", which a zero would misrepresent as "none here".
             standalone_attachment_count: request.include_item_counts ? (attachmentCountById.get(collection.id) || 0) : undefined,

--- a/src/services/agentDataProvider/handleReadNoteRequest.ts
+++ b/src/services/agentDataProvider/handleReadNoteRequest.ts
@@ -22,12 +22,11 @@ import {
     resolveObjectId,
     UNRESOLVED_LIBRARY_ID,
 } from '../../utils/libraryIdentity';
-import { checkLibraryExcluded, prepareAttachmentInfoBatchData, processAttachmentInfoBatch } from './utils';
+import { checkLibraryExcluded, getAttachmentInfoForItem, prepareAttachmentInfoBatchData, processAttachmentInfoBatch } from './utils';
 import { CITATION_TAG_PATTERN } from '../../../react/utils/citationPreprocessing';
 import {
     normalizeCitationTag,
     parseRawCitationAttributes,
-    parseZoteroId,
 } from '@beaver/agent-core/citations/citationGrammar';
 import { getNoteContentPreviewText } from '../../../react/utils/noteText';
 
@@ -86,7 +85,7 @@ function extractCitedItemRefs(simplifiedHtml: string): { libraryId: number; item
         const colonIdx = itemId.indexOf(':');
         const cleanId = (colonIdx !== -1 ? itemId.substring(0, colonIdx) : itemId).trim();
 
-        const parsed = parseZoteroId(cleanId);
+        const parsed = resolveObjectId(cleanId);
         if (!parsed) return;
 
         // Key on library_ref when available: an unresolved portable ref
@@ -104,12 +103,9 @@ function extractCitedItemRefs(simplifiedHtml: string): { libraryId: number; item
     while ((match = CITATION_TAG_PATTERN.exec(simplifiedHtml)) !== null) {
         const rawAttrs = parseRawCitationAttributes(match[1] || '');
 
-        // Attachment-to-parent cited_items resolution is out of v0.20 scope.
-        if (rawAttrs.att_id || rawAttrs.attachment_id) continue;
-
         const normalized = normalizeCitationTag(rawAttrs);
         if (normalized.ok && normalized.ref.kind === 'zotero') {
-            addRef(`${normalized.ref.library_id}-${normalized.ref.zotero_key}`);
+            addRef(`${normalized.ref.library_ref ?? normalized.ref.library_id}-${normalized.ref.zotero_key}`);
             continue;
         }
 
@@ -138,7 +134,7 @@ async function resolveCitedItems(
         if (checkLibraryExcluded(ref.libraryId)) continue;
         try {
             const item = await Zotero.Items.getByLibraryAndKeyAsync(ref.libraryId, ref.itemKey);
-            if (item && !item.deleted && (item.isRegularItem?.() || item.isNote?.() || isAnnotationItem(item))) {
+            if (item && !item.deleted && (item.isRegularItem?.() || item.isNote?.() || item.isAttachment?.() || isAnnotationItem(item))) {
                 items.push(item);
             }
         } catch {
@@ -190,6 +186,17 @@ async function resolveCitedItems(
             if (summary) results.push(summary);
         } else if (item.isNote?.() === true) {
             results.push(serializeNoteCitationSummary(item));
+        } else if (item.isAttachment?.()) {
+            await item.loadDataType('itemData');
+            results.push({
+                library_id: item.libraryID,
+                zotero_key: item.key,
+                library_ref: libraryRefForLibraryID(item.libraryID) ?? undefined,
+                item_type: 'attachment',
+                title: item.getField('title') || item.attachmentFilename || 'Attachment',
+                parent_key: item.parentKey || null,
+                attachments: [await getAttachmentInfoForItem(item, { skipWorkerFallback: true, includeAnnotationsCount: true })],
+            });
         } else if (isAnnotationItem(item)) {
             results.push(serializeAnnotationCitationSummary(item));
         }

--- a/src/services/agentDataProvider/libraryCounts.ts
+++ b/src/services/agentDataProvider/libraryCounts.ts
@@ -129,8 +129,13 @@ async function countCollections(libraryId: number): Promise<number> {
 
 async function countTags(libraryId: number): Promise<number> {
     try {
-        const tags = await Zotero.Tags.getAll(libraryId);
-        return (tags as any[]).length;
+        let count = 0;
+        await Zotero.DB.queryAsync(`
+            SELECT COUNT(DISTINCT IT.tagID)
+            FROM itemTags IT JOIN items I ON I.itemID = IT.itemID
+            WHERE I.libraryID = ? AND I.itemID NOT IN (SELECT itemID FROM deletedItems)
+        `, [libraryId], { onRow: (row: any) => { count = row.getResultByIndex(0); } });
+        return count;
     } catch (error) {
         logger(
             `getLibrarySummaries: Error counting tags for library ${libraryId}: ${error}`,

--- a/src/services/agentDataProvider/utils.ts
+++ b/src/services/agentDataProvider/utils.ts
@@ -437,6 +437,7 @@ export function degradedAttachmentInfo(
         title: safeStub(() => item.getDisplayTitle?.()) ?? null,
         filename: safeAttachmentFilename(item),
         content_kind: 'other',
+        mime_type: item.attachmentContentType || null,
         status: 'unreadable',
         // States what is known (the read failed) without asserting a cause: the
         // catch this comes from covers any failure, not just a malformed record.
@@ -628,12 +629,17 @@ export function getCollectionByIdOrName(
         ...otherLibraryIds.filter(id => !searchableIds.includes(id)),
     ];
 
+    const matches: CollectionLookupResult[] = [];
     for (const libId of sortedLibraryIds) {
+        if (!isKeyLike && !searchableIds.includes(libId)) continue;
         const found = findCollectionInLibrary(collectionIdOrName, libId, isKeyLike);
-        if (found) return found;
+        if (found) {
+            if (isKeyLike && found.collection.key === collectionIdOrName) return found;
+            if (searchableIds.includes(libId)) matches.push(found);
+        }
     }
-    
-    return null;
+    if (matches.length > 1) throw ambiguousCollectionError(collectionIdOrName, matches.map(match => match.collection));
+    return matches[0] ?? null;
 }
 
 /**
@@ -651,12 +657,35 @@ function findCollectionInLibrary(
     
     const collections = Zotero.Collections.getByLibrary(libraryId, true);
     const inputLower = input.toLowerCase();
-    const byName = collections.find(
+    const byName = collections.filter(
         (c: Zotero.Collection) => c.name.toLowerCase() === inputLower
     );
-    if (byName) return { collection: byName, libraryID: byName.libraryID };
+    if (byName.length > 1 && isLibrarySearchable(libraryId)) throw ambiguousCollectionError(input, byName);
+    if (byName[0]) return { collection: byName[0], libraryID: byName[0].libraryID };
     
     return null;
+}
+
+class CollectionAmbiguityError extends Error {
+    readonly code = 'ambiguous_collection';
+}
+
+/** Describe ambiguous names using only libraries the caller may access. */
+function ambiguousCollectionError(input: string, collections: Zotero.Collection[]): Error {
+    const candidates = collections.filter(c => isLibrarySearchable(c.libraryID)).map(collection => {
+        const path = [collection.name];
+        const seen = new Set<number>([collection.id]);
+        let parentId = collection.parentID;
+        while (parentId && !seen.has(parentId)) {
+            seen.add(parentId);
+            const parent = Zotero.Collections.get(parentId);
+            if (!parent) break;
+            path.unshift(parent.name);
+            parentId = parent.parentID;
+        }
+        return `${modelObjectId(collection.libraryID, collection.key)} (${path.join(' / ')})`;
+    });
+    return new CollectionAmbiguityError(`Ambiguous collection name "${input}". Use a collection ID: ${candidates.join('; ')}.`);
 }
 
 /** A collection a `collections_filter` entry matched outside the searched libraries. */
@@ -681,19 +710,20 @@ export interface CollectionsFilterResolution {
     unresolved: string[];
     /** Filter entries that matched only outside the searched libraries. */
     outOfScope: OutOfScopeCollection[];
+    ambiguity?: string;
 }
 
 /** A `collections_filter` that left the search with no usable collection. */
 export interface CollectionsFilterError {
     message: string;
-    error_code: 'collection_not_found' | 'library_not_searchable';
+    error_code: 'collection_not_found' | 'library_not_searchable' | 'ambiguous_collection';
 }
 
 /**
  * Resolve a `collections_filter` against the libraries a search will cover.
  *
- * A name is resolved in every searched library, because the same name can
- * legitimately exist in several of them. Matches outside those libraries are
+ * Names must identify a single collection across the searched libraries.
+ * Matches outside those libraries are
  * reported separately rather than dropped: numeric IDs and key-like entries
  * resolve through a cross-library fallback that can land in a library the
  * request is not scoped to, or that the user excluded from Beaver, and the
@@ -725,12 +755,23 @@ export function resolveCollectionsFilter(
             if (collection) matches.push(collection);
         } else {
             for (const libraryId of libraryIds) {
-                const match = getCollectionByIdOrName(filter, libraryId);
-                if (match) matches.push(match.collection);
+                try {
+                    const match = getCollectionByIdOrName(filter, libraryId);
+                    if (match) matches.push(match.collection);
+                } catch (error) {
+                    if (!(error instanceof CollectionAmbiguityError)) throw error;
+                    return { collections: [], unresolved, outOfScope, ambiguity: error.message };
+                }
             }
         }
 
-        const inScope = matches.filter((collection) => libraryIds.includes(collection.libraryID));
+        const inScope = Array.from(new Map(matches
+            .filter(collection => libraryIds.includes(collection.libraryID))
+            .map(collection => [collection.id, collection])).values());
+        if (inScope.length > 1 && typeof filter === 'string' && !/^\d+$/.test(filter)
+            && !parseItemReference(filter) && inScope.some(collection => collection.key !== filter)) {
+            return { collections: [], unresolved, outOfScope, ambiguity: ambiguousCollectionError(filter, inScope).message };
+        }
         if (inScope.length > 0) {
             for (const collection of inScope) collections.set(collection.id, collection);
         } else if (matches.length > 0) {
@@ -762,6 +803,7 @@ export function resolveCollectionsFilter(
 export function collectionsFilterError(
     resolution: CollectionsFilterResolution
 ): CollectionsFilterError | null {
+    if (resolution.ambiguity) return { message: resolution.ambiguity, error_code: 'ambiguous_collection' };
     if (resolution.collections.length > 0) return null;
 
     if (resolution.unresolved.length > 0) {

--- a/src/services/annotations/createAnnotation.ts
+++ b/src/services/annotations/createAnnotation.ts
@@ -529,7 +529,13 @@ export async function createNoteAnnotation(
     item.annotationType = "note";
     item.annotationComment = input.comment;
     item.annotationColor = resolveBeaverAnnotationColor(input.color);
-    applyAnnotationPlacement(item, buildNotePlacement(input, geometry));
+    const filePath = await attachment.getFilePathAsync();
+    const metadata = filePath ? await Zotero.Beaver?.documentCache?.getMetadata(
+        { libraryId: attachment.libraryID, zoteroKey: attachment.key }, filePath,
+    ) : null;
+    const pageLabel = firstNonBlankPageLabel(input.pageLabel)
+        ?? metadata?.pageLabels?.[input.notePosition.page_index];
+    applyAnnotationPlacement(item, buildNotePlacement({ ...input, pageLabel }, geometry));
     await saveBeaverAnnotation(item, input.tags);
 
     return createdAnnotationReference(attachment, item);

--- a/src/services/documentExtraction/attachmentInfo.ts
+++ b/src/services/documentExtraction/attachmentInfo.ts
@@ -571,6 +571,7 @@ export async function getAttachmentInfo(
         title: item.getField?.('title') || item.getDisplayTitle?.() || null,
         filename: safeAttachmentFilename(item),
         content_kind: contentKind,
+        mime_type: item.attachmentContentType || null,
         status: 'unreadable',
         page_count: null,
         line_count: null,

--- a/src/services/mcpInputValidation.ts
+++ b/src/services/mcpInputValidation.ts
@@ -1,0 +1,67 @@
+/** Validate the JSON Schema subset used by these tools, including direct HTTP calls. */
+export function validateInput(
+    value: any,
+    schema: any,
+    path = 'arguments',
+): void {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const matches = types.some((type: string) =>
+        type === 'integer'
+            ? Number.isSafeInteger(value)
+            : type === 'number'
+              ? typeof value === 'number' && Number.isFinite(value)
+              : type === 'array'
+                ? Array.isArray(value)
+                : type === 'object'
+                  ? value !== null &&
+                    typeof value === 'object' &&
+                    !Array.isArray(value)
+                  : typeof value === type,
+    );
+    if (schema.type && !matches)
+        throw new Error(`${path} must be ${types.join(' or ')}.`);
+    if (schema.enum && !schema.enum.includes(value))
+        throw new Error(`${path} must be one of: ${schema.enum.join(', ')}.`);
+    if (
+        typeof value === 'number' &&
+        (value < (schema.minimum ?? -Infinity) ||
+            value > (schema.maximum ?? Infinity))
+    ) {
+        throw new Error(
+            `${path} is outside the allowed range (${schema.minimum ?? '-infinity'}–${schema.maximum ?? 'infinity'}).`,
+        );
+    }
+    if (
+        typeof value === 'string' &&
+        schema.minLength &&
+        value.trim().length < schema.minLength
+    )
+        throw new Error(`${path} cannot be empty.`);
+    if (Array.isArray(value)) {
+        if (
+            value.length < (schema.minItems ?? 0) ||
+            value.length > (schema.maxItems ?? Infinity)
+        )
+            throw new Error(`${path} has an invalid number of items.`);
+        if (schema.items)
+            value.forEach((item, index) =>
+                validateInput(item, schema.items, `${path}[${index}]`),
+            );
+    } else if (value !== null && typeof value === 'object') {
+        for (const key of schema.required ?? [])
+            if (!(key in value)) throw new Error(`${path}.${key} is required.`);
+        for (const [key, item] of Object.entries(value)) {
+            if (
+                !Object.prototype.hasOwnProperty.call(
+                    schema.properties ?? {},
+                    key,
+                )
+            ) {
+                if (schema.additionalProperties === false)
+                    throw new Error(`Unknown argument: ${path}.${key}.`);
+                continue;
+            }
+            validateInput(item, schema.properties[key], `${path}.${key}`);
+        }
+    }
+}

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1,3 +1,4 @@
+import { validateInput } from './mcpInputValidation';
 import type { WindowRuntime } from "../runtime/instance";
 /**
  * MCP (Model Context Protocol) Service
@@ -85,7 +86,7 @@ export class MCPService {
         definition: McpToolDefinition,
         handler: (args: any) => Promise<any>,
     ): void {
-        this.tools.set(name, { definition, handler });
+        this.tools.set(name, { definition: { ...definition, inputSchema: { ...definition.inputSchema, additionalProperties: false } }, handler });
     }
 
     /**
@@ -264,7 +265,12 @@ export class MCPService {
             throw new Error(`Unknown tool: ${params.name}`);
         }
 
-        const args = params.arguments ?? {};
+        const args = Object.prototype.hasOwnProperty.call(params, 'arguments') ? params.arguments : {};
+        try {
+            validateInput(args, entry.definition.inputSchema);
+        } catch (error) {
+            return { content: [{ type: 'text', text: `Invalid arguments for ${params.name}: ${String(error)}` }], isError: true };
+        }
         const result = await entry.handler(args);
 
         // MCP tools/call must return { content: [...] }

--- a/src/utils/metadataUrl.ts
+++ b/src/utils/metadataUrl.ts
@@ -1,0 +1,9 @@
+/** Remove control-character corruption without changing valid URL text. */
+export function cleanMetadataUrl(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const cleaned = value
+        .replace(/\\u00(?:[01][0-9a-f]|7f)/gi, '')
+        .replace(/\p{Cc}/gu, '')
+        .trim();
+    return cleaned || null;
+}

--- a/src/utils/searchFilters.ts
+++ b/src/utils/searchFilters.ts
@@ -1,0 +1,33 @@
+/** Inclusive publication-year matching; unknown years never satisfy a bound. */
+export function matchesPublicationYear(
+    date: unknown,
+    min?: number | null,
+    max?: number | null,
+): boolean {
+    if (min == null && max == null) return true;
+    const match = String(date ?? '').match(/\b(\d{4})\b/);
+    const year = match ? Number(match[1]) : 0;
+    return (
+        year > 0 && (min == null || year >= min) && (max == null || year <= max)
+    );
+}
+
+/** Match name tokens within one creator, including institutional creators. */
+export function matchesCreatorName(
+    creators: { firstName?: string; lastName?: string; name?: string }[],
+    query: string,
+): boolean {
+    const tokens = query
+        .toLowerCase()
+        .trim()
+        .split(/[\s,]+/)
+        .filter(Boolean);
+    return (
+        tokens.length > 0 &&
+        creators.some((creator) => {
+            const name =
+                `${creator.firstName ?? ''} ${creator.lastName ?? creator.name ?? ''}`.toLowerCase();
+            return tokens.every((token) => name.includes(token));
+        })
+    );
+}

--- a/src/utils/zoteroSerializers.ts
+++ b/src/utils/zoteroSerializers.ts
@@ -1,3 +1,4 @@
+import { cleanMetadataUrl } from './metadataUrl';
 import { v4 as uuidv4 } from 'uuid';
 import { calculateObjectHash } from '../utils/hash';
 import { logger } from '@beaver/agent-core/platform/logger';
@@ -304,7 +305,7 @@ export async function serializeItem(item: Zotero.Item, clientDateModified: strin
         year: getYearFromItem(item),
         publication_title: item.getField('publicationTitle', false, true),
         abstract: item.getField('abstractNote'),
-        url: item.getField('url'),
+        url: cleanMetadataUrl(item.getField('url')),
         identifiers: getIdentifiersFromItem(item),
         language: item.getField('language'),
         formatted_citation: formatItemReference(item),
@@ -553,7 +554,7 @@ export async function serializeAttachment(
         library_id: item.libraryID,
         zotero_key: item.key,
         parent_key: item.parentKey || null,
-        attachment_url: item.getField('url'),
+        attachment_url: cleanMetadataUrl(item.getField('url')),
         link_mode: item.attachmentLinkMode,
         tags: item.getTags().length > 0 ? item.getTags() : null,
         collections: getCollectionKeysFromItem(item),

--- a/tests/live/mcpContract.live.test.ts
+++ b/tests/live/mcpContract.live.test.ts
@@ -1,0 +1,237 @@
+/** Behavioral checks through the public MCP transport against a Zotero library. */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    isZoteroAvailable,
+    skipIfNoZotero,
+} from '../helpers/zoteroAvailability';
+import { post } from '../helpers/zoteroHttpClient';
+import { PARENT_ITEM } from '../helpers/fixtures';
+import { deleteNote } from './helpers/noteTestClient';
+
+let available = false;
+const collections: string[] = [];
+const duplicateName = `MCP contract test ${Date.now()}`;
+async function call(
+    name: string,
+    args: any = {},
+    allowError = false,
+): Promise<any> {
+    const response = await post<any>(
+        '/beaver/mcp',
+        {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: { name, arguments: args },
+        },
+        { timeout: 120000 },
+    );
+    expect(response.error).toBeUndefined();
+    if (allowError) return response.result;
+    expect(
+        response.result.isError,
+        response.result.content?.[0]?.text,
+    ).not.toBe(true);
+    return JSON.parse(response.result.content[0].text);
+}
+beforeAll(async () => {
+    available = await isZoteroAvailable();
+});
+beforeEach((ctx) => skipIfNoZotero(ctx, available));
+afterAll(async () => {
+    if (collections.length)
+        await post('/beaver/test/collection-delete', {
+            library_id: 1,
+            collection_keys: collections,
+        });
+});
+
+describe('MCP argument and result contracts', () => {
+    it.each([
+        { item_category: 'annotation' },
+        { tags_filter: ['test'] },
+        { recursive: 'false' },
+        { tag: [4] },
+    ])('rejects misleading list arguments %j', async (args) => {
+        expect((await call('list_items', args, true)).isError).toBe(true);
+    });
+    it('omits unrequested collection counts', async () => {
+        const result = await call('list_collections', {
+            include_item_counts: false,
+        });
+        expect(result.collections.length).toBeGreaterThan(0);
+        for (const collection of result.collections) {
+            expect(collection).not.toHaveProperty('item_count');
+            expect(collection).not.toHaveProperty('standalone_note_count');
+            expect(collection).not.toHaveProperty(
+                'standalone_attachment_count',
+            );
+        }
+    });
+    it('agrees on unique tag counts across library and tag listings', async () => {
+        const libraries = await call('list_libraries');
+        const tags = await call('list_tags', {
+            library: 'u',
+            tag_type: 'all',
+            min_item_count: 0,
+        });
+        expect(
+            libraries.libraries.find(
+                (library: any) => library.library_ref === 'u',
+            ).tag_count,
+        ).toBe(tags.total_count);
+    });
+    it('rejects duplicate collection names and accepts an exact ID', async () => {
+        for (let index = 0; index < 2; index++) {
+            const created = await post<any>('/beaver/test/collection-create', {
+                library_id: 1,
+                name: duplicateName,
+            });
+            if (created.collection_key)
+                collections.push(created.collection_key);
+            expect(created.ok, created.error).toBe(true);
+        }
+        for (const [tool, args] of [
+            ['list_items', { collection: duplicateName }],
+            [
+                'search_by_metadata',
+                { title_query: 'police', collections_filter: [duplicateName] },
+            ],
+            [
+                'search_by_topic',
+                { topic_query: 'police', collections_filter: [duplicateName] },
+            ],
+        ] as const) {
+            const error = await call(tool, args, true);
+            expect(error.isError).toBe(true);
+            expect(error.content[0].text).toContain('Ambiguous collection');
+            for (const key of collections)
+                expect(error.content[0].text).toContain(key);
+        }
+        expect(
+            (await call('list_items', { collection: `u-${collections[0]}` }))
+                .total_count,
+        ).toBe(0);
+    });
+    it('normalizes metadata IDs and exposes attachment MIME types', async () => {
+        const result = await call('get_item_details', {
+            item_ids: [`${PARENT_ITEM.library_id}-${PARENT_ITEM.zotero_key}`],
+            include_attachments: true,
+        });
+        expect(result.items[0].item_id).toBe(`u-${PARENT_ITEM.zotero_key}`);
+        expect(
+            result.items[0].attachments.some(
+                (attachment: any) =>
+                    attachment.content_kind === 'pdf' &&
+                    attachment.content_type === 'application/pdf',
+            ),
+        ).toBe(true);
+        const listed = await call('list_items', {
+            item_category: 'attachment',
+            limit: 100,
+        });
+        const pdf = listed.items.find(
+            (item: any) => item.content_kind === 'pdf',
+        );
+        expect(pdf?.content_type).toBe('application/pdf');
+    });
+    it('includes directly cited PDF attachments in note citation summaries', async () => {
+        let attachment: any;
+        for (let offset = 0; !attachment; offset += 100) {
+            const page = await call('list_items', {
+                item_category: 'attachment',
+                limit: 100,
+                offset,
+            });
+            attachment = page.items.find(
+                (item: any) =>
+                    item.content_kind === 'pdf' &&
+                    item.parent_item_id == null &&
+                    item.status === 'available',
+            );
+            if (!page.has_more) break;
+        }
+        expect(
+            attachment,
+            'A readable standalone PDF fixture is required',
+        ).toBeDefined();
+        const note = await call('create_note', {
+            title: 'MCP contract citation',
+            content: `Source: <citation id="${attachment.item_id}" loc="page1"/>`,
+        });
+        try {
+            const read = await call('read_note', { note_id: note.note_id });
+            expect(read.content).toContain(`id="${attachment.item_id}"`);
+            expect(read.cited_items).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        item_id: attachment.item_id,
+                        item_type: 'attachment',
+                    }),
+                ]),
+            );
+        } finally {
+            await deleteNote(1, note.note_id.split('-')[1]);
+        }
+    });
+    it('allows paginated annotation browsing without filters', async () => {
+        const result = await call('find_annotations', { limit: 1 });
+        expect(result.annotations.length).toBeLessThanOrEqual(1);
+        expect(result.total_count).toBeGreaterThanOrEqual(
+            result.annotations.length,
+        );
+    });
+});
+
+describe('MCP year and creator filters', () => {
+    it('includes first and full creator names in both search tools', async () => {
+        for (const name of ['Joscha', 'Joscha Legewie']) {
+            const metadata = await call('search_by_metadata', {
+                author_query: name,
+            });
+            const topic = await call('search_by_topic', {
+                topic_query: 'police stops race gender',
+                author_filter: [name],
+            });
+            expect(metadata.results.length).toBeGreaterThan(0);
+            expect(topic.results.length).toBeGreaterThan(0);
+        }
+    }, 120000);
+    it('excludes the next year including year-only dates from metadata search', async () => {
+        const unbounded = await call('search_by_metadata', {
+            author_query: 'Legewie',
+            limit: 25,
+        });
+        expect(unbounded.results.some((item: any) => item.year > 2015)).toBe(
+            true,
+        );
+        const bounded = await call('search_by_metadata', {
+            author_query: 'Legewie',
+            max_year: 2015,
+            limit: 25,
+        });
+        expect(bounded.results.length).toBeGreaterThan(0);
+        expect(
+            bounded.results.every(
+                (item: any) => item.year != null && item.year <= 2015,
+            ),
+        ).toBe(true);
+    }, 120000);
+    it.each([{ min_year: 2020 }, { max_year: 2010 }])(
+        'excludes unknown years from bounded topic search %j',
+        async (bounds) => {
+            const result = await call('search_by_topic', {
+                topic_query: 'aggressive policing police stops race',
+                limit: 25,
+                ...bounds,
+            });
+            for (const item of result.results) {
+                expect(item.year).not.toBeNull();
+                if ('min_year' in bounds)
+                    expect(item.year).toBeGreaterThanOrEqual(bounds.min_year!);
+                else expect(item.year).toBeLessThanOrEqual(bounds.max_year!);
+            }
+        },
+        120000,
+    );
+});

--- a/tests/unit/handlers/collectionScope.test.ts
+++ b/tests/unit/handlers/collectionScope.test.ts
@@ -195,12 +195,38 @@ describe('resolveCollectionsFilter', () => {
         (globalThis as any).Zotero = previousZotero;
     });
 
-    it('resolves a shared name in every searched library', () => {
+    it('requires disambiguation for a shared name across searched libraries', () => {
         const resolution = resolveCollectionsFilter(['Papers'], [1, 100]);
 
-        expect(resolution.collections.map(c => (c as any).id)).toEqual([11, 12]);
+        expect(resolution.collections).toEqual([]);
+        expect(collectionsFilterError(resolution)).toMatchObject({ error_code: 'ambiguous_collection' });
+        expect(resolution.ambiguity).toContain('AAAAAAAA');
+        expect(resolution.ambiguity).toContain('BBBBBBBB');
+        expect(resolution.ambiguity).not.toContain('Private');
         expect(resolution.unresolved).toEqual([]);
         expect(resolution.outOfScope).toEqual([]);
+    });
+
+    it('rejects duplicate names within one library and shows parent paths', () => {
+        const root = { id: 21, key: 'ROOTAAAA', name: 'Root', libraryID: 1 };
+        const first = { id: 22, key: 'CHILDAAA', name: 'Research', libraryID: 1, parentID: 21 };
+        const second = { id: 23, key: 'CHILDBBB', name: 'Research', libraryID: 1 };
+        COLLECTIONS.push(root, first, second);
+        try {
+            const result = resolveCollectionsFilter(['Research'], [1]);
+            expect(result.collections).toEqual([]);
+            expect(result.ambiguity).toContain('Root / Research');
+            expect(result.ambiguity).toContain('CHILDAAA');
+            expect(result.ambiguity).toContain('CHILDBBB');
+        } finally { COLLECTIONS.splice(-3); }
+    });
+
+    it('does not treat an eight-character collection name as an unambiguous key', () => {
+        COLLECTIONS.push({ id: 21, key: 'NAMEAAAA', name: 'Research', libraryID: 1 }, { id: 22, key: 'NAMEBBBB', name: 'Research', libraryID: 100 });
+        try {
+            const result = resolveCollectionsFilter(['Research'], [1, 100]);
+            expect(collectionsFilterError(result)?.error_code).toBe('ambiguous_collection');
+        } finally { COLLECTIONS.splice(-2); }
     });
 
     it('returns a collection once when several filter entries resolve to it', () => {

--- a/tests/unit/handlers/getMetadataCompact.test.ts
+++ b/tests/unit/handlers/getMetadataCompact.test.ts
@@ -128,6 +128,15 @@ beforeEach(() => {
     };
 });
 
+describe('metadata identity and field quality', () => {
+    it('normalizes a legacy ID and removes escaped control-only URLs', async () => {
+        const item = regularItem('AAAAAAAA', { toJSON: () => ({ itemType: 'journalArticle', title: 'Source', url: String.raw`\u0000\u0000` }) });
+        mocks.resolveItemReference.mockResolvedValue({ status: 'found', item });
+        const result = await handleGetMetadataRequest(request({ item_ids: ['1-AAAAAAAA'] }));
+        expect(result.items[0]).toMatchObject({ item_id: 'u-AAAAAAAA', url: null });
+    });
+});
+
 describe('handleGetMetadataRequest compact projection', () => {
     it('returns one chip-sized row per item, keyed back to the requested id', async () => {
         const res = await handleGetMetadataRequest(request({ detail: 'compact' }));

--- a/tests/unit/handlers/libraryCounts.test.ts
+++ b/tests/unit/handlers/libraryCounts.test.ts
@@ -83,6 +83,8 @@ describe('getLibrarySummaries', () => {
                 } else if (sql.includes('JOIN itemNotes N')) {
                     noteCountSql.push(sql);
                     count = libraryId === 1 ? 5 : 1;
+                } else if (sql.includes('COUNT(DISTINCT IT.tagID)')) {
+                    count = libraryId === 1 ? 2 : 1;
                 } else if (sql.includes('FROM collections')) {
                     count = libraryId === 1 ? 3 : 2;
                 }
@@ -206,6 +208,7 @@ describe('getLibrarySummaries', () => {
                 _params: number[],
                 options?: { onRow?: (row: any) => void }
             ) => {
+                if (sql.includes('COUNT(DISTINCT IT.tagID)')) throw new Error('tags failed');
                 if (sql.includes('JOIN itemNotes N')) {
                     throw new Error('notes failed');
                 }

--- a/tests/unit/handlers/listCollectionsRecursive.test.ts
+++ b/tests/unit/handlers/listCollectionsRecursive.test.ts
@@ -89,6 +89,15 @@ beforeEach(() => {
 });
 
 describe('handleListCollectionsRequest recursive', () => {
+    it('omits all item counts when they were not requested', async () => {
+        const result = await handleListCollectionsRequest(request({ include_item_counts: false }));
+        for (const row of JSON.parse(JSON.stringify(result)).collections) {
+            expect(row).not.toHaveProperty('item_count');
+            expect(row).not.toHaveProperty('standalone_attachment_count');
+            expect(row).not.toHaveProperty('standalone_note_count');
+        }
+    });
+
     it('returns top-level collections only by default', async () => {
         const res = await handleListCollectionsRequest(request());
 

--- a/tests/unit/handlers/mcpToolHandlers.test.ts
+++ b/tests/unit/handlers/mcpToolHandlers.test.ts
@@ -1524,7 +1524,7 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
             const result = await callTool(endpoint, 'get_item_details', {});
 
             expect(result.isError).toBe(true);
-            expect(result.content[0].text).toContain('non-empty array');
+            expect(result.content[0].text).toContain('item_ids');
         });
 
         it('returns error for too many items (>25)', async () => {
@@ -2193,17 +2193,17 @@ describe('MCP Tool Handlers (via useMcpServer)', () => {
             expect(req.recursive).toBe(false);
         });
 
-        it('falls back to regular for unsupported annotation category', async () => {
-            mockHandleListItemsRequest.mockResolvedValue({
-                type: 'list_items',
-                items: [],
-                total_count: 0,
-            });
+        it('rejects unsupported annotation category without listing regular items', async () => {
+            const result = await callTool(endpoint, 'list_items', { item_category: 'annotation' });
+            expect(result.isError).toBe(true);
+            expect(mockHandleListItemsRequest).not.toHaveBeenCalled();
+        });
 
-            await callTool(endpoint, 'list_items', { item_category: 'annotation' });
-
-            const req = mockHandleListItemsRequest.mock.calls[0][0];
-            expect(req.item_category).toBe('regular');
+        it('rejects search-tool tag parameters rather than ignoring the filter', async () => {
+            const result = await callTool(endpoint, 'list_items', { tags_filter: ['important'] });
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('tags_filter');
+            expect(mockHandleListItemsRequest).not.toHaveBeenCalled();
         });
 
         it('passes valid item_category values', async () => {
@@ -2912,6 +2912,6 @@ describe('MCP libraries and annotations', () => {
         const result = JSON.parse((await callTool(endpoint, 'read_attachment', { attachment_id: 'u-ATT00001', start_page: 2, include_annotation_locations: true })).content[0].text);
         expect(mockHandleZoteroDocumentRequest).toHaveBeenCalledWith(expect.objectContaining({ mode: 'structured' }));
         expect(result.pages).toHaveLength(1);
-        expect(result.pages[0].passages[0]).toEqual({ text: 'Source.', page_locations: [{ page_idx: 1, page_label: 'iii', boxes: [box] }], note_position: { ...note.note_position, page_index: 1 } });
+        expect(result.pages[0].passages[0]).toEqual({ text: 'Source.', page_label: 'iii', page_locations: [{ page_idx: 1, page_label: 'iii', boxes: [box] }], note_position: { ...note.note_position, page_index: 1 } });
     });
 });

--- a/tests/unit/notes/handleReadNoteRequest.test.ts
+++ b/tests/unit/notes/handleReadNoteRequest.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../../src/services/agentDataProvider/utils', () => ({
     prepareAttachmentInfoBatchData: vi.fn(async () => ({ bestAttachmentMap: new Map() })),
     processAttachmentInfoBatch: vi.fn(async () => []),
     toAttachmentSummary: vi.fn((attachment: any) => attachment),
+    getAttachmentInfoForItem: vi.fn(async item => ({ attachment_id: `u-${item.key}`, content_kind: 'pdf', status: 'readable', is_primary: false })),
     checkLibraryExcluded: vi.fn(() => null),
 }));
 
@@ -334,7 +335,7 @@ describe('handleReadNoteRequest — cited_items extraction', () => {
         );
     });
 
-    it('does not populate cited_items from attachment citations', async () => {
+    it('resolves legacy attachment citations', async () => {
         vi.mocked(getOrSimplify).mockReturnValueOnce({
             simplified: '<p><citation att_id="1-ATTACH1" page="3"/></p>',
             metadata: { elements: new Map() },
@@ -350,8 +351,17 @@ describe('handleReadNoteRequest — cited_items extraction', () => {
         const response = await handleReadNoteRequest(makeRequest());
 
         expect(response.success).toBe(true);
-        expect(response.cited_items).toBeUndefined();
-        expect(getByLibraryAndKeyAsync).not.toHaveBeenCalledWith(1, 'ATTACH1');
+        expect(response.cited_items).toHaveLength(1);
+        expect(getByLibraryAndKeyAsync).toHaveBeenCalledWith(1, 'ATTACH1');
+    });
+
+    it('preserves the identity of a portable attachment citation without a ref attribute', async () => {
+        Zotero.Libraries.userLibraryID = 1;
+        vi.mocked(getOrSimplify).mockReturnValueOnce({ simplified: '<p><citation id="u-PDF12345" loc="page2"/></p>', metadata: { elements: new Map() }, isStale: false });
+        const attachment = { libraryID: 1, key: 'PDF12345', isAttachment: () => true, loadDataType: vi.fn(), getField: () => 'Source PDF' };
+        vi.mocked(Zotero.Items.getByLibraryAndKeyAsync).mockImplementation(async (_library, key) => key === 'ABCD1234' ? makeMockItem() : attachment as any);
+        const result = await handleReadNoteRequest(makeRequest());
+        expect(result.cited_items).toEqual([expect.objectContaining({ zotero_key: 'PDF12345', item_type: 'attachment', title: 'Source PDF' })]);
     });
 
     it('populates cited_items for note and annotation link citations', async () => {

--- a/tests/unit/services/annotations/createAnnotationTags.test.ts
+++ b/tests/unit/services/annotations/createAnnotationTags.test.ts
@@ -112,6 +112,15 @@ describe("createAnnotation tag application", () => {
     expect(constructedItems[0].tagsAtSave).toEqual(["methods"]);
   });
 
+  it("resolves an omitted PDF note label from cached document metadata", async () => {
+    (globalThis as any).Zotero.Beaver.documentCache.getMetadata.mockResolvedValue({ pages: [geometry], pageLabels: { 0: '220' } });
+    await createNoteAnnotation(mockAttachment(), {
+      notePosition: { page_index: 0, x: 100, y: 100, side: 'right', coord_origin: CoordOrigin.TOPLEFT },
+      comment: 'A note',
+    });
+    expect((constructedItems[0] as any).annotationPageLabel).toBe('220');
+  });
+
   it("applies note tags before saveTx", async () => {
     await createNoteAnnotation(mockAttachment(), {
       notePosition: {

--- a/tests/unit/services/mcpService.test.ts
+++ b/tests/unit/services/mcpService.test.ts
@@ -59,7 +59,7 @@ describe('MCPService', () => {
             service.registerTool('my_tool', {
                 name: 'my_tool',
                 description: 'A test tool',
-                inputSchema: { type: 'object', properties: {} },
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             }, handler);
 
             const res = await rpc(service, {
@@ -73,7 +73,7 @@ describe('MCPService', () => {
             expect(res.body.result.tools[0]).toEqual({
                 name: 'my_tool',
                 description: 'A test tool',
-                inputSchema: { type: 'object', properties: {} },
+                inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             });
         });
 
@@ -309,12 +309,31 @@ describe('MCPService', () => {
     // =====================================================================
 
     describe('tools/call', () => {
+        it.each([
+            { category: 'annotation' }, { unexpected: true }, { category: 3 },
+            { names: ['ok', 3] }, { placement: { x: '10' } }, null,
+        ])('rejects invalid arguments before invoking the handler: %j', async args => {
+            const handler = vi.fn();
+            service.registerTool('validated', {
+                name: 'validated', description: 'Validated tool', inputSchema: {
+                    type: 'object', properties: {
+                        category: { type: 'string', enum: ['regular', 'note'] },
+                        names: { type: 'array', items: { type: 'string' } },
+                        placement: { type: 'object', additionalProperties: false, properties: { x: { type: 'number' } } },
+                    },
+                },
+            }, handler);
+            const result = await rpc(service, { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'validated', arguments: args } });
+            expect(result.body.result.isError).toBe(true);
+            expect(handler).not.toHaveBeenCalled();
+        });
+
         it('calls the registered handler with arguments', async () => {
             const handler = vi.fn().mockResolvedValue('hello world');
             service.registerTool('greet', {
                 name: 'greet',
                 description: 'Greet',
-                inputSchema: {},
+                inputSchema: { type: 'object', properties: { name: { type: 'string' } } },
             }, handler);
 
             const res = await rpc(service, {

--- a/tests/unit/utils/metadataUrl.test.ts
+++ b/tests/unit/utils/metadataUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { cleanMetadataUrl } from '../../../src/utils/metadataUrl';
+
+describe('metadata URLs', () => {
+    it.each(['\u0000\u0000', String.raw`\u0000\u0000`, '', '  ', null])(
+        'omits control-only values %j',
+        (value) => {
+            expect(cleanMetadataUrl(value)).toBeNull();
+        },
+    );
+    it('preserves a valid URL and removes surrounding control characters', () => {
+        expect(
+            cleanMetadataUrl('\u0000https://example.org/a?q=hello%20world\r\n'),
+        ).toBe('https://example.org/a?q=hello%20world');
+    });
+});

--- a/tests/unit/utils/resolveItemsByFilters.test.ts
+++ b/tests/unit/utils/resolveItemsByFilters.test.ts
@@ -83,7 +83,7 @@ describe('resolveItemsByFilters', () => {
 
         const allConds = searches.flatMap((s) => s.conditions);
         expect(allConds).toContainEqual({ c: 'date', op: 'isAfter', val: '2017-12-31' });
-        expect(allConds).toContainEqual({ c: 'date', op: 'isBefore', val: '2021-01-01' });
+        expect(allConds).toContainEqual({ c: 'date', op: 'isBefore', val: '2021' });
     });
 
     it('uses an exact-year condition when year.exact is set', async () => {

--- a/tests/unit/utils/searchFilters.test.ts
+++ b/tests/unit/utils/searchFilters.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+    matchesPublicationYear,
+    matchesCreatorName,
+} from '../../../src/utils/searchFilters';
+
+describe('publication-year bounds', () => {
+    it.each(['', null, 'undated', '0000-00-00'])(
+        'excludes unknown date %s when bounded',
+        (date) => {
+            expect(matchesPublicationYear(date, 2020)).toBe(false);
+            expect(matchesPublicationYear(date, undefined, 2010)).toBe(false);
+            expect(matchesPublicationYear(date)).toBe(true);
+        },
+    );
+    it.each(['2016', '2016-00-00', '2016-01', '2016-01-01', 'June 2016'])(
+        'uses inclusive years for %s',
+        (date) => {
+            expect(matchesPublicationYear(date, undefined, 2015)).toBe(false);
+            expect(matchesPublicationYear(date, 2017)).toBe(false);
+            expect(matchesPublicationYear(date, 2016, 2016)).toBe(true);
+        },
+    );
+});
+
+describe('creator-name matching', () => {
+    const creators = [
+        { firstName: 'Joscha', lastName: 'Legewie' },
+        { firstName: 'Jeffrey', lastName: 'Fagan' },
+    ];
+    it.each(['joscha', 'LEGEWIE', 'Joscha Legewie', 'Legewie, Joscha'])(
+        'matches %s',
+        (query) => {
+            expect(matchesCreatorName(creators, query)).toBe(true);
+        },
+    );
+    it('requires the tokens to belong to one creator', () => {
+        expect(matchesCreatorName(creators, 'Joscha Fagan')).toBe(false);
+        expect(matchesCreatorName(creators, '')).toBe(false);
+    });
+    it('supports institutional creators', () => {
+        expect(
+            matchesCreatorName(
+                [{ lastName: 'World Health Organization' }],
+                'world health',
+            ),
+        ).toBe(true);
+    });
+});

--- a/tests/unit/utils/searchTools.test.ts
+++ b/tests/unit/utils/searchTools.test.ts
@@ -88,6 +88,17 @@ describe("searchItemsByMetadata", () => {
         expect(items).toEqual([{ id: 1 }, { id: 3 }, { id: 7 }]);
     });
 
+    it('filters years and full creator names before applying the result limit', async () => {
+        const fixtures = [
+            { id: 1, date: '2016', firstName: 'Joscha', lastName: 'Legewie' },
+            { id: 3, date: '', firstName: 'Joscha', lastName: 'Legewie' },
+            { id: 9, date: '2015-00-00', firstName: 'Joscha', lastName: 'Legewie' },
+        ].map(({ date, firstName, lastName, ...item }) => ({ ...item, getField: () => date, getCreators: () => [{ firstName, lastName }] }));
+        vi.mocked(Zotero.Items.getAsync).mockImplementation(async () => fixtures as any);
+        const items = await searchItemsByMetadata(4, { tags: ['education'], author_query: 'Joscha Legewie', year_max: 2015, limit: 1 });
+        expect(items.map(item => item.id)).toEqual([9]);
+    });
+
     it("unions one recursive search per collection key", async () => {
         const items = await searchItemsByMetadata(4, {
             title_query: "schools",


### PR DESCRIPTION
## Summary

- Normalize MCP filter validation, portable item IDs, attachment metadata, and metadata URLs.
- Improve creator and publication-year matching across metadata and topic searches.
- Clarify collection ambiguity, recursive collection listing, tag filtering, and annotation search behavior.
- Add structured attachment passages and citation resolution for attachments and annotations.
- Expand MCP contract and unit coverage for updated schemas and edge cases.

## Testing

- Not run; changes include new live MCP contract tests and unit tests for filters, metadata URLs, handlers, annotations, and search behavior.