### PR TITLE
feat(chat): add configurable line spacing

### DIFF
--- a/addon/content/styles/beaver.css
+++ b/addon/content/styles/beaver.css
@@ -1649,11 +1649,25 @@
 }
 
 
-/* [id^="beaver-pane-"] .markdown {
-    margin-top: 0px !important;
-    width: 100%;
-    line-height: 1.5;
-} */
+/* Chat typography presets. These live on ThreadView so note previews, tables,
+   the composer, and other markdown surfaces retain their own spacing. */
+[id^="beaver-pane-"] .chat-line-spacing-compact {
+    --beaver-chat-line-height: 1.35;
+}
+
+[id^="beaver-pane-"] .chat-line-spacing-default {
+    --beaver-chat-line-height: 1.5;
+}
+
+[id^="beaver-pane-"] .chat-line-spacing-relaxed {
+    --beaver-chat-line-height: 1.7;
+}
+
+[id^="beaver-pane-"] .chat-line-spacing .markdown,
+[id^="beaver-pane-"] .chat-line-spacing .markdown li,
+[id^="beaver-pane-"] .chat-line-spacing .user-request-content {
+    line-height: var(--beaver-chat-line-height);
+}
 
 [id^="beaver-pane-"] .markdown p {
     margin-block-start: 0px !important;

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -22,6 +22,8 @@ pref("addSelectedItemsOnOpen", true);
 pref("addSelectedItemsOnNewThread", true);
 pref("addBeaverProvenanceNote", false);
 pref("focusResponseForScreenReaders", false);
+// Line spacing used by messages in the chat history: compact, default, or relaxed.
+pref("chatLineSpacing", "compact");
 pref("annotationToolEnabled", true);
 // Author name on annotations Beaver creates. Empty string = no attribution.
 // Only affects new annotations. Reader-created annotations ignore this —

--- a/react/components/agentRuns/ThreadView.tsx
+++ b/react/components/agentRuns/ThreadView.tsx
@@ -11,6 +11,9 @@ import { store } from "../../store";
 import { useAutoScroll } from "../../hooks/useAutoScroll";
 import { toolExpandedAtom, messageSourcesVisibilityAtom, annotationPanelStateAtom } from "../../atoms/messageUIState";
 import { logger } from "@beaver/agent-core/platform/logger";
+import { usePreference } from '../../hooks/usePreference';
+import { getPref } from '../../../src/utils/prefs';
+import { normalizeChatLineSpacing } from '../../utils/chatLineSpacing';
 
 const RESTORE_THRESHOLD = 100; // pixels - threshold for restoring scroll position
 const RESTORE_DEBOUNCE_MS = 50; // ms - debounce delay for scroll restoration
@@ -50,6 +53,9 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
         const contentRef = useRef<HTMLDivElement | null>(null);
         const pendingRunId = useAtomValue(pendingScrollToRunAtom);
         const isLoadingThread = useAtomValue(isLoadingThreadAtom);
+        const [chatLineSpacing] = usePreference(() =>
+            normalizeChatLineSpacing(getPref('chatLineSpacing')),
+        );
         const setPendingScrollToRun = useSetAtom(pendingScrollToRunAtom);
         const restoredFromAtomRef = useRef(false);
         const currentThreadId = useAtomValue(currentThreadIdAtom);
@@ -582,7 +588,7 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
             return (
                 <div 
                     id="beaver-thread-view"
-                    className={`display-flex flex-col flex-1 min-h-0 items-center justify-center ${className || ''}`}
+                    className={`chat-line-spacing chat-line-spacing-${chatLineSpacing} display-flex flex-col flex-1 min-h-0 items-center justify-center ${className || ''}`}
                     ref={setScrollContainerRef}
                 >
                     <p className="text-secondary">No messages yet</p>
@@ -595,7 +601,7 @@ export const ThreadView = forwardRef<HTMLDivElement, ThreadViewProps>(
                 id="beaver-thread-view"
                 role="log"
                 aria-label="Chat history"
-                className={`display-flex flex-col flex-1 min-h-0 overflow-y-auto scrollbar min-w-0 pb-4 ${className || ''}`}
+                className={`chat-line-spacing chat-line-spacing-${chatLineSpacing} display-flex flex-col flex-1 min-h-0 overflow-y-auto scrollbar min-w-0 pb-4 ${className || ''}`}
                 onScroll={handleScroll}
                 ref={setScrollContainerRef}
             >

--- a/react/components/preferences/PreferencePage.tsx
+++ b/react/components/preferences/PreferencePage.tsx
@@ -19,6 +19,7 @@ import AdvancedSection from "./AdvancedSection";
 import PermissionsSection from "./PermissionsSection";
 import LibraryAccessList from "./LibraryAccessList";
 import BackgroundProcessingSection from "./BackgroundProcessingSection";
+import { normalizeChatLineSpacing } from '../../utils/chatLineSpacing';
 
 
 const PreferencePage: React.FC = () => {
@@ -40,6 +41,9 @@ const PreferencePage: React.FC = () => {
     const [runStatusPopupEnabled, setRunStatusPopupEnabled] = useAtom(runStatusPopupEnabledAtom);
     const [addProvenanceNote, setAddProvenanceNote] = usePreference(() => getPref('addBeaverProvenanceNote'));
     const [focusResponseForScreenReaders, setFocusResponseForScreenReaders] = usePreference(() => getPref('focusResponseForScreenReaders'));
+    const [chatLineSpacing, setChatLineSpacing] = usePreference(() =>
+        normalizeChatLineSpacing(getPref('chatLineSpacing')),
+    );
     const [showDiffPreview, setShowDiffPreview] = usePreference(() => getPref('showDiffPreviewInNoteEditor') !== false);
     const diffPreviewSupported = isDiffPreviewSupported();
     const [consentToShare, setConsentToShare] = useState(() => profileWithPlan?.consent_to_share || false);
@@ -140,6 +144,12 @@ const PreferencePage: React.FC = () => {
         setPref("focusResponseForScreenReaders", newValue);
         setFocusResponseForScreenReaders(newValue);
     }, [focusResponseForScreenReaders]);
+
+    const handleChatLineSpacingChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+        const newValue = normalizeChatLineSpacing(event.target.value);
+        setPref('chatLineSpacing', newValue);
+        setChatLineSpacing(newValue);
+    }, []);
 
     const handleShowDiffPreviewToggle = useCallback(() => {
         if (!diffPreviewSupported) return;
@@ -468,9 +478,28 @@ const PreferencePage: React.FC = () => {
                         <SectionLabel>Accessibility</SectionLabel>
                         <SettingsGroup>
                             <SettingsRow
+                                title="Chat Line Spacing"
+                                description="Adjust the vertical spacing of chat messages for easier reading"
+                                control={
+                                    <select
+                                        id="chat-line-spacing"
+                                        value={chatLineSpacing}
+                                        onChange={handleChatLineSpacingChange}
+                                        className="py-1 px-2 border preference-input text-sm"
+                                        style={{ minWidth: '104px', margin: 0 }}
+                                        onClick={(event) => event.stopPropagation()}
+                                    >
+                                        <option value="compact">Compact</option>
+                                        <option value="default">Default</option>
+                                        <option value="relaxed">Relaxed</option>
+                                    </select>
+                                }
+                            />
+                            <SettingsRow
                                 title="Announce Responses for Screen Readers"
                                 description="Move focus to screen-reader text when Beaver starts and finishes generating a response"
                                 onClick={handleFocusResponseForScreenReadersToggle}
+                                hasBorder
                                 tooltip="When enabled, focus moves from the chat input to screen-reader-only status text while Beaver generates, then to a screen-reader-only copy of the completed response."
                                 control={
                                     <input

--- a/react/utils/chatLineSpacing.ts
+++ b/react/utils/chatLineSpacing.ts
@@ -1,0 +1,16 @@
+export const CHAT_LINE_SPACING_VALUES = [
+    "compact",
+    "default",
+    "relaxed",
+] as const;
+
+export type ChatLineSpacing = (typeof CHAT_LINE_SPACING_VALUES)[number];
+
+export const DEFAULT_CHAT_LINE_SPACING: ChatLineSpacing = "compact";
+
+export function normalizeChatLineSpacing(value: unknown): ChatLineSpacing {
+    return typeof value === "string" &&
+        CHAT_LINE_SPACING_VALUES.includes(value as ChatLineSpacing)
+        ? (value as ChatLineSpacing)
+        : DEFAULT_CHAT_LINE_SPACING;
+}

--- a/tests/unit/utils/chatLineSpacing.test.ts
+++ b/tests/unit/utils/chatLineSpacing.test.ts
@@ -1,0 +1,22 @@
+import {
+    DEFAULT_CHAT_LINE_SPACING,
+    normalizeChatLineSpacing,
+} from "../../../react/utils/chatLineSpacing";
+
+describe("normalizeChatLineSpacing", () => {
+    it.each(["compact", "default", "relaxed"] as const)(
+        "accepts the %s preset",
+        (value) => {
+            expect(normalizeChatLineSpacing(value)).toBe(value);
+        },
+    );
+
+    it.each([undefined, null, "", "wide", 1.7])(
+        "falls back for invalid stored value %s",
+        (value) => {
+            expect(normalizeChatLineSpacing(value)).toBe(
+                DEFAULT_CHAT_LINE_SPACING,
+            );
+        },
+    );
+});

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -24,6 +24,7 @@ declare namespace _ZoteroTypes {
       "addSelectedItemsOnNewThread": boolean;
       "addBeaverProvenanceNote": boolean;
       "focusResponseForScreenReaders": boolean;
+      "chatLineSpacing": string;
       "annotationToolEnabled": boolean;
       "annotationAuthorName": string;
       "maxAddAttachmentToMessage": number;


### PR DESCRIPTION
## Summary
- add Compact, Default, and Relaxed chat line-spacing presets
- persist the selected preset in Zotero preferences and apply it to chat message rendering
- validate stored values with unit coverage

## Validation
- `npx vitest run tests/unit/utils/chatLineSpacing.test.ts`
- `npx tsc --noEmit`
- manually verified sign-in, Chinese chat rendering, setting changes, and persistence after restart in Zotero