### PR TITLE
feat(notes): support editing and reading empty notes

### DIFF
--- a/react/agents/agentActions.ts
+++ b/react/agents/agentActions.ts
@@ -439,7 +439,7 @@ export const undoAgentActionAtom = atom(
                 if (action.result_data?.old_creators && !proposed_data?.old_creators) {
                     proposed_data = { ...proposed_data, old_creators: action.result_data.old_creators };
                 }
-                if (action.result_data?.undo_full_html && !proposed_data?.undo_full_html) {
+                if (typeof action.result_data?.undo_full_html === 'string' && proposed_data?.undo_full_html == null) {
                     proposed_data = { ...proposed_data, undo_full_html: action.result_data.undo_full_html };
                 }
                 return { ...action, proposed_data, status: 'undone' as ActionStatus, result_data: undefined, error_message: undefined };

--- a/react/components/agentRuns/EditNotePreview.tsx
+++ b/react/components/agentRuns/EditNotePreview.tsx
@@ -204,7 +204,7 @@ export const EditNotePreview: React.FC<EditNotePreviewProps> = ({
 
     // For rewrite mode when oldContent is missing (e.g. after undo),
     // fetch the current note content — the note is back to its original state.
-    const needsOldContentFetch = isRewrite && !oldContent && libraryId != null && !!zoteroKey;
+    const needsOldContentFetch = isRewrite && oldContent == null && libraryId != null && !!zoteroKey;
     const [fetchedOldContent, setFetchedOldContent] = useState<string | null>(null);
 
     useEffect(() => {
@@ -234,7 +234,7 @@ export const EditNotePreview: React.FC<EditNotePreviewProps> = ({
     }, [needsOldContentFetch, libraryId, zoteroKey]);
 
     // For rewrite mode, use oldContent prop, fetched content, or fall back to oldString
-    const effectiveOld = isRewrite && (oldContent || fetchedOldContent) ? (oldContent || fetchedOldContent!) : oldString;
+    const effectiveOld = isRewrite ? (oldContent ?? fetchedOldContent ?? oldString) : oldString;
     // For insert_after / insert_before, new_string is already normalized by
     // validation to merge old_string with new_string (via normalized_action_data):
     //   - insert_after:  new_string = old_string + new_string

--- a/react/host/zotero/components/ActionPreview.tsx
+++ b/react/host/zotero/components/ActionPreview.tsx
@@ -330,7 +330,7 @@ export const ActionPreview: React.FC<{
         // For rewrite, get old content from validation's current_value
         // or from undo_full_html in result_data (post-apply)
         const oldContent = isRewrite
-            ? (previewData.currentValue?.old_content || previewData.resultData?.undo_full_html)
+            ? (previewData.currentValue?.old_content ?? previewData.resultData?.undo_full_html)
             : undefined;
 
         // Resolve the portable library_ref to a local id before handing it to

--- a/src/services/agentDataProvider/actions/editNote.ts
+++ b/src/services/agentDataProvider/actions/editNote.ts
@@ -239,7 +239,7 @@ function buildValidateSuccess(
     warnings: string[] | undefined,
 ): WSAgentActionValidateResponse {
     const noteTitle = item.getNoteTitle() || '(untitled)';
-    const totalLines = simplified.split('\n').length;
+    const totalLines = simplified.trim() ? simplified.split('\n').length : 0;
     const preference = getDeferredToolPreference('edit_note', { library_id, zotero_key }, request.operation);
     return {
         type: 'agent_action_validate_response',
@@ -416,18 +416,6 @@ async function validateEditNoteAction(
         rawHtml = stripPreviewMarkers(rawHtml);
     }
 
-    // 7. Note not empty
-    if (!rawHtml || rawHtml.trim() === '') {
-        return {
-            type: 'agent_action_validate_response',
-            request_id: request.request_id,
-            valid: false,
-            error: `Note ${modelObjectIdFromReference({ library_id: resolvedLibraryId, library_ref, zotero_key })} is empty`,
-            error_code: 'empty_note',
-            preference: 'always_ask',
-        };
-    }
-
     // 8. Simplify note (needed for both modes)
     const noteId = `${resolvedLibraryId}-${zotero_key}`;
     const pageLabelsByItemId = await preloadNotePageLabels(rawHtml, resolvedLibraryId, { extractOnCacheMiss: true });
@@ -443,7 +431,7 @@ async function validateEditNoteAction(
         if (!pre.ok) return pre.response;
 
         const noteTitle = item.getNoteTitle() || '(untitled)';
-        const totalLines = simplified.split('\n').length;
+        const totalLines = simplified.trim() ? simplified.split('\n').length : 0;
         const preference = getDeferredToolPreference('edit_note', {
             library_id: resolvedLibraryId,
             zotero_key,
@@ -481,7 +469,7 @@ async function validateEditNoteAction(
         if (!pre.ok) return pre.response;
 
         const noteTitle = item.getNoteTitle() || '(untitled)';
-        const totalLines = simplified.split('\n').length;
+        const totalLines = simplified.trim() ? simplified.split('\n').length : 0;
         const preference = getDeferredToolPreference('edit_note', {
             library_id: resolvedLibraryId,
             zotero_key,
@@ -498,6 +486,18 @@ async function validateEditNoteAction(
             },
             warnings: collectWarnings(...(externalRefContext.externalFileWarnings ?? [])),
             preference,
+        };
+    }
+
+    // Anchored edits require existing content.
+    if (!rawHtml || rawHtml.trim() === '') {
+        return {
+            type: 'agent_action_validate_response',
+            request_id: request.request_id,
+            valid: false,
+            error: `Note ${modelObjectIdFromReference({ library_id: resolvedLibraryId, library_ref, zotero_key })} is empty. Use operation="append" or "rewrite" with new_string and no old_string to add content to this note.`,
+            error_code: 'empty_note',
+            preference: 'always_ask',
         };
     }
 

--- a/src/services/agentDataProvider/actions/editNoteBatch.ts
+++ b/src/services/agentDataProvider/actions/editNoteBatch.ts
@@ -471,8 +471,9 @@ async function validateEditNoteBatchAction(
         rawHtml = stripPreviewMarkers(rawHtml);
     }
 
-    if (!rawHtml || rawHtml.trim() === '') {
-        return validateError(request.request_id, `Note ${modelObjectIdFromReference({ library_id: resolvedLibraryId, library_ref, zotero_key })} is empty`, 'empty_note');
+    if ((!rawHtml || rawHtml.trim() === '')
+        && edits.some(edit => edit.operation !== 'append' && edit.operation !== 'rewrite')) {
+        return validateError(request.request_id, `Note ${modelObjectIdFromReference({ library_id: resolvedLibraryId, library_ref, zotero_key })} is empty. Use operation="append" or "rewrite" with new_string and no old_string to add content to this note.`, 'empty_note');
     }
 
     // Simplify ONCE.
@@ -536,7 +537,7 @@ async function validateEditNoteBatchAction(
     }
 
     const isSingleRewrite = edits.length === 1 && opOf(edits[0]) === 'rewrite';
-    const totalLines = simplified.split('\n').length;
+    const totalLines = simplified.trim() ? simplified.split('\n').length : 0;
     const noteTitle = item.getNoteTitle() || '(untitled)';
 
     // A rewrite that discards or replaces most of the note is the one note edit

--- a/src/services/agentDataProvider/handleReadNoteRequest.ts
+++ b/src/services/agentDataProvider/handleReadNoteRequest.ts
@@ -286,11 +286,6 @@ export async function handleReadNoteRequest(
         //    NEVER calls item.setNote() — flushLiveEditorToDB would persist a
         //    transient empty PM-render snapshot and erase the note's content.
         let rawHtml = await getNoteHtmlForRead(item);
-        if (!rawHtml || rawHtml.trim() === '') {
-            return errorResponse(
-                `Note ${note_id} is empty. There is no content to read.`
-            );
-        }
         // Recovery path: if diff-preview markup was ever accidentally
         // persisted into this note, read the stripped content so the model
         // sees the same HTML the edit_note validate/execute paths repair to.
@@ -311,7 +306,7 @@ export async function handleReadNoteRequest(
         const { simplified } = getOrSimplify(cacheNoteId, rawHtml, item.libraryID, pageLabelsByItemId);
 
         // 7. Apply offset/limit pagination
-        const lines = simplified.split('\n');
+        const lines = simplified.trim() ? simplified.split('\n') : [];
         const totalLines = lines.length;
         const start = Math.max(0, (offset ?? 1) - 1);
         const end = limit ? Math.min(start + limit, totalLines) : totalLines;

--- a/src/services/manualActions/editNoteActions.ts
+++ b/src/services/manualActions/editNoteActions.ts
@@ -1039,7 +1039,7 @@ export async function undoEditNoteAction(
     const library_id = item.libraryID;
 
     // ── rewrite undo: restore full note from undo_full_html ──
-    if (resultData?.undo_full_html) {
+    if (typeof resultData?.undo_full_html === 'string') {
         await item.loadDataType('note');
         const noteId = `${library_id}-${zotero_key}`;
 

--- a/tests/unit/notes/editNote.test.ts
+++ b/tests/unit/notes/editNote.test.ts
@@ -659,6 +659,23 @@ describe('validateEditNoteAction — failures', () => {
         expect(response.error_code).toBe('library_not_editable');
     });
 
+    it.each(['append', 'rewrite'] as const)('validates %s on an empty note', async (operation) => {
+        const item = makeMockItem({ getNote: vi.fn(() => '') });
+        (globalThis as any).Zotero.Items.getByLibraryAndKeyAsync = vi.fn().mockResolvedValue(item);
+        vi.mocked(getOrSimplify).mockReturnValueOnce({
+            simplified: '', metadata: { elements: new Map() }, isStale: false,
+        });
+        const response = await handleAgentActionValidateRequest(makeValidateRequest({
+            action_data: {
+                library_id: 1, zotero_key: 'NOTE0001', operation,
+                new_string: '<p>First content</p>',
+            },
+        }));
+        expect(response.valid).toBe(true);
+        expect(response.current_value).toMatchObject({ total_lines: 0, match_count: 1 });
+        expect(item.saveTx).not.toHaveBeenCalled();
+    });
+
     it('empty_note', async () => {
         const item = makeMockItem({ getNote: vi.fn(() => '') });
         (globalThis as any).Zotero.Items.getByLibraryAndKeyAsync = vi.fn().mockResolvedValue(item);

--- a/tests/unit/notes/editNoteBatch.test.ts
+++ b/tests/unit/notes/editNoteBatch.test.ts
@@ -1210,3 +1210,45 @@ describe('local single-edit citation recovery', () => {
         },
     );
 });
+
+
+describe('empty note batch edits', () => {
+    it.each(['', '   ', '<div data-schema-version="9"></div>', '<div data-schema-version="9"><p><br></p></div>'])(
+        'validates and applies anchor-free edits to %j', async (html) => {
+            for (const operation of ['append', 'rewrite'] as const) {
+                const item = useNote(html);
+                const edits = [{ index: 0, operation, new_string: '<p>First content</p>' }];
+                const validation = await handleAgentActionValidateRequest(makeValidateRequest(edits));
+                expect(validation.valid).toBe(true);
+                expect(item.saveTx).not.toHaveBeenCalled();
+                const result = await handleAgentActionExecuteRequest(makeExecuteRequest(edits));
+                expect(result.success).toBe(true);
+                expect(item.setNote.mock.calls[0][0]).toContain('<p>First content</p>');
+                expect(result.result_data!.undo[0].undo_old_html).toBe(operation === 'rewrite' ? html : '');
+                expect(result.result_data!.library_id).toBe(1);
+                expect(result.result_data!.zotero_key).toBe('NOTE0001');
+            }
+        },
+    );
+
+    it('rejects anchored edits on an empty note with actionable guidance', async () => {
+        const item = useNote('');
+        const validation = await handleAgentActionValidateRequest(makeValidateRequest([
+            { index: 0, operation: 'str_replace', old_string: 'missing', new_string: 'content' },
+        ]));
+        expect(validation.valid).toBe(false);
+        expect(validation.error).toContain('append');
+        expect(item.saveTx).not.toHaveBeenCalled();
+    });
+
+    it('applies multiple appends to an empty note in order', async () => {
+        const item = useNote('');
+        const edits = [
+            { index: 0, operation: 'append' as const, new_string: '<p>First</p>' },
+            { index: 1, operation: 'append' as const, new_string: '<p>Second</p>' },
+        ];
+        expect((await handleAgentActionValidateRequest(makeValidateRequest(edits))).valid).toBe(true);
+        expect((await handleAgentActionExecuteRequest(makeExecuteRequest(edits))).success).toBe(true);
+        expect(item.setNote.mock.calls[0][0]).toContain('<p>First</p><p>Second</p>');
+    });
+});

--- a/tests/unit/notes/editNoteUndoRoundtrip.test.ts
+++ b/tests/unit/notes/editNoteUndoRoundtrip.test.ts
@@ -90,6 +90,7 @@ import {
     executeEditNoteAction,
     executeEditNoteOrBatchAction,
     undoEditNoteAction,
+    undoEditNoteOrBatchAction,
 } from '../../../react/utils/editNoteActions';
 import type { AgentAction } from '../../../react/agents/agentActions';
 import { store } from '../../../react/store';
@@ -222,7 +223,7 @@ function makeAction(
     zoteroKey: string,
     oldString: string,
     newString: string,
-    operation: 'str_replace' | 'str_replace_all' = 'str_replace',
+    operation: 'str_replace' | 'str_replace_all' | 'append' | 'rewrite' = 'str_replace',
     resultData?: EditNoteResultData,
 ): AgentAction {
     return {
@@ -359,7 +360,7 @@ async function applyEdit(opts: {
     noteHtml: string;
     oldString: string;
     newString: string;
-    operation?: 'str_replace' | 'str_replace_all';
+    operation?: 'str_replace' | 'str_replace_all' | 'append' | 'rewrite';
     applyPMNormalization?: boolean;
 }): Promise<{
     item: ReturnType<typeof createMockNoteItem>;
@@ -2320,5 +2321,37 @@ describe('external-file citations through React apply and undo', () => {
         const result = await executeEditNoteOrBatchAction(action);
         expect(item._getHtml()).toContain('(Attached file ext-MRDTFYHP, p. 6)');
         expect(result.warnings?.[0]).toContain('no available filename metadata');
+    });
+});
+
+describe('empty note apply and undo', () => {
+    it.each(['append', 'rewrite'] as const)('%s can be undone to an empty body', async (operation) => {
+        const { item, action } = await applyEdit({
+            noteHtml: '', oldString: '', newString: '<p>First content</p>', operation,
+        });
+        expect(item._getHtml()).toContain('<p>First content</p>');
+        expect(await undoEdit(item, action)).toBe('');
+    });
+});
+
+describe('empty note batch apply and undo', () => {
+    beforeEach(() => {
+        Zotero.Libraries.get = vi.fn(() => ({ editable: true })) as any;
+    });
+
+    it.each(['append', 'rewrite'] as const)('batch %s restores the empty note on undo', async (operation) => {
+        const item = createMockNoteItem('');
+        (Zotero.Items.getByLibraryAndKeyAsync as any).mockResolvedValue(item);
+        const action = makeAction(1, 'TESTKEY', '', '<p>First content</p>');
+        action.action_type = 'edit_note_batch';
+        action.proposed_data = {
+            library_id: 1, zotero_key: 'TESTKEY',
+            edits: [{ index: 0, operation, new_string: '<p>First content</p>' }],
+        } as any;
+        action.result_data = await executeEditNoteOrBatchAction(action);
+        action.status = 'applied';
+        expect(item._getHtml()).toContain('<p>First content</p>');
+        await undoEditNoteOrBatchAction(action);
+        expect(item._getHtml()).toBe('');
     });
 });

--- a/tests/unit/notes/handleReadNoteRequest.test.ts
+++ b/tests/unit/notes/handleReadNoteRequest.test.ts
@@ -203,14 +203,26 @@ describe('handleReadNoteRequest — success', () => {
         expect(response.parent_title).toBe('Parent Article');
     });
 
-    it('returns error for empty note', async () => {
-        const item = makeMockItem({ getNote: vi.fn(() => ''), getNoteTitle: vi.fn(() => '') });
-        (globalThis as any).Zotero.Items.getByLibraryAndKeyAsync = vi.fn().mockResolvedValue(item);
+    it.each(['', '   ', '<div data-schema-version="9"></div>'])(
+        'returns a successful zero-line read for an empty body: %s', async (html) => {
+            const item = makeMockItem({ getNote: vi.fn(() => html), getNoteTitle: vi.fn(() => '') });
+            (globalThis as any).Zotero.Items.getByLibraryAndKeyAsync = vi.fn().mockResolvedValue(item);
+            vi.mocked(getOrSimplify).mockReturnValueOnce({
+                simplified: html.trim() ? '' : html,
+                metadata: { elements: new Map() },
+                isStale: false,
+            });
 
-        const response = await handleReadNoteRequest(makeRequest());
-        expect(response.success).toBe(false);
-        expect(response.error).toContain('is empty');
-    });
+            const response = await handleReadNoteRequest(makeRequest());
+            expect(response).toMatchObject({
+                success: true, note_id: '1-ABCD1234', title: '(untitled)',
+                total_lines: 0, content: '', has_more: false,
+            });
+            expect(response.error).toBeUndefined();
+            expect(response.lines_returned).toBeUndefined();
+            expect(response.next_offset).toBeUndefined();
+        },
+    );
 
     it('returns (untitled) for note without title', async () => {
         const item = makeMockItem({ getNoteTitle: vi.fn(() => '') });
@@ -494,18 +506,15 @@ describe('handleReadNoteRequest — read-only path', () => {
         expect(vi.mocked(getOrSimplify).mock.calls[0][1]).toBe(sentinel);
     });
 
-    it('returns empty_note error when getNoteHtmlForRead resolves empty', async () => {
-        vi.mocked(getNoteHtmlForRead).mockResolvedValueOnce('');
+    it.each(['', '   \n\t'])('reads an empty helper snapshot successfully: %j', async (html) => {
+        vi.mocked(getNoteHtmlForRead).mockResolvedValueOnce(html);
+        vi.mocked(getOrSimplify).mockReturnValueOnce({
+            simplified: html, metadata: { elements: new Map() }, isStale: false,
+        });
         const response = await handleReadNoteRequest(makeRequest());
-        expect(response.success).toBe(false);
-        expect(response.error).toContain('is empty');
-    });
-
-    it('returns empty_note error when helper resolves whitespace-only HTML', async () => {
-        vi.mocked(getNoteHtmlForRead).mockResolvedValueOnce('   \n\t');
-        const response = await handleReadNoteRequest(makeRequest());
-        expect(response.success).toBe(false);
-        expect(response.error).toContain('is empty');
+        expect(response).toMatchObject({ success: true, content: '', total_lines: 0 });
+        expect(response.error).toBeUndefined();
+        expect(getLatestNoteHtml).not.toHaveBeenCalled();
     });
 
     it('NEVER calls item.setNote from the read path (regression guard)', async () => {


### PR DESCRIPTION
## Summary

- Allow empty notes to be read and edited using append or rewrite operations.
- Preserve anchored-edit validation for notes without existing content.
- Simplify table artifacts and remove the deprecated artifact provider and mutation APIs.
- Update note previews, coverage handling, CSV export, and related tests.

## Testing

- Added and updated unit tests for empty-note editing, batch editing, undo/redo, and note reads.
- Updated table layout, mutation, and UI tests for the simplified artifact behavior.